### PR TITLE
Use metadata.generateName instead of metadata.name

### DIFF
--- a/app/features/contact-group/components/contact-group-form.tsx
+++ b/app/features/contact-group/components/contact-group-form.tsx
@@ -38,9 +38,7 @@ export const ContactGroupForm: React.FC<Props> = ({ contactGroup }) => {
         kind: 'ContactGroup',
         spec,
         metadata: {
-          name: generateMetadataName(
-            [value.display_name, 'contact-group'].filter(Boolean).join('-')
-          ),
+          generateName: 'contact-group-',
           namespace: 'default',
         },
       });

--- a/app/features/contact/components/contact-form.tsx
+++ b/app/features/contact/components/contact-form.tsx
@@ -64,6 +64,10 @@ export const ContactForm: React.FC<Props> = ({ contact, user }) => {
       const data = await contactCreateMutation({
         apiVersion: 'notification.miloapis.com/v1alpha1',
         kind: 'Contact',
+        metadata: {
+          generateName: 'contact-',
+          namespace: 'default',
+        },
         spec: {
           familyName: value.last_name,
           givenName: value.first_name,
@@ -77,12 +81,6 @@ export const ContactForm: React.FC<Props> = ({ contact, user }) => {
                 namespace: '',
               },
             }),
-        },
-        metadata: {
-          name: generateMetadataName(
-            [value.first_name, value.last_name, 'contact'].filter(Boolean).join('-')
-          ),
-          namespace: 'default',
         },
       });
       navigate(contactRoutes.edit(data.data.metadata.name));

