### PR TITLE
Fix domain loading bug #233

### DIFF
--- a/app/features/domain/components/domain-status-probe.tsx
+++ b/app/features/domain/components/domain-status-probe.tsx
@@ -22,12 +22,16 @@ function getConditionTitle(conditionType: string): string {
 export function DomainStatusProbe({
   projectName,
   domainName,
+  namespace,
 }: {
   projectName: string;
   domainName: string;
+  namespace?: string;
 }) {
   const { t } = useLingui();
+  const namespaceToUse = namespace ?? 'default';
   const { data, isLoading, error } = useDomainStatus(projectName, domainName, {
+    namespace: namespaceToUse,
     enabled: Boolean(domainName),
     refetchIntervalMs: 10000,
   });

--- a/app/features/domain/hooks/useDomainStatus.ts
+++ b/app/features/domain/hooks/useDomainStatus.ts
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 type UseDomainStatusOptions = {
   enabled?: boolean;
   refetchIntervalMs?: number | false;
+  namespace?: string;
 };
 
 export function useDomainStatus(
@@ -11,13 +12,14 @@ export function useDomainStatus(
   domainName: string | undefined,
   options?: UseDomainStatusOptions
 ) {
+  const namespace = options?.namespace ?? 'default';
   const enabled = Boolean(domainName) && (options?.enabled ?? true);
   const refetchInterval = options?.refetchIntervalMs ?? 10000;
 
   return useQuery({
-    queryKey: ['domains', domainName, 'status'],
+    queryKey: ['projects', projectName, 'domains', namespace, domainName, 'status'],
     enabled,
-    queryFn: () => projectDomainStatusQuery(projectName, domainName as string),
+    queryFn: () => projectDomainStatusQuery(projectName, domainName as string, namespace),
     refetchInterval: enabled
       ? typeof refetchInterval === 'number'
         ? refetchInterval

--- a/app/resources/request/client/project.request.test.ts
+++ b/app/resources/request/client/project.request.test.ts
@@ -67,11 +67,19 @@ describe('project.request', () => {
     });
   });
 
-  test('projectDomainStatusQuery', async () => {
+  test('projectDomainStatusQuery defaults to the default namespace', async () => {
     await projectDomainStatusQuery('proj', 'example.com');
     expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
       method: 'GET',
       url: 'apis/resourcemanager.miloapis.com/v1alpha1/projects/proj/control-plane/apis/networking.datumapis.com/v1alpha/namespaces/default/domains/example.com/status',
+    });
+  });
+
+  test('projectDomainStatusQuery uses provided namespace', async () => {
+    await projectDomainStatusQuery('proj', 'example.com', 'org-acme');
+    expect(axiosMock.apiRequestClient).toHaveBeenCalledWith({
+      method: 'GET',
+      url: 'apis/resourcemanager.miloapis.com/v1alpha1/projects/proj/control-plane/apis/networking.datumapis.com/v1alpha/namespaces/org-acme/domains/example.com/status',
     });
   });
 

--- a/app/routes/project/detail/domain/detail.tsx
+++ b/app/routes/project/detail/domain/detail.tsx
@@ -24,11 +24,14 @@ export const handle = {
 
 export const loader = async ({ params, request }: Route.LoaderArgs) => {
   const session = await authenticator.getSession(request);
+  const url = new URL(request.url);
+  const namespace = url.searchParams.get('namespace') ?? 'default';
 
   const data = await projectDomainDetailQuery(
     session?.accessToken ?? '',
     params?.projectName ?? '',
-    params?.domainName ?? ''
+    params?.domainName ?? '',
+    namespace
   );
 
   return data;
@@ -118,6 +121,7 @@ export default function Page() {
                   <DomainStatusProbe
                     projectName={project.metadata.name}
                     domainName={data?.metadata?.name}
+                    namespace={data?.metadata?.namespace}
                   />
                 </TableCell>
               </TableRow>

--- a/app/routes/project/detail/domain/index.tsx
+++ b/app/routes/project/detail/domain/index.tsx
@@ -31,7 +31,12 @@ export default function Page() {
     columnHelper.accessor('spec.domainName', {
       header: () => <Trans>Domain</Trans>,
       cell: ({ getValue, row }) => (
-        <Link to={projectRoutes.domain.detail(project.metadata.name, row.original.metadata.name)}>
+        <Link
+          to={projectRoutes.domain.detail(
+            project.metadata.name,
+            row.original.metadata.name,
+            row.original.metadata.namespace
+          )}>
           {getValue()}
         </Link>
       ),
@@ -54,6 +59,7 @@ export default function Page() {
         <DomainStatusProbe
           projectName={project.metadata.name}
           domainName={row.original.metadata.name}
+          namespace={row.original.metadata.namespace}
         />
       ),
     }),

--- a/app/utils/config/routes.config.ts
+++ b/app/utils/config/routes.config.ts
@@ -29,8 +29,10 @@ export const projectRoutes = {
   },
   domain: {
     list: (projectName: string) => `/customers/projects/${projectName}/domains`,
-    detail: (projectName: string, domainName: string) =>
-      `/customers/projects/${projectName}/domains/${domainName}`,
+    detail: (projectName: string, domainName: string, namespace?: string) => {
+      const path = `/customers/projects/${projectName}/domains/${domainName}`;
+      return namespace ? `${path}?namespace=${encodeURIComponent(namespace)}` : path;
+    },
   },
   httpProxy: {
     list: (projectName: string) => `/customers/projects/${projectName}/http-proxies`,


### PR DESCRIPTION
# Pull Request Guidelines

## Title

Fix: Load domains in non-default namespaces

## Description

This PR addresses issue #233 by ensuring that the application correctly handles domains residing in non-default namespaces. Previously, domain detail views and status polling would always default to the `default` namespace, preventing proper loading and status updates for domains in other namespaces.

The changes involve:
- Propagating the domain's namespace through the URL for detail pages.
- Updating loaders and hooks (`useDomainStatus`, `DomainStatusProbe`) to extract and utilize the correct namespace from the URL or component props when making API requests.
- Adjusting `react-query` keys to include the namespace, ensuring proper caching for domains across different namespaces.
- Adding unit tests to verify that `projectDomainStatusQuery` correctly uses both default and provided namespaces.

This fix allows users to view and manage domains in any namespace.

Fixes #233

## Labels

`bug`, `enhancement`, `changelog:highlight`

---
<a href="https://cursor.com/background-agent?bcId=bc-8183dbfa-acb0-4409-a102-8eb50cd8dca7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8183dbfa-acb0-4409-a102-8eb50cd8dca7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

