### PR TITLE
[Fix #209] Error when loading user page

### DIFF
--- a/app/components/error/generic.tsx
+++ b/app/components/error/generic.tsx
@@ -19,26 +19,18 @@ const GenericError = ({ message, requestId }: { message: string; requestId?: str
         <LogoIcon width={64} className="mb-4" />
 
         <div className="flex max-w-xl flex-col gap-2">
-          <p className="w-full text-center text-2xl font-bold">Whoops! Something went wrong.</p>
-          <p className="text-muted-foreground text-center text-sm">
-            Something went wrong on our end. Our team has been notified, and we&apos;re working to
-            fix it. Please try again later. If the issue persists, reach out to{' '}
-            <Link to={`mailto:support@datum.net`} className="text-primary underline">
-              support@datum.net
-            </Link>
-            .
+          <p className="w-full text-center text-2xl font-bold">
+            Something glitched! Probably not your fault.
           </p>
 
-          {(requestId || isDebug) && (
-            <div className="text-muted-foreground rounded-r-md border-l-4 border-red-500 bg-red-50 p-4 text-center text-sm dark:bg-red-950/20">
-              {requestId && (
-                <div className="text-xs">
-                  <strong>Request ID:</strong> {requestId}
-                </div>
-              )}
-              {isDebug && <code className="font-mono text-xs">{message}</code>}
-            </div>
-          )}
+          <div className="text-muted-foreground rounded-r-md border-l-4 border-red-500 bg-red-50 p-4 text-center text-sm dark:bg-red-950/20">
+            {requestId && (
+              <div className="text-xs">
+                <strong>Request ID:</strong> {requestId}
+              </div>
+            )}
+            <code className="font-mono text-xs">{message}</code>
+          </div>
         </div>
         <div className="flex items-center gap-2">
           <Link to={'/'}>
@@ -47,10 +39,6 @@ const GenericError = ({ message, requestId }: { message: string; requestId?: str
               Back to Home
             </Button>
           </Link>
-          <Button variant="outline" size="sm" onClick={() => navigate(0)}>
-            <RefreshCcwIcon className="size-4" />
-            Refresh Page
-          </Button>
         </div>
       </CardContent>
     </Card>

--- a/app/modules/axios/axios.server.ts
+++ b/app/modules/axios/axios.server.ts
@@ -104,12 +104,27 @@ const onResponseError = (error: AxiosError): Promise<AxiosError> => {
 
   // Log the API request error with consistent format
   if (requestId) {
+    const data = error.response?.data as {
+      message?: string;
+      reason?: string;
+      error?: string;
+      error_description?: string;
+    };
+
     logger.error('API Request Error', {
       requestId,
       url: error.config?.url,
       method: error.config?.method,
       status: error.response?.status,
       error: error.message,
+      data: Object.fromEntries(
+        Object.entries({
+          message: data?.message,
+          reason: data?.reason,
+          error: data?.error,
+          error_description: data?.error_description,
+        }).filter(([_, v]) => !!v)
+      ),
     });
   }
 


### PR DESCRIPTION
Improving the error page and the API error logger in Grafana to display the actual error responses returned by the API.

<img width="1930" height="1252" alt="image" src="https://github.com/user-attachments/assets/f465b764-08f6-47f7-95ab-d594823e0e2d" />

```js
{
  level: "error",
  time: 1761034847298,
  msg: "API Request Error",
  data: {
    requestId: "dc80ee50-d4ee-4802-8a84-eea2e359db85",
    url: "/apis/iam.miloapis.com/v1alpha1/users/334500834643546137",
    method: "get",
    status: 403,
    error: "Request failed with status code 403",
    data: {
      message: "users.iam.miloapis.com \"334500834643546137\" is forbidden: User \"gaghan430@gmail.com\" cannot get resource \"users\" in API group \"iam.miloapis.com\" at the cluster scope",
      reason: "Forbidden",
    },
  },
  caller: {
    file: "logger.ts",
    fullPath: "/Volumes/Work/datum/staff-portal/app/utils/logger/logger.ts",
    line: 39,
    column: 18,
  },
}