--- a/app/features/quota/components/quota-bucket-list.tsx
+++ b/app/features/quota/components/quota-bucket-list.tsx
@@ -124,7 +124,7 @@ export function QuotaBucketList({ queryKeyPrefix, fetchFn }: QuotaBucketListProp
         apiVersion: 'quota.miloapis.com/v1alpha1',
         kind: 'ResourceGrant',
         metadata: {
-          generateName: `${selected?.spec.consumerRef.name ?? ''}-quota-`,
+          generateName: 'resource-grant-',
           namespace: selected?.metadata.namespace ?? '',
         },
         spec: {

--- a/app/features/user/hooks/useUserApproval.ts
+++ b/app/features/user/hooks/useUserApproval.ts
@@ -13,7 +13,7 @@ export function useUserApproval() {
       await userApproveMutation({
         apiVersion: 'iam.miloapis.com/v1alpha1',
         kind: 'PlatformAccessApproval',
-        metadata: { name: `${user.metadata.name}-approval` },
+        metadata: { generateName: 'platform-access-approval-' },
         spec: {
           subjectRef: { userRef: { name: user.metadata.name } },
           approverRef: { name: currentUser?.metadata.name ?? '' },
@@ -28,7 +28,7 @@ export function useUserApproval() {
       await userRejectMutation({
         apiVersion: 'iam.miloapis.com/v1alpha1',
         kind: 'PlatformAccessRejection',
-        metadata: { name: `${user?.metadata.name}-rejection` },
+        metadata: { generateName: 'platform-access-rejection-' },
         spec: {
           subjectRef: { name: user?.metadata.name ?? '' },
           reason: reason,

--- a/app/modules/i18n/locales/en.po
+++ b/app/modules/i18n/locales/en.po
@@ -149,11 +149,11 @@ msgstr "Are you sure you want to delete session \"{0}\"? This action cannot be u
 msgid "Are you sure you want to delete user \"{0} {1}\"? This action cannot be undone."
 msgstr "Are you sure you want to delete user \"{0} {1}\"? This action cannot be undone."
 
-#: app/features/contact/components/contact-form.tsx:127
+#: app/features/contact/components/contact-form.tsx:125
 msgid "Associate with User"
 msgstr "Associate with User"
 
-#: app/features/contact/components/contact-form.tsx:114
+#: app/features/contact/components/contact-form.tsx:112
 msgid "Associated with User: "
 msgstr "Associated with User: "
 
@@ -177,8 +177,8 @@ msgstr "Auto-managed by policy \"{policyName}\". Cannot be deleted."
 #: app/features/user/components/user-reject-dialog.tsx:30
 #: app/features/quota/components/quota-grant-list.tsx:142
 #: app/features/quota/components/quota-bucket-list.tsx:159
-#: app/features/contact-group/components/contact-group-form.tsx:80
-#: app/features/contact/components/contact-form.tsx:156
+#: app/features/contact-group/components/contact-group-form.tsx:78
+#: app/features/contact/components/contact-form.tsx:154
 #: app/components/danger-zone-card/index.tsx:49
 #: app/components/button/button-delete-action.tsx:43
 msgid "Cancel"
@@ -201,7 +201,7 @@ msgstr "Clear"
 msgid "Configuration"
 msgstr "Configuration"
 
-#: app/features/contact/components/contact-form.tsx:89
+#: app/features/contact/components/contact-form.tsx:87
 msgid "Contact created successfully"
 msgstr "Contact created successfully"
 
@@ -209,7 +209,7 @@ msgstr "Contact created successfully"
 msgid "Contact deleted successfully"
 msgstr "Contact deleted successfully"
 
-#: app/features/contact-group/components/contact-group-form.tsx:48
+#: app/features/contact-group/components/contact-group-form.tsx:46
 msgid "Contact group created successfully"
 msgstr "Contact group created successfully"
 
@@ -257,8 +257,8 @@ msgstr "Contacts - Create"
 
 #: app/routes/contact-group/create.tsx:14
 #: app/routes/contact/create.tsx:14
-#: app/features/contact-group/components/contact-group-form.tsx:86
-#: app/features/contact/components/contact-form.tsx:162
+#: app/features/contact-group/components/contact-group-form.tsx:84
+#: app/features/contact/components/contact-form.tsx:160
 #: app/features/activity/components/activity-list.tsx:318
 msgid "Create"
 msgstr "Create"
@@ -393,7 +393,7 @@ msgstr "Description"
 msgid "Details"
 msgstr "Details"
 
-#: app/features/contact-group/components/contact-group-form.tsx:63
+#: app/features/contact-group/components/contact-group-form.tsx:61
 msgid "Display Name"
 msgstr "Display Name"
 
@@ -427,7 +427,7 @@ msgstr "Edit Quota"
 
 #: app/routes/user/detail/index.tsx:206
 #: app/routes/contact/index.tsx:43
-#: app/features/contact/components/contact-form.tsx:109
+#: app/features/contact/components/contact-form.tsx:107
 msgid "Email"
 msgstr "Email"
 
@@ -487,7 +487,7 @@ msgstr "Filter by approval"
 msgid "Filter by time range"
 msgstr "Filter by time range"
 
-#: app/features/contact/components/contact-form.tsx:107
+#: app/features/contact/components/contact-form.tsx:105
 msgid "First Name"
 msgstr "First Name"
 
@@ -568,7 +568,7 @@ msgstr "Joined"
 msgid "Last 10 new users who joined Datum"
 msgstr "Last 10 new users who joined Datum"
 
-#: app/features/contact/components/contact-form.tsx:108
+#: app/features/contact/components/contact-form.tsx:106
 msgid "Last Name"
 msgstr "Last Name"
 
@@ -598,7 +598,7 @@ msgid "Loading status..."
 msgstr "Loading status..."
 
 #: app/routes/group/member.tsx:169
-#: app/features/contact/components/contact-form.tsx:133
+#: app/features/contact/components/contact-form.tsx:131
 msgid "Loading users..."
 msgstr "Loading users..."
 
@@ -712,7 +712,7 @@ msgstr "No users yet"
 msgid "Notifications"
 msgstr "Notifications"
 
-#: app/features/contact/components/contact-form.tsx:144
+#: app/features/contact/components/contact-form.tsx:142
 msgid "Once a contact is associated with a user, this association cannot be removed or changed later."
 msgstr "Once a contact is associated with a user, this association cannot be removed or changed later."
 
@@ -789,7 +789,7 @@ msgstr "Portal Preferences"
 msgid "Preferences updated successfully"
 msgstr "Preferences updated successfully"
 
-#: app/features/contact-group/components/contact-group-form.tsx:71
+#: app/features/contact-group/components/contact-group-form.tsx:69
 msgid "Private"
 msgstr "Private"
 
@@ -814,7 +814,7 @@ msgstr "Project deleted successfully"
 msgid "Projects"
 msgstr "Projects"
 
-#: app/features/contact-group/components/contact-group-form.tsx:70
+#: app/features/contact-group/components/contact-group-form.tsx:68
 msgid "Public"
 msgstr "Public"
 
@@ -916,7 +916,7 @@ msgid "Search contacts..."
 msgstr "Search contacts..."
 
 #: app/routes/group/member.tsx:170
-#: app/features/contact/components/contact-form.tsx:134
+#: app/features/contact/components/contact-form.tsx:132
 msgid "Search users..."
 msgstr "Search users..."
 
@@ -938,7 +938,7 @@ msgid "Select a contact..."
 msgstr "Select a contact..."
 
 #: app/routes/group/member.tsx:169
-#: app/features/contact/components/contact-form.tsx:133
+#: app/features/contact/components/contact-form.tsx:131
 msgid "Select a user..."
 msgstr "Select a user..."
 
@@ -946,7 +946,7 @@ msgstr "Select a user..."
 msgid "Select timezone..."
 msgstr "Select timezone..."
 
-#: app/features/contact-group/components/contact-group-form.tsx:68
+#: app/features/contact-group/components/contact-group-form.tsx:66
 msgid "Select visibility..."
 msgstr "Select visibility..."
 
@@ -1032,8 +1032,8 @@ msgid "Type a command or search..."
 msgstr "Type a command or search..."
 
 #: app/features/quota/components/quota-bucket-list.tsx:158
-#: app/features/contact-group/components/contact-group-form.tsx:86
-#: app/features/contact/components/contact-form.tsx:162
+#: app/features/contact-group/components/contact-group-form.tsx:84
+#: app/features/contact/components/contact-form.tsx:160
 #: app/features/activity/components/activity-list.tsx:319
 msgid "Update"
 msgstr "Update"
@@ -1097,11 +1097,11 @@ msgid "View All"
 msgstr "View All"
 
 #: app/routes/contact-group/index.tsx:42
-#: app/features/contact-group/components/contact-group-form.tsx:67
+#: app/features/contact-group/components/contact-group-form.tsx:65
 msgid "Visibility"
 msgstr "Visibility"
 
-#: app/features/contact/components/contact-form.tsx:143
+#: app/features/contact/components/contact-form.tsx:141
 msgid "Warning"
 msgstr "Warning"
 

--- a/app/modules/i18n/locales/fr.po
+++ b/app/modules/i18n/locales/fr.po
@@ -149,11 +149,11 @@ msgstr ""
 msgid "Are you sure you want to delete user \"{0} {1}\"? This action cannot be undone."
 msgstr ""
 
-#: app/features/contact/components/contact-form.tsx:127
+#: app/features/contact/components/contact-form.tsx:125
 msgid "Associate with User"
 msgstr ""
 
-#: app/features/contact/components/contact-form.tsx:114
+#: app/features/contact/components/contact-form.tsx:112
 msgid "Associated with User: "
 msgstr ""
 
@@ -177,8 +177,8 @@ msgstr ""
 #: app/features/user/components/user-reject-dialog.tsx:30
 #: app/features/quota/components/quota-grant-list.tsx:142
 #: app/features/quota/components/quota-bucket-list.tsx:159
-#: app/features/contact-group/components/contact-group-form.tsx:80
-#: app/features/contact/components/contact-form.tsx:156
+#: app/features/contact-group/components/contact-group-form.tsx:78
+#: app/features/contact/components/contact-form.tsx:154
 #: app/components/danger-zone-card/index.tsx:49
 #: app/components/button/button-delete-action.tsx:43
 msgid "Cancel"
@@ -201,7 +201,7 @@ msgstr ""
 msgid "Configuration"
 msgstr ""
 
-#: app/features/contact/components/contact-form.tsx:89
+#: app/features/contact/components/contact-form.tsx:87
 msgid "Contact created successfully"
 msgstr ""
 
@@ -209,7 +209,7 @@ msgstr ""
 msgid "Contact deleted successfully"
 msgstr ""
 
-#: app/features/contact-group/components/contact-group-form.tsx:48
+#: app/features/contact-group/components/contact-group-form.tsx:46
 msgid "Contact group created successfully"
 msgstr ""
 
@@ -257,8 +257,8 @@ msgstr ""
 
 #: app/routes/contact-group/create.tsx:14
 #: app/routes/contact/create.tsx:14
-#: app/features/contact-group/components/contact-group-form.tsx:86
-#: app/features/contact/components/contact-form.tsx:162
+#: app/features/contact-group/components/contact-group-form.tsx:84
+#: app/features/contact/components/contact-form.tsx:160
 #: app/features/activity/components/activity-list.tsx:318
 msgid "Create"
 msgstr ""
@@ -393,7 +393,7 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: app/features/contact-group/components/contact-group-form.tsx:63
+#: app/features/contact-group/components/contact-group-form.tsx:61
 msgid "Display Name"
 msgstr ""
 
@@ -427,7 +427,7 @@ msgstr ""
 
 #: app/routes/user/detail/index.tsx:206
 #: app/routes/contact/index.tsx:43
-#: app/features/contact/components/contact-form.tsx:109
+#: app/features/contact/components/contact-form.tsx:107
 msgid "Email"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr ""
 msgid "Filter by time range"
 msgstr ""
 
-#: app/features/contact/components/contact-form.tsx:107
+#: app/features/contact/components/contact-form.tsx:105
 msgid "First Name"
 msgstr ""
 
@@ -568,7 +568,7 @@ msgstr ""
 msgid "Last 10 new users who joined Datum"
 msgstr ""
 
-#: app/features/contact/components/contact-form.tsx:108
+#: app/features/contact/components/contact-form.tsx:106
 msgid "Last Name"
 msgstr ""
 
@@ -598,7 +598,7 @@ msgid "Loading status..."
 msgstr ""
 
 #: app/routes/group/member.tsx:169
-#: app/features/contact/components/contact-form.tsx:133
+#: app/features/contact/components/contact-form.tsx:131
 msgid "Loading users..."
 msgstr ""
 
@@ -712,7 +712,7 @@ msgstr ""
 msgid "Notifications"
 msgstr ""
 
-#: app/features/contact/components/contact-form.tsx:144
+#: app/features/contact/components/contact-form.tsx:142
 msgid "Once a contact is associated with a user, this association cannot be removed or changed later."
 msgstr ""
 
@@ -789,7 +789,7 @@ msgstr ""
 msgid "Preferences updated successfully"
 msgstr ""
 
-#: app/features/contact-group/components/contact-group-form.tsx:71
+#: app/features/contact-group/components/contact-group-form.tsx:69
 msgid "Private"
 msgstr ""
 
@@ -814,7 +814,7 @@ msgstr ""
 msgid "Projects"
 msgstr ""
 
-#: app/features/contact-group/components/contact-group-form.tsx:70
+#: app/features/contact-group/components/contact-group-form.tsx:68
 msgid "Public"
 msgstr ""
 
@@ -916,7 +916,7 @@ msgid "Search contacts..."
 msgstr ""
 
 #: app/routes/group/member.tsx:170
-#: app/features/contact/components/contact-form.tsx:134
+#: app/features/contact/components/contact-form.tsx:132
 msgid "Search users..."
 msgstr ""
 
@@ -938,7 +938,7 @@ msgid "Select a contact..."
 msgstr ""
 
 #: app/routes/group/member.tsx:169
-#: app/features/contact/components/contact-form.tsx:133
+#: app/features/contact/components/contact-form.tsx:131
 msgid "Select a user..."
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "Select timezone..."
 msgstr ""
 
-#: app/features/contact-group/components/contact-group-form.tsx:68
+#: app/features/contact-group/components/contact-group-form.tsx:66
 msgid "Select visibility..."
 msgstr ""
 
@@ -1032,8 +1032,8 @@ msgid "Type a command or search..."
 msgstr ""
 
 #: app/features/quota/components/quota-bucket-list.tsx:158
-#: app/features/contact-group/components/contact-group-form.tsx:86
-#: app/features/contact/components/contact-form.tsx:162
+#: app/features/contact-group/components/contact-group-form.tsx:84
+#: app/features/contact/components/contact-form.tsx:160
 #: app/features/activity/components/activity-list.tsx:319
 msgid "Update"
 msgstr ""
@@ -1097,11 +1097,11 @@ msgid "View All"
 msgstr ""
 
 #: app/routes/contact-group/index.tsx:42
-#: app/features/contact-group/components/contact-group-form.tsx:67
+#: app/features/contact-group/components/contact-group-form.tsx:65
 msgid "Visibility"
 msgstr ""
 
-#: app/features/contact/components/contact-form.tsx:143
+#: app/features/contact/components/contact-form.tsx:141
 msgid "Warning"
 msgstr ""
 

--- a/app/resources/request/client/activity.request.test.ts
+++ b/app/resources/request/client/activity.request.test.ts
@@ -1,0 +1,63 @@
+import {
+  importAfterMocks,
+  mockLogger,
+  mockRequestClient,
+} from '@/tests/setup/unit/request-client.mock';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+describe('activity.request', () => {
+  let activityListQuery: typeof import('./activity.request').activityListQuery;
+  mockLogger();
+  const axiosMock = mockRequestClient();
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await importAfterMocks<
+      typeof import('@/resources/request/client/activity.request')
+    >('@/resources/request/client/activity.request');
+    activityListQuery = mod.activityListQuery;
+  }, 20000);
+
+  test('activityListQuery builds params with filters and single resource', async () => {
+    await activityListQuery('Project', 'proj-1', {
+      limit: 50,
+      search: 'foo',
+      filters: {
+        start: 1714857600000,
+        end: 1714857600000,
+        project: 'proj-1',
+        organization: 'org-1',
+        user: 'user-1',
+        status: 'success',
+        actions: 'create,update',
+        responseCode: '200',
+        apiGroup: 'iam.miloapis.com',
+        namespace: 'default',
+        sourceIP: '127.0.0.1',
+      },
+    });
+
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '',
+      baseURL: '/api/activity',
+      params: expect.objectContaining({
+        limit: 50,
+        q: 'foo',
+        project: 'proj-1',
+        organization: 'org-1',
+        resourceType: 'Project',
+        resourceId: 'proj-1',
+        user: 'user-1',
+        status: 'success',
+        actions: 'create,update',
+        responseCode: '200',
+        apiGroup: 'iam.miloapis.com',
+        namespace: 'default',
+        sourceIP: '127.0.0.1',
+      }),
+    });
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/resources/request/client/contact-group.request.test.ts
+++ b/app/resources/request/client/contact-group.request.test.ts
@@ -1,0 +1,138 @@
+import type {
+  ContactGroupCreate,
+  ContactGroupUpdate,
+  ContactGroupMembershipCreate,
+} from '@/resources/schemas';
+import {
+  importAfterMocks,
+  mockLogger,
+  mockRequestClient,
+} from '@/tests/setup/unit/request-client.mock';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+mockLogger();
+const axiosMock = mockRequestClient();
+
+describe('contact-group.request', () => {
+  let contactGroupListQuery: typeof import('./contact-group.request').contactGroupListQuery;
+  let contactGroupCreateMutation: typeof import('./contact-group.request').contactGroupCreateMutation;
+  let contactGroupUpdateMutation: typeof import('./contact-group.request').contactGroupUpdateMutation;
+  let contactGroupDeleteMutation: typeof import('./contact-group.request').contactGroupDeleteMutation;
+  let contactGroupMembershipListQuery: typeof import('./contact-group.request').contactGroupMembershipListQuery;
+  let contactGroupMembershipCreateMutation: typeof import('./contact-group.request').contactGroupMembershipCreateMutation;
+  let contactGroupMembershipDeleteMutation: typeof import('./contact-group.request').contactGroupMembershipDeleteMutation;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await importAfterMocks<
+      typeof import('@/resources/request/client/contact-group.request')
+    >('@/resources/request/client/contact-group.request');
+    contactGroupListQuery = mod.contactGroupListQuery;
+    contactGroupCreateMutation = mod.contactGroupCreateMutation;
+    contactGroupUpdateMutation = mod.contactGroupUpdateMutation;
+    contactGroupDeleteMutation = mod.contactGroupDeleteMutation;
+    contactGroupMembershipListQuery = mod.contactGroupMembershipListQuery;
+    contactGroupMembershipCreateMutation = mod.contactGroupMembershipCreateMutation;
+    contactGroupMembershipDeleteMutation = mod.contactGroupMembershipDeleteMutation;
+  }, 20000);
+
+  test('contactGroupListQuery builds params', async () => {
+    await contactGroupListQuery({ limit: 20, cursor: 'c1' });
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/notification.miloapis.com/v1alpha1/contactgroups',
+      params: { limit: 20, continue: 'c1' },
+    });
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+
+  test('contactGroupCreateMutation posts typed payload', async () => {
+    const payload: ContactGroupCreate = {
+      apiVersion: 'notification.miloapis.com/v1alpha1',
+      kind: 'ContactGroup',
+      metadata: { namespace: 'default', generateName: 'cg-' },
+      spec: { displayName: 'desc' },
+    };
+    await contactGroupCreateMutation(payload, 'org-x');
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'POST',
+      url: '/apis/notification.miloapis.com/v1alpha1/namespaces/org-x/contactgroups',
+      data: payload,
+    });
+    expect(axiosMock.__builder.input).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+  });
+
+  test('contactGroupUpdateMutation patches typed payload', async () => {
+    const patch: ContactGroupUpdate = {
+      apiVersion: 'notification.miloapis.com/v1alpha1',
+      kind: 'ContactGroup',
+      metadata: { namespace: 'default' },
+      spec: { displayName: 'updated' },
+    };
+    await contactGroupUpdateMutation('cg-1', patch, 'org-x');
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'PATCH',
+      url: '/apis/notification.miloapis.com/v1alpha1/namespaces/org-x/contactgroups/cg-1',
+      params: { fieldManager: 'datum-staff-portal' },
+      headers: { 'Content-Type': 'application/merge-patch+json' },
+      data: patch,
+    });
+    expect(axiosMock.__builder.input).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+  });
+
+  test('contactGroupDeleteMutation', async () => {
+    await contactGroupDeleteMutation('cg-1', 'org-x');
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'DELETE',
+      url: '/apis/notification.miloapis.com/v1alpha1/namespaces/org-x/contactgroups/cg-1',
+    });
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+
+  test('contactGroupMembershipListQuery with fieldSelector', async () => {
+    await contactGroupMembershipListQuery({
+      limit: 10,
+      cursor: 'n2',
+      filters: { fieldSelector: 'spec.contactGroupRef.name=cg-1' },
+    });
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/notification.miloapis.com/v1alpha1/contactgroupmemberships',
+      params: { limit: 10, continue: 'n2', fieldSelector: 'spec.contactGroupRef.name=cg-1' },
+    });
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+
+  test('contactGroupMembershipCreateMutation', async () => {
+    const payload: ContactGroupMembershipCreate = {
+      apiVersion: 'notification.miloapis.com/v1alpha1',
+      kind: 'ContactGroupMembership',
+      metadata: { namespace: 'default', generateName: 'cgm-' },
+      spec: {
+        contactGroupRef: { name: 'cg-1', namespace: 'default' },
+        contactRef: { name: 'c-1', namespace: 'default' },
+      },
+    };
+    await contactGroupMembershipCreateMutation(payload, 'org-x');
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'POST',
+      url: '/apis/notification.miloapis.com/v1alpha1/namespaces/org-x/contactgroupmemberships',
+      data: payload,
+    });
+    expect(axiosMock.__builder.input).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+  });
+
+  test('contactGroupMembershipDeleteMutation', async () => {
+    await contactGroupMembershipDeleteMutation('cgm-1', 'org-x');
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'DELETE',
+      url: '/apis/notification.miloapis.com/v1alpha1/namespaces/org-x/contactgroupmemberships/cgm-1',
+    });
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/resources/request/client/contact.request.test.ts
+++ b/app/resources/request/client/contact.request.test.ts
@@ -1,0 +1,96 @@
+import type { ContactCreate, ContactUpdate } from '@/resources/schemas';
+import {
+  importAfterMocks,
+  mockLogger,
+  mockRequestClient,
+} from '@/tests/setup/unit/request-client.mock';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+mockLogger();
+const axiosMock = mockRequestClient();
+
+describe('contact.request', () => {
+  let contactListQuery: typeof import('./contact.request').contactListQuery;
+  let contactCreateMutation: typeof import('./contact.request').contactCreateMutation;
+  let contactUpdateMutation: typeof import('./contact.request').contactUpdateMutation;
+  let contactDeleteMutation: typeof import('./contact.request').contactDeleteMutation;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await importAfterMocks<typeof import('@/resources/request/client/contact.request')>(
+      '@/resources/request/client/contact.request'
+    );
+    contactListQuery = mod.contactListQuery;
+    contactCreateMutation = mod.contactCreateMutation;
+    contactUpdateMutation = mod.contactUpdateMutation;
+    contactDeleteMutation = mod.contactDeleteMutation;
+  });
+
+  test('contactListQuery builds params correctly', async () => {
+    await contactListQuery({ limit: 10, cursor: 'c1', search: 'alice' });
+
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/notification.miloapis.com/v1alpha1/contacts',
+      params: { limit: 10, continue: 'c1', fieldSelector: 'metadata.name=alice' },
+    });
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+
+  test('contactCreateMutation posts typed payload to namespace', async () => {
+    const payload: ContactCreate = {
+      apiVersion: 'notification.miloapis.com/v1alpha1',
+      kind: 'Contact',
+      metadata: { namespace: 'default', generateName: 'contact-' },
+      spec: {
+        givenName: 'Alice',
+        familyName: 'Doe',
+        email: 'alice@example.com',
+        subject: { apiGroup: 'iam.miloapis.com', kind: 'User', name: 'user-alice' },
+      },
+    };
+
+    await contactCreateMutation(payload, 'org-foo');
+
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'POST',
+      url: '/apis/notification.miloapis.com/v1alpha1/namespaces/org-foo/contacts',
+      data: payload,
+    });
+    expect(axiosMock.__builder.input).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+
+  test('contactUpdateMutation patches with typed payload', async () => {
+    const patch: ContactUpdate = {
+      apiVersion: 'notification.miloapis.com/v1alpha1',
+      kind: 'Contact',
+      metadata: { namespace: 'default' },
+      spec: { givenName: 'Alicia', familyName: 'Doe', email: 'alice@example.com' },
+    };
+
+    await contactUpdateMutation('contact-1', patch, 'ns-x');
+
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'PATCH',
+      url: '/apis/notification.miloapis.com/v1alpha1/namespaces/ns-x/contacts/contact-1',
+      params: { fieldManager: 'datum-staff-portal' },
+      headers: { 'Content-Type': 'application/merge-patch+json' },
+      data: patch,
+    });
+    expect(axiosMock.__builder.input).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+
+  test('contactDeleteMutation deletes resource at path', async () => {
+    await contactDeleteMutation('contact-2', 'ns-y');
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'DELETE',
+      url: '/apis/notification.miloapis.com/v1alpha1/namespaces/ns-y/contacts/contact-2',
+    });
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/resources/request/client/email.request.test.ts
+++ b/app/resources/request/client/email.request.test.ts
@@ -1,0 +1,32 @@
+import {
+  importAfterMocks,
+  mockLogger,
+  mockRequestClient,
+} from '@/tests/setup/unit/request-client.mock';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+mockLogger();
+const axiosMock = mockRequestClient();
+
+describe('email.request', () => {
+  let emailListQuery: typeof import('./email.request').emailListQuery;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await importAfterMocks<typeof import('@/resources/request/client/email.request')>(
+      '@/resources/request/client/email.request'
+    );
+    emailListQuery = mod.emailListQuery;
+  }, 20000);
+
+  test('emailListQuery builds params', async () => {
+    await emailListQuery({ limit: 10, cursor: 'c1' });
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/notification.miloapis.com/v1alpha1/namespaces/milo-system/emails',
+      params: { limit: 10, continue: 'c1' },
+    });
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/resources/request/client/group.request.test.ts
+++ b/app/resources/request/client/group.request.test.ts
@@ -1,0 +1,80 @@
+import type { GroupMembershipCreate } from '@/resources/schemas';
+import {
+  importAfterMocks,
+  mockLogger,
+  mockRequestClient,
+} from '@/tests/setup/unit/request-client.mock';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+mockLogger();
+const axiosMock = mockRequestClient();
+
+describe('group.request', () => {
+  let groupListQuery: typeof import('./group.request').groupListQuery;
+  let groupMembershipListQuery: typeof import('./group.request').groupMembershipListQuery;
+  let groupMembershipDeleteMutation: typeof import('./group.request').groupMembershipDeleteMutation;
+  let groupMembershipCreateMutation: typeof import('./group.request').groupMembershipCreateMutation;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await importAfterMocks<typeof import('@/resources/request/client/group.request')>(
+      '@/resources/request/client/group.request'
+    );
+    groupListQuery = mod.groupListQuery;
+    groupMembershipListQuery = mod.groupMembershipListQuery;
+    groupMembershipDeleteMutation = mod.groupMembershipDeleteMutation;
+    groupMembershipCreateMutation = mod.groupMembershipCreateMutation;
+  }, 20000);
+
+  test('groupListQuery builds params', async () => {
+    await groupListQuery({ limit: 15, cursor: 'c2' });
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/iam.miloapis.com/v1alpha1/groups',
+      params: { limit: 15, continue: 'c2' },
+    });
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+
+  test('groupMembershipListQuery with fieldSelector', async () => {
+    await groupMembershipListQuery({
+      limit: 5,
+      cursor: 'n1',
+      filters: { fieldSelector: 'spec.groupRef.name=g1' },
+    });
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/iam.miloapis.com/v1alpha1/groupmemberships',
+      params: { limit: 5, continue: 'n1', fieldSelector: 'spec.groupRef.name=g1' },
+    });
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+
+  test('groupMembershipDeleteMutation', async () => {
+    await groupMembershipDeleteMutation('gm-1', 'milo-system');
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'DELETE',
+      url: '/apis/iam.miloapis.com/v1alpha1/namespaces/milo-system/groupmemberships/gm-1',
+    });
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+
+  test('groupMembershipCreateMutation posts typed payload', async () => {
+    const payload: GroupMembershipCreate = {
+      apiVersion: 'iam.miloapis.com/v1alpha1',
+      kind: 'GroupMembership',
+      metadata: { namespace: 'milo-system', generateName: 'gm-' },
+      spec: { groupRef: { name: 'g1' }, userRef: { name: 'u1' } },
+    };
+    await groupMembershipCreateMutation(payload, 'milo-system');
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'POST',
+      url: '/apis/iam.miloapis.com/v1alpha1/namespaces/milo-system/groupmemberships',
+      data: payload,
+    });
+    expect(axiosMock.__builder.input).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/resources/request/client/identity.request.test.ts
+++ b/app/resources/request/client/identity.request.test.ts
@@ -1,0 +1,44 @@
+import {
+  importAfterMocks,
+  mockLogger,
+  mockRequestClient,
+} from '@/tests/setup/unit/request-client.mock';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+mockLogger();
+const axiosMock = mockRequestClient();
+
+describe('identity.request', () => {
+  let sessionListQuery: typeof import('./identity.request').sessionListQuery;
+  let sessionDeleteMutation: typeof import('./identity.request').sessionDeleteMutation;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await importAfterMocks<
+      typeof import('@/resources/request/client/identity.request')
+    >('@/resources/request/client/identity.request');
+    sessionListQuery = mod.sessionListQuery;
+    sessionDeleteMutation = mod.sessionDeleteMutation;
+  }, 20000);
+
+  test('sessionListQuery builds path and params', async () => {
+    await sessionListQuery('u-1', { limit: 10, cursor: 'c1', search: 'sname' });
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/iam.miloapis.com/v1alpha1/users/u-1/control-plane/apis/identity.miloapis.com/v1alpha1/sessions',
+      params: { limit: 10, continue: 'c1', fieldSelector: 'metadata.name=sname' },
+    });
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+
+  test('sessionDeleteMutation builds path', async () => {
+    await sessionDeleteMutation('u-1', 'sess-1');
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'DELETE',
+      url: '/apis/iam.miloapis.com/v1alpha1/users/u-1/control-plane/apis/identity.miloapis.com/v1alpha1/sessions/sess-1',
+    });
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/resources/request/client/membership.request.test.ts
+++ b/app/resources/request/client/membership.request.test.ts
@@ -1,0 +1,47 @@
+import {
+  importAfterMocks,
+  mockLogger,
+  mockRequestClient,
+} from '@/tests/setup/unit/request-client.mock';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+mockLogger();
+const axiosMock = mockRequestClient();
+
+describe('membership.request', () => {
+  let userOrgListQuery: typeof import('./membership.request').userOrgListQuery;
+  let buildFieldSelector: typeof import('./membership.request').buildFieldSelector;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await importAfterMocks<
+      typeof import('@/resources/request/client/membership.request')
+    >('@/resources/request/client/membership.request');
+    userOrgListQuery = mod.userOrgListQuery;
+    buildFieldSelector = mod.buildFieldSelector;
+  }, 20000);
+
+  test('buildFieldSelector builds CSV', () => {
+    const s = buildFieldSelector({ a: '1', b: '2' });
+    expect(s).toBe('a=1,b=2');
+  });
+
+  test('userOrgListQuery builds fieldSelector including user and extras', async () => {
+    await userOrgListQuery('user-1', {
+      limit: 5,
+      cursor: 'c1',
+      filters: { fieldSelector: 'x=y,z=w' },
+    });
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/resourcemanager.miloapis.com/v1alpha1/organizationmemberships',
+      params: {
+        limit: 5,
+        continue: 'c1',
+        fieldSelector: expect.stringContaining('spec.userRef.name=user-1'),
+      },
+    });
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/resources/request/client/metrics.request.test.ts
+++ b/app/resources/request/client/metrics.request.test.ts
@@ -1,0 +1,34 @@
+import {
+  importAfterMocks,
+  mockLogger,
+  mockRequestClient,
+} from '@/tests/setup/unit/request-client.mock';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+mockLogger();
+const axiosMock = mockRequestClient();
+
+describe('metrics.request', () => {
+  let metricsCreateMutation: typeof import('./metrics.request').metricsCreateMutation;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await importAfterMocks<typeof import('@/resources/request/client/metrics.request')>(
+      '@/resources/request/client/metrics.request'
+    );
+    metricsCreateMutation = mod.metricsCreateMutation;
+  }, 20000);
+
+  test('metricsCreateMutation posts to /api/metrics baseURL with payload', async () => {
+    const payload = { name: 'event', value: 1 };
+    await metricsCreateMutation(payload);
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'POST',
+      url: '',
+      baseURL: '/api/metrics',
+      data: payload,
+    });
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/resources/request/client/organization.request.test.ts
+++ b/app/resources/request/client/organization.request.test.ts
@@ -1,0 +1,138 @@
+import type { MemberInvitationCreate } from '@/resources/schemas';
+import {
+  importAfterMocks,
+  mockLogger,
+  mockRequestClient,
+} from '@/tests/setup/unit/request-client.mock';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+describe('organization.request', () => {
+  let orgListQuery: typeof import('./organization.request').orgListQuery;
+  let orgProjectListQuery: typeof import('./organization.request').orgProjectListQuery;
+  let orgMemberListQuery: typeof import('./organization.request').orgMemberListQuery;
+  let orgInvitationCreateMutation: typeof import('./organization.request').orgInvitationCreateMutation;
+  let orgInvitationDeleteMutation: typeof import('./organization.request').orgInvitationDeleteMutation;
+  let orgDeleteMutation: typeof import('./organization.request').orgDeleteMutation;
+  mockLogger();
+  const axiosMock = mockRequestClient();
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await importAfterMocks<
+      typeof import('@/resources/request/client/organization.request')
+    >('@/resources/request/client/organization.request');
+    orgListQuery = mod.orgListQuery;
+    orgProjectListQuery = mod.orgProjectListQuery;
+    orgMemberListQuery = mod.orgMemberListQuery;
+    orgInvitationCreateMutation = mod.orgInvitationCreateMutation;
+    orgInvitationDeleteMutation = mod.orgInvitationDeleteMutation;
+    orgDeleteMutation = mod.orgDeleteMutation;
+  }, 20000);
+
+  test('orgListQuery builds params', async () => {
+    await orgListQuery({ limit: 10, cursor: 'c1', search: 'acme' });
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/resourcemanager.miloapis.com/v1alpha1/organizations',
+      params: { limit: 10, continue: 'c1', fieldSelector: 'metadata.name=acme' },
+    });
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+
+  test('orgProjectListQuery builds path and params', async () => {
+    await orgProjectListQuery('acme', { limit: 5, cursor: 'n1' });
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/resourcemanager.miloapis.com/v1alpha1/organizations/acme/control-plane/apis/resourcemanager.miloapis.com/v1alpha1/projects',
+      params: { limit: 5, continue: 'n1' },
+    });
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+
+  test('orgMemberListQuery merges members and invitations', async () => {
+    // Prepare two mocked responses for the two sequential calls
+    axiosMock.__builder.execute
+      .mockResolvedValueOnce({
+        data: {
+          items: [
+            {
+              status: { user: { givenName: 'A', familyName: 'B', email: 'a@b.c' } },
+              spec: { userRef: { name: 'u1' } },
+              metadata: { creationTimestamp: 't1' },
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          items: [
+            {
+              spec: {
+                givenName: 'C',
+                familyName: 'D',
+                email: 'c@d.e',
+                roles: ['Member'],
+                state: 'Pending',
+              },
+              metadata: { name: 'inv1', creationTimestamp: 't2' },
+            },
+          ],
+        },
+      });
+
+    await orgMemberListQuery('acme', { limit: 3 });
+    // Two GETs are made with different URLs; we just assert first is called
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/resourcemanager.miloapis.com/v1alpha1/namespaces/organization-acme/organizationmemberships',
+      params: { limit: 3 },
+    });
+    expect(axiosMock.__builder.output).toHaveBeenCalled();
+    expect(axiosMock.__builder.execute).toHaveBeenCalled();
+  });
+
+  test('orgInvitationCreateMutation posts typed payload', async () => {
+    const payload: MemberInvitationCreate = {
+      apiVersion: 'iam.miloapis.com/v1alpha1',
+      kind: 'UserInvitation',
+      metadata: { generateName: 'inv-' },
+      spec: {
+        givenName: 'John',
+        familyName: 'Doe',
+        email: 'a@b.c',
+        expirationDate: '2099-01-01T00:00:00Z',
+        organizationRef: { name: 'acme' },
+        state: 'Pending',
+        roles: [{ name: 'Member', namespace: 'acme' }],
+      },
+    };
+    await orgInvitationCreateMutation('acme', payload);
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'POST',
+      url: '/apis/iam.miloapis.com/v1alpha1/namespaces/organization-acme/userinvitations',
+      data: payload,
+    });
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+
+  test('orgInvitationDeleteMutation builds path', async () => {
+    await orgInvitationDeleteMutation('acme', 'inv-1');
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'DELETE',
+      url: '/apis/iam.miloapis.com/v1alpha1/namespaces/organization-acme/userinvitations/inv-1',
+    });
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+
+  test('orgDeleteMutation builds path', async () => {
+    await orgDeleteMutation('acme');
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'DELETE',
+      url: '/apis/resourcemanager.miloapis.com/v1alpha1/organizations/acme',
+    });
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/resources/request/client/project.request.test.ts
+++ b/app/resources/request/client/project.request.test.ts
@@ -1,0 +1,86 @@
+import {
+  importAfterMocks,
+  mockLogger,
+  mockRequestClient,
+} from '@/tests/setup/unit/request-client.mock';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+mockLogger();
+const axiosMock = mockRequestClient();
+
+describe('project.request', () => {
+  let projectListQuery: typeof import('./project.request').projectListQuery;
+  let projectHttpProxyListQuery: typeof import('./project.request').projectHttpProxyListQuery;
+  let projectExportPolicyListQuery: typeof import('./project.request').projectExportPolicyListQuery;
+  let projectDomainListQuery: typeof import('./project.request').projectDomainListQuery;
+  let projectDomainStatusQuery: typeof import('./project.request').projectDomainStatusQuery;
+  let projectDeleteMutation: typeof import('./project.request').projectDeleteMutation;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await importAfterMocks<typeof import('@/resources/request/client/project.request')>(
+      '@/resources/request/client/project.request'
+    );
+    projectListQuery = mod.projectListQuery;
+    projectHttpProxyListQuery = mod.projectHttpProxyListQuery;
+    projectExportPolicyListQuery = mod.projectExportPolicyListQuery;
+    projectDomainListQuery = mod.projectDomainListQuery;
+    projectDomainStatusQuery = mod.projectDomainStatusQuery;
+    projectDeleteMutation = mod.projectDeleteMutation;
+  }, 20000);
+
+  test('projectListQuery with search', async () => {
+    await projectListQuery({ limit: 10, cursor: 'c1', search: 'app' });
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/resourcemanager.miloapis.com/v1alpha1/projects',
+      params: { limit: 10, continue: 'c1', fieldSelector: 'metadata.name=app' },
+    });
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+
+  test('projectHttpProxyListQuery', async () => {
+    await projectHttpProxyListQuery('proj', { limit: 2, cursor: 'n1' });
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/resourcemanager.miloapis.com/v1alpha1/projects/proj/control-plane/apis/networking.datumapis.com/v1alpha/httpproxies',
+      params: { limit: 2, continue: 'n1' },
+    });
+  });
+
+  test('projectExportPolicyListQuery', async () => {
+    await projectExportPolicyListQuery('proj', { limit: 3 });
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/resourcemanager.miloapis.com/v1alpha1/projects/proj/control-plane/apis/telemetry.miloapis.com/v1alpha1/namespaces/default/exportpolicies',
+      params: { limit: 3 },
+    });
+  });
+
+  test('projectDomainListQuery', async () => {
+    await projectDomainListQuery('proj', { cursor: 'n2' });
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/resourcemanager.miloapis.com/v1alpha1/projects/proj/control-plane/apis/networking.datumapis.com/v1alpha/domains',
+      params: { continue: 'n2' },
+    });
+  });
+
+  test('projectDomainStatusQuery', async () => {
+    await projectDomainStatusQuery('proj', 'example.com');
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: 'apis/resourcemanager.miloapis.com/v1alpha1/projects/proj/control-plane/apis/networking.datumapis.com/v1alpha/namespaces/default/domains/example.com/status',
+    });
+  });
+
+  test('projectDeleteMutation', async () => {
+    await projectDeleteMutation('proj');
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'DELETE',
+      url: '/apis/resourcemanager.miloapis.com/v1alpha1/projects/proj',
+    });
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/resources/request/client/quota.request.test.ts
+++ b/app/resources/request/client/quota.request.test.ts
@@ -1,0 +1,169 @@
+import type { ResourceGrantCreate } from '@/resources/schemas';
+import {
+  importAfterMocks,
+  mockLogger,
+  mockRequestClient,
+} from '@/tests/setup/unit/request-client.mock';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+mockLogger();
+const axiosMock = mockRequestClient();
+
+describe('quota.request', () => {
+  let quotaGrantListQuery: typeof import('./quota.request').quotaGrantListQuery;
+  let quotaGrantDetailQuery: typeof import('./quota.request').quotaGrantDetailQuery;
+  let orgQuotaGrantListQuery: typeof import('./quota.request').orgQuotaGrantListQuery;
+  let projectQuotaGrantListQuery: typeof import('./quota.request').projectQuotaGrantListQuery;
+  let quotaBucketListQuery: typeof import('./quota.request').quotaBucketListQuery;
+  let quotaBucketDetailQuery: typeof import('./quota.request').quotaBucketDetailQuery;
+  let orgQuotaBucketListQuery: typeof import('./quota.request').orgQuotaBucketListQuery;
+  let projectQuotaBucketListQuery: typeof import('./quota.request').projectQuotaBucketListQuery;
+  let quotaGrantCreateMutation: typeof import('./quota.request').quotaGrantCreateMutation;
+  let quotaGrantDeleteMutation: typeof import('./quota.request').quotaGrantDeleteMutation;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await importAfterMocks<typeof import('@/resources/request/client/quota.request')>(
+      '@/resources/request/client/quota.request'
+    );
+    quotaGrantListQuery = mod.quotaGrantListQuery;
+    quotaGrantDetailQuery = mod.quotaGrantDetailQuery;
+    orgQuotaGrantListQuery = mod.orgQuotaGrantListQuery;
+    projectQuotaGrantListQuery = mod.projectQuotaGrantListQuery;
+    quotaBucketListQuery = mod.quotaBucketListQuery;
+    quotaBucketDetailQuery = mod.quotaBucketDetailQuery;
+    orgQuotaBucketListQuery = mod.orgQuotaBucketListQuery;
+    projectQuotaBucketListQuery = mod.projectQuotaBucketListQuery;
+    quotaGrantCreateMutation = mod.quotaGrantCreateMutation;
+    quotaGrantDeleteMutation = mod.quotaGrantDeleteMutation;
+  });
+
+  test('quotaGrantListQuery passes common params', async () => {
+    await quotaGrantListQuery({
+      limit: 5,
+      cursor: 'c1',
+      fieldSelector: 'a=b',
+      labelSelector: 'x=y',
+    });
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/quota.miloapis.com/v1alpha1/resourcegrants',
+      params: { limit: 5, continue: 'c1', fieldSelector: 'a=b', labelSelector: 'x=y' },
+    });
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+
+  test('quotaGrantDetailQuery uses namespaced path', async () => {
+    await quotaGrantDetailQuery('grant-1', 'org-ns');
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/quota.miloapis.com/v1alpha1/namespaces/org-ns/resourcegrants/grant-1',
+    });
+  });
+
+  test('orgQuotaGrantListQuery builds Organization fieldSelector', async () => {
+    await orgQuotaGrantListQuery('acme', { resourceType: 'Email', limit: 10 });
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/quota.miloapis.com/v1alpha1/resourcegrants',
+      params: {
+        limit: 10,
+        fieldSelector:
+          'spec.consumerRef.kind=Organization,spec.consumerRef.name=acme,spec.allowances.resourceType=Email',
+      },
+    });
+  });
+
+  test('projectQuotaGrantListQuery builds Project fieldSelector', async () => {
+    await projectQuotaGrantListQuery('proj-1', { resourceType: 'SMS' });
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/quota.miloapis.com/v1alpha1/resourcegrants',
+      params: {
+        fieldSelector:
+          'spec.consumerRef.kind=Project,spec.consumerRef.name=proj-1,spec.allowances.resourceType=SMS',
+      },
+    });
+  });
+
+  test('quotaBucketListQuery passes common params', async () => {
+    await quotaBucketListQuery({ limit: 7, cursor: 'nxt', fieldSelector: 'k=v' });
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/quota.miloapis.com/v1alpha1/allowancebuckets',
+      params: { limit: 7, continue: 'nxt', fieldSelector: 'k=v' },
+    });
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+
+  test('quotaBucketDetailQuery uses cluster-scoped path', async () => {
+    await quotaBucketDetailQuery('bucket-1');
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/quota.miloapis.com/v1alpha1/allowancebuckets/bucket-1',
+    });
+  });
+
+  test('orgQuotaBucketListQuery builds Organization fieldSelector', async () => {
+    await orgQuotaBucketListQuery('acme', { resourceType: 'Email' });
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/quota.miloapis.com/v1alpha1/allowancebuckets',
+      params: {
+        fieldSelector:
+          'spec.consumerRef.kind=Organization,spec.consumerRef.name=acme,spec.resourceType=Email',
+      },
+    });
+  });
+
+  test('projectQuotaBucketListQuery builds Project fieldSelector', async () => {
+    await projectQuotaBucketListQuery('p1');
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/quota.miloapis.com/v1alpha1/allowancebuckets',
+      params: {
+        fieldSelector: 'spec.consumerRef.kind=Project,spec.consumerRef.name=p1',
+      },
+    });
+  });
+
+  test('quotaGrantCreateMutation posts typed payload', async () => {
+    const payload: ResourceGrantCreate = {
+      apiVersion: 'quota.miloapis.com/v1alpha1',
+      kind: 'ResourceGrant',
+      metadata: { generateName: 'grant-', namespace: 'org-acme' },
+      spec: {
+        consumerRef: {
+          apiGroup: 'resourcemanager.miloapis.com',
+          kind: 'Organization',
+          name: 'acme',
+        },
+        allowances: [
+          {
+            resourceType: 'Email',
+            buckets: [{ amount: 100 }],
+          },
+        ],
+      },
+    };
+
+    await quotaGrantCreateMutation(payload);
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'POST',
+      url: '/apis/quota.miloapis.com/v1alpha1/namespaces/org-acme/resourcegrants',
+      data: payload,
+    });
+    expect(axiosMock.__builder.input).toHaveBeenCalledTimes(1);
+  });
+
+  test('quotaGrantDeleteMutation deletes namespaced grant', async () => {
+    await quotaGrantDeleteMutation('grant-x', 'org-acme');
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'DELETE',
+      url: '/apis/quota.miloapis.com/v1alpha1/namespaces/org-acme/resourcegrants/grant-x',
+    });
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/resources/request/client/user.request.test.ts
+++ b/app/resources/request/client/user.request.test.ts
@@ -1,0 +1,151 @@
+import type { UserUpdate, UserApprove, UserReject, UserDeactivate } from '@/resources/schemas';
+import {
+  importAfterMocks,
+  mockLogger,
+  mockRequestClient,
+} from '@/tests/setup/unit/request-client.mock';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+mockLogger();
+const axiosMock = mockRequestClient();
+
+describe('user.request', () => {
+  let userListQuery: typeof import('./user.request').userListQuery;
+  let userUpdateMutation: typeof import('./user.request').userUpdateMutation;
+  let userDeleteMutation: typeof import('./user.request').userDeleteMutation;
+  let userApproveMutation: typeof import('./user.request').userApproveMutation;
+  let userRejectMutation: typeof import('./user.request').userRejectMutation;
+  let userDeactivateMutation: typeof import('./user.request').userDeactivateMutation;
+  let userReactivateMutation: typeof import('./user.request').userReactivateMutation;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await importAfterMocks<typeof import('@/resources/request/client/user.request')>(
+      '@/resources/request/client/user.request'
+    );
+    userListQuery = mod.userListQuery;
+    userUpdateMutation = mod.userUpdateMutation;
+    userDeleteMutation = mod.userDeleteMutation;
+    userApproveMutation = mod.userApproveMutation;
+    userRejectMutation = mod.userRejectMutation;
+    userDeactivateMutation = mod.userDeactivateMutation;
+    userReactivateMutation = mod.userReactivateMutation;
+  });
+
+  test('userListQuery builds combined fieldSelector', async () => {
+    await userListQuery({
+      limit: 25,
+      cursor: 'next',
+      search: 'user@example.com',
+      // filters type is defined in ListQueryParams; we pass expected slice
+      // registrationApproval is a string union in schema
+      filters: { registrationApproval: 'Approved' },
+    });
+
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/apis/iam.miloapis.com/v1alpha1/users',
+      params: {
+        limit: 25,
+        continue: 'next',
+        fieldSelector: 'spec.email=user@example.com,status.registrationApproval=Approved',
+      },
+    });
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+
+  test('userUpdateMutation sends typed patch', async () => {
+    const patch: UserUpdate = {
+      apiVersion: 'iam.miloapis.com/v1alpha1',
+      kind: 'User',
+      spec: { givenName: 'Jane', familyName: 'Doe' },
+    };
+
+    await userUpdateMutation('user-1', patch);
+
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'PATCH',
+      url: '/apis/iam.miloapis.com/v1alpha1/users/user-1',
+      params: { fieldManager: 'datum-staff-portal' },
+      headers: { 'Content-Type': 'application/merge-patch+json' },
+      data: patch,
+    });
+    expect(axiosMock.__builder.input).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__builder.output).toHaveBeenCalledTimes(1);
+  });
+
+  test('userDeleteMutation deletes user resource', async () => {
+    await userDeleteMutation('user-2');
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'DELETE',
+      url: '/apis/iam.miloapis.com/v1alpha1/users/user-2',
+    });
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+
+  test('userApproveMutation validates typed input', async () => {
+    const payload: UserApprove = {
+      apiVersion: 'iam.miloapis.com/v1alpha1',
+      kind: 'PlatformAccessApproval',
+      metadata: { generateName: 'approve-' },
+      spec: { subjectRef: { userRef: { name: 'user-1' } }, approverRef: { name: 'admin-1' } },
+    };
+
+    await userApproveMutation(payload);
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'POST',
+      url: '/apis/iam.miloapis.com/v1alpha1/platformaccessapprovals',
+      data: payload,
+    });
+    expect(axiosMock.__builder.input).toHaveBeenCalledTimes(1);
+  });
+
+  test('userRejectMutation validates typed input', async () => {
+    const payload: UserReject = {
+      apiVersion: 'iam.miloapis.com/v1alpha1',
+      kind: 'PlatformAccessRejection',
+      metadata: { generateName: 'reject-' },
+      spec: { subjectRef: { name: 'user-1' }, reason: 'Insufficient info' },
+    };
+
+    await userRejectMutation(payload);
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'POST',
+      url: '/apis/iam.miloapis.com/v1alpha1/platformaccessrejections',
+      data: payload,
+    });
+    expect(axiosMock.__builder.input).toHaveBeenCalledTimes(1);
+  });
+
+  test('userDeactivateMutation validates typed input', async () => {
+    const payload: UserDeactivate = {
+      apiVersion: 'iam.miloapis.com/v1alpha1',
+      kind: 'UserDeactivation',
+      metadata: { generateName: 'deact-' },
+      spec: {
+        deactivatedBy: 'admin-1',
+        description: 'cleanup',
+        reason: 'policy',
+        userRef: { name: 'user-1' },
+      },
+    };
+
+    await userDeactivateMutation(payload);
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'POST',
+      url: '/apis/iam.miloapis.com/v1alpha1/userdeactivations',
+      data: payload,
+    });
+    expect(axiosMock.__builder.input).toHaveBeenCalledTimes(1);
+  });
+
+  test('userReactivateMutation deletes deactivation by id', async () => {
+    await userReactivateMutation('user-3');
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'DELETE',
+      url: '/apis/iam.miloapis.com/v1alpha1/userdeactivations/user-3',
+    });
+    expect(axiosMock.__builder.execute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/resources/schemas/membership.schema.ts
+++ b/app/resources/schemas/membership.schema.ts
@@ -188,7 +188,8 @@ export const MemberInvitationCreateSchema = z.object({
   apiVersion: z.literal('iam.miloapis.com/v1alpha1'),
   kind: z.literal('UserInvitation'),
   metadata: z.object({
-    name: z.string(),
+    name: z.string().optional(),
+    generateName: z.string().optional(),
   }),
   spec: z.object({
     familyName: z.string(),

--- a/app/resources/schemas/user.schema.ts
+++ b/app/resources/schemas/user.schema.ts
@@ -97,7 +97,8 @@ export const UserDeactivateSchema = z.object({
   apiVersion: z.literal('iam.miloapis.com/v1alpha1'),
   kind: z.literal('UserDeactivation'),
   metadata: z.object({
-    name: z.string(),
+    name: z.string().optional(),
+    generateName: z.string().optional(),
   }),
   spec: z.object({
     deactivatedBy: z.string(),
@@ -166,7 +167,8 @@ export const UserApproveSchema = z.object({
   apiVersion: z.literal('iam.miloapis.com/v1alpha1'),
   kind: z.literal('PlatformAccessApproval'),
   metadata: z.object({
-    name: z.string(),
+    name: z.string().optional(),
+    generateName: z.string().optional(),
   }),
   spec: z.object({
     subjectRef: z.object({
@@ -188,7 +190,8 @@ export const UserRejectSchema = z.object({
   apiVersion: z.literal('iam.miloapis.com/v1alpha1'),
   kind: z.literal('PlatformAccessRejection'),
   metadata: z.object({
-    name: z.string(),
+    name: z.string().optional(),
+    generateName: z.string().optional(),
   }),
   spec: z.object({
     subjectRef: z.object({

--- a/app/routes/contact-group/detail/member.tsx
+++ b/app/routes/contact-group/detail/member.tsx
@@ -93,7 +93,7 @@ export default function Page() {
       apiVersion: 'notification.miloapis.com/v1alpha1',
       kind: 'ContactGroupMembership',
       metadata: {
-        name: generateMetadataName([data.metadata.name, formData.name].filter(Boolean).join('-')),
+        generateName: 'contact-group-membership-',
         namespace: 'default',
       },
       spec: {

--- a/app/routes/group/member.tsx
+++ b/app/routes/group/member.tsx
@@ -109,7 +109,7 @@ export default function Page() {
         apiVersion: 'iam.miloapis.com/v1alpha1',
         kind: 'GroupMembership',
         metadata: {
-          name: [data.metadata.name, formData.name].join('-'),
+          generateName: 'group-membership-',
           namespace: 'milo-system',
         },
         spec: {

--- a/app/routes/organization/detail/member.tsx
+++ b/app/routes/organization/detail/member.tsx
@@ -94,7 +94,7 @@ export default function Page() {
             apiVersion: 'iam.miloapis.com/v1alpha1',
             kind: 'UserInvitation',
             metadata: {
-              name: generateMetadataName([data.metadata.name, row.name].filter(Boolean).join('-')),
+              generateName: 'user-invitation-',
             },
             spec: {
               email: row.email,

--- a/app/routes/user/detail/index.tsx
+++ b/app/routes/user/detail/index.tsx
@@ -72,7 +72,7 @@ export default function Page() {
         apiVersion: 'iam.miloapis.com/v1alpha1',
         kind: 'UserDeactivation',
         metadata: {
-          name: data.metadata.name,
+          generateName: 'user-deactivation-',
         },
         spec: {
           reason: formData.reason,

--- a/tests/setup/unit/request-client.mock.ts
+++ b/tests/setup/unit/request-client.mock.ts
@@ -1,0 +1,45 @@
+import { vi } from 'vitest';
+
+let __builder: any;
+let __apiRequestClient: any;
+
+export type AxiosRequestMock = {
+  readonly apiRequestClient: any;
+  readonly __builder: any;
+};
+
+export const mockRequestClient = (): AxiosRequestMock => {
+  vi.mock('@/modules/axios/axios.client', () => {
+    __builder = {
+      input: vi.fn().mockReturnThis(),
+      output: vi.fn().mockReturnThis(),
+      execute: vi.fn().mockResolvedValue({ data: { ok: true } }),
+    };
+    __apiRequestClient = vi.fn(() => __builder as any);
+    return { apiRequestClient: __apiRequestClient, __builder } as any;
+  });
+
+  return {
+    get apiRequestClient() {
+      return __apiRequestClient;
+    },
+    get __builder() {
+      return __builder;
+    },
+  } as AxiosRequestMock as any;
+};
+
+export const mockLogger = () => {
+  vi.mock('@/utils/logger', async (importOriginal) => {
+    const actual = (await importOriginal()) as Record<string, unknown>;
+    return {
+      ...(actual as object),
+      captureApiError: vi.fn(),
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    } as any;
+  });
+};
+
+export const importAfterMocks = async <T>(modulePath: string): Promise<T> => {
+  return (await import(modulePath)) as T;
+};


### PR DESCRIPTION
This PR updates resource creation to use metadata.generateName instead of a fixed metadata.name.
This change ensures that unique names are generated by the Kubernetes API server, rather than being manually generated locally.