### PR TITLE
[Enhance #353] Bring back organization scope in Zitadel auth (configurable via env var)

### DIFF
--- a/app/modules/auth/strategies/zitadel.strategy.ts
+++ b/app/modules/auth/strategies/zitadel.strategy.ts
@@ -51,21 +51,18 @@ class ZitadelStrategy extends OAuth2Strategy<IZitadelResponse> {
 }
 
 export async function createZitadelStrategy() {
+  const defaultScopes = ['openid', 'profile', 'email', 'phone', 'address', 'offline_access'];
+  const mergedScopes = Array.from(
+    new Set([...(defaultScopes as string[]), ...((env.authOidcScopes as string[]) ?? [])])
+  );
+
   const config: OAuthProviderConfig = {
     name: 'Zitadel',
     issuer: env.AUTH_OIDC_ISSUER,
     clientId: env.AUTH_OIDC_CLIENT_ID,
     clientSecret: env.AUTH_OIDC_CLIENT_SECRET,
     redirectURI: `${env.APP_URL}/auth/callback`,
-    scopes: [
-      'openid',
-      'profile',
-      'email',
-      'phone',
-      'address',
-      'offline_access',
-      // 'urn:zitadel:iam:org:id:325848471661779545',
-    ],
+    scopes: mergedScopes,
     // Force re-authentication to avoid silent SSO
     prompt: OIDCPrompt.LOGIN,
   };

--- a/app/utils/config/env.server.ts
+++ b/app/utils/config/env.server.ts
@@ -9,6 +9,15 @@ const envSchema = z.object({
   AUTH_OIDC_CLIENT_ID: z.string(),
   SESSION_SECRET: z.string().min(32),
   VERSION: z.string(),
+
+  // Optional configuration
+  AUTH_OIDC_SCOPES: z.string().optional(),
+  AUTH_OIDC_CLIENT_SECRET: z.string().optional(),
+  OTEL_ENABLED: z.string().optional(),
+  OTEL_EXPORTER_OTLP_ENDPOINT: z.string().optional(),
+  OTEL_LOG_LEVEL: z.string().optional(),
+  SENTRY_ENV: z.string().optional(),
+  SENTRY_DSN: z.string().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;
@@ -29,21 +38,16 @@ const parsedEnv = getEnv();
 
 export const env = {
   ...parsedEnv,
-  AUTH_OIDC_CLIENT_SECRET: process.env.AUTH_OIDC_CLIENT_SECRET,
-  OTEL_ENABLED: process.env.OTEL_ENABLED,
-  OTEL_EXPORTER_OTLP_ENDPOINT: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
-  OTEL_LOG_LEVEL: process.env.OTEL_LOG_LEVEL,
-
-  // Sentry configuration
-  SENTRY_ENV: process.env.SENTRY_ENV,
-  SENTRY_DSN: process.env.SENTRY_DSN,
-
+  authOidcScopes: parsedEnv.AUTH_OIDC_SCOPES
+    ? parsedEnv.AUTH_OIDC_SCOPES.split(/[ ,]+/)
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : [],
   isDev: parsedEnv.NODE_ENV === 'development',
   isProd: parsedEnv.NODE_ENV === 'production',
   isTest: parsedEnv.NODE_ENV === 'test',
   isDebug: toBoolean(process.env.DEBUG),
   isCypress: toBoolean(process.env.CYPRESS),
-  isOtelEnabled:
-    toBoolean(process.env.OTEL_ENABLED) && process.env.OTEL_EXPORTER_OTLP_ENDPOINT !== '',
-  isSentryEnabled: !!process.env.SENTRY_DSN,
+  isOtelEnabled: toBoolean(parsedEnv.OTEL_ENABLED) && parsedEnv.OTEL_EXPORTER_OTLP_ENDPOINT !== '',
+  isSentryEnabled: !!parsedEnv.SENTRY_DSN,
 };


### PR DESCRIPTION
Reintroduce the organization scope in Zitadel authentication flow, making it configurable through an environment variable. This will allow restricting access to the staff portal to only users belonging to Datum.

