### PR TITLE
Fix Recent Users widget

### DIFF
--- a/app/features/dashboard/components/recent-users-widget.tsx
+++ b/app/features/dashboard/components/recent-users-widget.tsx
@@ -23,9 +23,9 @@ function UserItem({ log }: { log: any }) {
     }
   }, [log?.raw]);
 
-  if (!userData) return null;
+  if (!userData?.spec) return null;
 
-  const { givenName, familyName } = userData.spec;
+  const { givenName, familyName } = userData?.spec ?? {};
   const initials = `${givenName?.charAt(0) || ''}${familyName?.charAt(0) || ''}`;
   const fullName = `${givenName || ''} ${familyName || ''}`.trim();
 
@@ -39,13 +39,13 @@ function UserItem({ log }: { log: any }) {
           <div className="min-w-0 flex-1">
             <DisplayName
               displayName={fullName}
-              name={userData.spec.email}
+              name={userData?.spec?.email}
               to={userRoutes.detail(userData.metadata.name)}
             />
           </div>
           <div className="ml-3 flex items-center gap-2">
             <Text size="sm" textColor="muted">
-              <DateFormatter date={userData.metadata.creationTimestamp} withTime />
+              <DateFormatter date={userData?.metadata?.creationTimestamp} withTime />
             </Text>
           </div>
         </div>
@@ -79,6 +79,7 @@ export function RecentUsersWidget() {
         filters: {
           actions: 'create',
           user: 'zitadel-actions-server',
+          status: 'success',
           start: getUnixTime(subDays(new Date(), 7)) * 1000000000,
         },
         limit: 10,

--- a/app/modules/i18n/locales/en.po
+++ b/app/modules/i18n/locales/en.po
@@ -448,7 +448,7 @@ msgstr "Irreversible and destructive actions"
 msgid "Joined"
 msgstr "Joined"
 
-#: app/features/dashboard/components/recent-users-widget.tsx:111
+#: app/features/dashboard/components/recent-users-widget.tsx:112
 msgid "Last 10 new users who joined Datum"
 msgstr "Last 10 new users who joined Datum"
 
@@ -890,7 +890,7 @@ msgstr "Verified"
 msgid "Version"
 msgstr "Version"
 
-#: app/features/dashboard/components/recent-users-widget.tsx:106
+#: app/features/dashboard/components/recent-users-widget.tsx:107
 msgid "View All"
 msgstr "View All"
 

--- a/app/modules/i18n/locales/fr.po
+++ b/app/modules/i18n/locales/fr.po
@@ -448,7 +448,7 @@ msgstr ""
 msgid "Joined"
 msgstr ""
 
-#: app/features/dashboard/components/recent-users-widget.tsx:111
+#: app/features/dashboard/components/recent-users-widget.tsx:112
 msgid "Last 10 new users who joined Datum"
 msgstr ""
 
@@ -890,7 +890,7 @@ msgstr ""
 msgid "Version"
 msgstr ""
 
-#: app/features/dashboard/components/recent-users-widget.tsx:106
+#: app/features/dashboard/components/recent-users-widget.tsx:107
 msgid "View All"
 msgstr ""
 


### PR DESCRIPTION
This PR addresses an issue where the Recent Users widget on the dashboard failed to display due to data being undefined.