### PR TITLE
[Enhance #341] Session conflict when accessing Staff Portal after logging in to Cloud Portal

### DIFF
--- a/app/modules/auth/oauth.helper.ts
+++ b/app/modules/auth/oauth.helper.ts
@@ -1,6 +1,14 @@
 import { logger } from '@/utils/logger';
 import { CodeChallengeMethod, OAuth2Strategy } from 'remix-auth-oauth2';
 
+export enum OIDCPrompt {
+  NONE = 'none',
+  LOGIN = 'login',
+  CONSENT = 'consent',
+  SELECT_ACCOUNT = 'select_account',
+  CREATE = 'create',
+}
+
 export interface OAuthFallbackConfig {
   clientId: string;
   clientSecret: string | null;
@@ -19,7 +27,7 @@ export interface OAuthProviderConfig {
   clientSecret?: string;
   redirectURI: string;
   scopes: string[];
-  prompt?: string;
+  prompt?: OIDCPrompt;
   endpoints?: {
     authorization?: string;
     token?: string;

--- a/app/modules/auth/oauth.helper.ts
+++ b/app/modules/auth/oauth.helper.ts
@@ -19,6 +19,7 @@ export interface OAuthProviderConfig {
   clientSecret?: string;
   redirectURI: string;
   scopes: string[];
+  prompt?: string;
   endpoints?: {
     authorization?: string;
     token?: string;
@@ -99,6 +100,7 @@ export async function createGenericOAuthProvider<T>(
           clientSecret: config.clientSecret ?? null,
           redirectURI: config.redirectURI,
           scopes: config.scopes,
+          prompt: config.prompt,
         },
         callback
       ),

--- a/app/modules/auth/strategies/zitadel.strategy.ts
+++ b/app/modules/auth/strategies/zitadel.strategy.ts
@@ -1,4 +1,4 @@
-import { createGenericOAuthProvider, OAuthProviderConfig } from '../oauth.helper';
+import { createGenericOAuthProvider, OAuthProviderConfig, OIDCPrompt } from '../oauth.helper';
 import { authUserQuery } from '@/resources/request/server';
 import { env } from '@/utils/config/env.server';
 import { sessionCookie, tokenCookie } from '@/utils/cookies';
@@ -59,7 +59,7 @@ export async function createZitadelStrategy() {
     redirectURI: `${env.APP_URL}/auth/callback`,
     scopes: ['openid', 'profile', 'email', 'phone', 'address', 'offline_access'],
     // Force re-authentication to avoid silent SSO
-    prompt: 'login',
+    prompt: OIDCPrompt.LOGIN,
   };
 
   return createGenericOAuthProvider(

--- a/app/modules/auth/strategies/zitadel.strategy.ts
+++ b/app/modules/auth/strategies/zitadel.strategy.ts
@@ -58,6 +58,8 @@ export async function createZitadelStrategy() {
     clientSecret: env.AUTH_OIDC_CLIENT_SECRET,
     redirectURI: `${env.APP_URL}/auth/callback`,
     scopes: ['openid', 'profile', 'email', 'phone', 'address', 'offline_access'],
+    // Force re-authentication to avoid silent SSO
+    prompt: 'login',
   };
 
   return createGenericOAuthProvider(

--- a/app/utils/cookies/base.ts
+++ b/app/utils/cookies/base.ts
@@ -22,7 +22,7 @@ export abstract class BaseCookie<T extends IBaseCookieData> {
   }
 
   private initialize() {
-    this.cookie = createCookie(`${this.COOKIE_KEY}_staff`, {
+    this.cookie = createCookie(this.COOKIE_KEY, {
       path: '/',
       domain: new URL(env.APP_URL).hostname,
       sameSite: 'lax',


### PR DESCRIPTION
### **Problem**
- Two applications using different Zitadel client IDs but same issuer were sharing authentication sessions
- Logging into one app automatically logged users into the other app
- Logging out from one app logged users out of both apps
- This occurred due to shared Zitadel SSO session at the identity provider level

### **Root Cause**
- Both apps used the same Zitadel issuer (`auth.staging.env.datum.net`)
- Zitadel maintains a single SSO session per user across all clients under the same issuer
- Default OAuth flow allows silent authentication if an existing SSO session exists
- RP-initiated logout (`end_session`) terminates the global SSO session

### **Solution**
Added `prompt=login` parameter to force re-authentication, preventing silent SSO reuse.