### PR TITLE
Display the default filter in all the activity pages

### DIFF
--- a/app/components/date/date-range-picker.tsx
+++ b/app/components/date/date-range-picker.tsx
@@ -38,7 +38,67 @@ interface DateRangePickerProps {
   presets?: DateRangePreset[];
   defaultPresets?: boolean;
   showSelectedPresetLabel?: boolean;
+  showTimePicker?: boolean;
+  showClearButton?: boolean;
 }
+
+const DEFAULT_PRESETS: DateRangePreset[] = [
+  {
+    label: 'Last 5 minutes',
+    getValue: () => ({ from: subMinutes(new Date(), 5), to: new Date() }),
+  },
+  {
+    label: 'Last 15 minutes',
+    getValue: () => ({ from: subMinutes(new Date(), 15), to: new Date() }),
+  },
+  {
+    label: 'Last 30 minutes',
+    getValue: () => ({ from: subMinutes(new Date(), 30), to: new Date() }),
+  },
+  { label: 'Last 1 hour', getValue: () => ({ from: subHours(new Date(), 1), to: new Date() }) },
+  { label: 'Last 3 hours', getValue: () => ({ from: subHours(new Date(), 3), to: new Date() }) },
+  { label: 'Last 6 hours', getValue: () => ({ from: subHours(new Date(), 6), to: new Date() }) },
+  {
+    label: 'Last 12 hours',
+    getValue: () => ({ from: subHours(new Date(), 12), to: new Date() }),
+  },
+  {
+    label: 'Last 24 hours',
+    getValue: () => ({ from: subHours(new Date(), 24), to: new Date() }),
+  },
+  { label: 'Last 2 days', getValue: () => ({ from: subDays(new Date(), 2), to: new Date() }) },
+  { label: 'Last 7 days', getValue: () => ({ from: subDays(new Date(), 7), to: new Date() }) },
+  { label: 'Last 30 days', getValue: () => ({ from: subDays(new Date(), 30), to: new Date() }) },
+  {
+    label: 'Today',
+    getValue: () => ({ from: startOfDay(new Date()), to: endOfDay(new Date()) }),
+  },
+  { label: 'Today so far', getValue: () => ({ from: startOfDay(new Date()), to: new Date() }) },
+  {
+    label: 'This week',
+    getValue: () => ({ from: startOfWeek(new Date()), to: endOfWeek(new Date()) }),
+  },
+  {
+    label: 'This week so far',
+    getValue: () => ({ from: startOfWeek(new Date()), to: new Date() }),
+  },
+  {
+    label: 'This month',
+    getValue: () => ({ from: startOfMonth(new Date()), to: endOfMonth(new Date()) }),
+  },
+  {
+    label: 'This month so far',
+    getValue: () => ({ from: startOfMonth(new Date()), to: new Date() }),
+  },
+  {
+    label: 'This year',
+    getValue: () => ({ from: startOfYear(new Date()), to: endOfYear(new Date()) }),
+  },
+  {
+    label: 'This year so far',
+    getValue: () => ({ from: startOfYear(new Date()), to: new Date() }),
+  },
+];
 
 export function DateRangePicker({
   value,
@@ -49,69 +109,13 @@ export function DateRangePicker({
   presets,
   defaultPresets = false,
   showSelectedPresetLabel = false,
+  showTimePicker = true,
+  showClearButton = true,
 }: DateRangePickerProps) {
   const [startTime, setStartTime] = React.useState<string>('');
   const [endTime, setEndTime] = React.useState<string>('');
   const [open, setOpen] = React.useState<boolean>(false);
   const [selectedPresetLabel, setSelectedPresetLabel] = React.useState<string | undefined>();
-
-  const DEFAULT_PRESETS: DateRangePreset[] = [
-    {
-      label: 'Last 5 minutes',
-      getValue: () => ({ from: subMinutes(new Date(), 5), to: new Date() }),
-    },
-    {
-      label: 'Last 15 minutes',
-      getValue: () => ({ from: subMinutes(new Date(), 15), to: new Date() }),
-    },
-    {
-      label: 'Last 30 minutes',
-      getValue: () => ({ from: subMinutes(new Date(), 30), to: new Date() }),
-    },
-    { label: 'Last 1 hour', getValue: () => ({ from: subHours(new Date(), 1), to: new Date() }) },
-    { label: 'Last 3 hours', getValue: () => ({ from: subHours(new Date(), 3), to: new Date() }) },
-    { label: 'Last 6 hours', getValue: () => ({ from: subHours(new Date(), 6), to: new Date() }) },
-    {
-      label: 'Last 12 hours',
-      getValue: () => ({ from: subHours(new Date(), 12), to: new Date() }),
-    },
-    {
-      label: 'Last 24 hours',
-      getValue: () => ({ from: subHours(new Date(), 24), to: new Date() }),
-    },
-    { label: 'Last 2 days', getValue: () => ({ from: subDays(new Date(), 2), to: new Date() }) },
-    { label: 'Last 7 days', getValue: () => ({ from: subDays(new Date(), 7), to: new Date() }) },
-    { label: 'Last 30 days', getValue: () => ({ from: subDays(new Date(), 30), to: new Date() }) },
-    {
-      label: 'Today',
-      getValue: () => ({ from: startOfDay(new Date()), to: endOfDay(new Date()) }),
-    },
-    { label: 'Today so far', getValue: () => ({ from: startOfDay(new Date()), to: new Date() }) },
-    {
-      label: 'This week',
-      getValue: () => ({ from: startOfWeek(new Date()), to: endOfWeek(new Date()) }),
-    },
-    {
-      label: 'This week so far',
-      getValue: () => ({ from: startOfWeek(new Date()), to: new Date() }),
-    },
-    {
-      label: 'This month',
-      getValue: () => ({ from: startOfMonth(new Date()), to: endOfMonth(new Date()) }),
-    },
-    {
-      label: 'This month so far',
-      getValue: () => ({ from: startOfMonth(new Date()), to: new Date() }),
-    },
-    {
-      label: 'This year',
-      getValue: () => ({ from: startOfYear(new Date()), to: endOfYear(new Date()) }),
-    },
-    {
-      label: 'This year so far',
-      getValue: () => ({ from: startOfYear(new Date()), to: new Date() }),
-    },
-  ];
 
   const resolvedPresets: DateRangePreset[] | undefined = React.useMemo(() => {
     if (presets && presets.length > 0) return presets;
@@ -226,12 +230,25 @@ export function DateRangePicker({
           <Button
             variant="outline"
             className={cn(
-              'w-[350px] justify-start text-left font-normal',
+              'relative w-[350px] justify-start pr-8 text-left font-normal',
               !value && 'text-muted-foreground'
             )}
             disabled={disabled}>
             <CalendarIcon className="mr-2 h-4 w-4" />
             {formatDisplayValue()}
+            {value && showClearButton && (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  clearRange();
+                }}
+                disabled={disabled}
+                className="absolute right-1 h-6 w-6">
+                <X className="h-3 w-3" />
+              </Button>
+            )}
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-auto p-0" align="start">
@@ -246,37 +263,40 @@ export function DateRangePicker({
                   onSelect={handleDateSelect}
                   numberOfMonths={2}
                 />
-                <div className="mt-3 flex items-center gap-2">
-                  <div className="flex-1">
-                    <label className="text-sm font-medium">
-                      <Trans>Start Time</Trans>
-                    </label>
-                    <Input
-                      type="time"
-                      value={startTime}
-                      onChange={(e) => handleTimeChange('start', e.target.value)}
-                      className="mt-1"
-                    />
+                {showTimePicker && (
+                  <div className="mt-3 flex items-center gap-2">
+                    <div className="flex-1">
+                      <label className="text-sm font-medium">
+                        <Trans>Start Time</Trans>
+                      </label>
+                      <Input
+                        type="time"
+                        value={startTime}
+                        onChange={(e) => handleTimeChange('start', e.target.value)}
+                        className="mt-1"
+                      />
+                    </div>
+                    <div className="flex-1">
+                      <label className="text-sm font-medium">
+                        <Trans>End Time</Trans>
+                      </label>
+                      <Input
+                        type="time"
+                        value={endTime}
+                        onChange={(e) => handleTimeChange('end', e.target.value)}
+                        className="mt-1"
+                      />
+                    </div>
                   </div>
-                  <div className="flex-1">
-                    <label className="text-sm font-medium">
-                      <Trans>End Time</Trans>
-                    </label>
-                    <Input
-                      type="time"
-                      value={endTime}
-                      onChange={(e) => handleTimeChange('end', e.target.value)}
-                      className="mt-1"
-                    />
-                  </div>
-                </div>
+                )}
               </div>
               {resolvedPresets && resolvedPresets.length > 0 && (
                 <div className="w-56 border-l pl-3">
                   <div className="mb-2 text-sm font-medium">
                     <Trans>Quick ranges</Trans>
                   </div>
-                  <div className="flex max-h-96 flex-col gap-1 overflow-y-auto pr-1">
+                  <div
+                    className={`flex ${!showTimePicker ? 'max-h-64' : 'max-h-84'} flex-col gap-1 overflow-y-auto pr-1`}>
                     {resolvedPresets.map((preset) => (
                       <Button
                         key={preset.label}
@@ -295,16 +315,6 @@ export function DateRangePicker({
           </div>
         </PopoverContent>
       </Popover>
-      {value && (
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={clearRange}
-          disabled={disabled}
-          className="h-9 w-9">
-          <X className="h-4 w-4" />
-        </Button>
-      )}
     </div>
   );
 }

--- a/app/features/activity/components/activity-list.tsx
+++ b/app/features/activity/components/activity-list.tsx
@@ -32,6 +32,7 @@ import {
 } from 'date-fns';
 import { fromZonedTime, toZonedTime } from 'date-fns-tz';
 import { AlertTriangle, CheckCircle, Info, XCircle } from 'lucide-react';
+import { useCallback, useMemo } from 'react';
 
 interface ActivityListProps {
   resourceType?: string;
@@ -210,20 +211,34 @@ export default function ActivityList({
     return timeZone && timeZone !== 'Etc/GMT' ? fromZonedTime(utcDate, timeZone) : utcDate;
   };
 
-  const convertToApiTimestamp = (date: Date) => {
-    const timeZone = settings?.timezone;
-    const utcDate = timeZone && timeZone !== 'Etc/GMT' ? toZonedTime(date, timeZone) : date;
-    return getUnixTime(utcDate) * 1000000000;
-  };
+  const convertToApiTimestamp = useCallback(
+    (date: Date) => {
+      const timeZone = settings?.timezone;
+      const utcDate = timeZone && timeZone !== 'Etc/GMT' ? toZonedTime(date, timeZone) : date;
+      return getUnixTime(utcDate) * 1000000000;
+    },
+    [settings?.timezone]
+  );
+
+  // Create filterConfig with default "Last 7 days" values
+  const activityFilterConfig = useMemo(() => {
+    const now = new Date();
+    const sevenDaysAgo = subDays(now, 7);
+    return {
+      start: {
+        defaultValue: convertToApiTimestamp(sevenDaysAgo),
+      },
+      end: {
+        defaultValue: convertToApiTimestamp(now),
+      },
+    };
+  }, [convertToApiTimestamp]);
 
   const tableState = useDataTableQuery<ActivityListResponse>({
     queryKeyPrefix,
     fetchFn: (args) => {
-      // If no date filters are set, default to last 7 days
-      const defaultStartDate = getUnixTime(subDays(new Date(), 7)) * 1000000000; // Convert to nanoseconds
       const filters: ActivityQueryParams = {
         ...args.filters,
-        start: args.filters?.start || defaultStartDate,
       };
 
       const resource = {
@@ -261,7 +276,7 @@ export default function ActivityList({
     useSorting: true,
     useFilters: true,
     useSearch: true,
-    filterConfig: filterConfigs.dateRange,
+    filterConfig: activityFilterConfig,
   });
 
   return (
@@ -283,18 +298,15 @@ export default function ActivityList({
           <DateRangePicker
             presets={ACTIVITY_DATE_PRESETS}
             placeholder={timeRangePlaceholder || t`Filter by time range`}
-            value={
-              tableState.filters.start || tableState.filters.end
-                ? {
-                    from: tableState.filters.start
-                      ? convertFromApiTimestamp(tableState.filters.start)
-                      : undefined,
-                    to: tableState.filters.end
-                      ? convertFromApiTimestamp(tableState.filters.end)
-                      : undefined,
-                  }
-                : undefined
-            }
+            showClearButton={false}
+            value={{
+              from: tableState.filters.start
+                ? convertFromApiTimestamp(String(tableState.filters.start))
+                : undefined,
+              to: tableState.filters.end
+                ? convertFromApiTimestamp(String(tableState.filters.end))
+                : undefined,
+            }}
             onValueChange={(range) => {
               if (range) {
                 const filters: Record<string, any> = {};

--- a/app/modules/datum-ui/data-table/hooks/useDataTableQuery.tsx
+++ b/app/modules/datum-ui/data-table/hooks/useDataTableQuery.tsx
@@ -163,34 +163,37 @@ export function useDataTableQuery<T>({
   const filters = useMemo(() => {
     const result = {} as Record<string, any>;
 
-    if (!filtersRaw || !useFilters) return result;
+    if (!useFilters) return result;
 
-    try {
-      const parsed = JSON.parse(filtersRaw);
+    // Parse filters from URL if they exist
+    if (filtersRaw) {
+      try {
+        const parsed = JSON.parse(filtersRaw);
 
-      // Handle all values from the parsed filters
-      Object.entries(parsed).forEach(([filterKey, rawValue]) => {
-        if (rawValue !== undefined) {
-          try {
-            const filterConfigItem = filterConfig[filterKey];
-            result[filterKey] = filterConfigItem?.parser
-              ? filterConfigItem.parser(rawValue)
-              : rawValue;
-          } catch (error) {
-            console.warn(`Failed to parse filter value for ${filterKey}:`, error);
+        // Handle all values from the parsed filters
+        Object.entries(parsed).forEach(([filterKey, rawValue]) => {
+          if (rawValue !== undefined) {
+            try {
+              const filterConfigItem = filterConfig[filterKey];
+              result[filterKey] = filterConfigItem?.parser
+                ? filterConfigItem.parser(rawValue)
+                : rawValue;
+            } catch (error) {
+              console.warn(`Failed to parse filter value for ${filterKey}:`, error);
+            }
           }
-        }
-      });
-
-      // Apply default values from filter config
-      Object.entries(filterConfig).forEach(([filterKey, filterConfigItem]) => {
-        if (result[filterKey] === undefined && filterConfigItem.defaultValue !== undefined) {
-          result[filterKey] = filterConfigItem.defaultValue;
-        }
-      });
-    } catch (error) {
-      console.warn('Failed to parse filter values:', error);
+        });
+      } catch (error) {
+        console.warn('Failed to parse filter values:', error);
+      }
     }
+
+    // Apply default values from filter config (even when filtersRaw is empty)
+    Object.entries(filterConfig).forEach(([filterKey, filterConfigItem]) => {
+      if (result[filterKey] === undefined && filterConfigItem.defaultValue !== undefined) {
+        result[filterKey] = filterConfigItem.defaultValue;
+      }
+    });
 
     return result;
   }, [filtersRaw, useFilters, filterConfig]);

--- a/app/modules/i18n/locales/en.po
+++ b/app/modules/i18n/locales/en.po
@@ -44,11 +44,11 @@ msgstr "# of Sources"
 msgid "Account Management"
 msgstr "Account Management"
 
-#: app/features/activity/components/activity-list.tsx:93
+#: app/features/activity/components/activity-list.tsx:94
 msgid "Action"
 msgstr "Action"
 
-#: app/features/activity/components/activity-list.tsx:311
+#: app/features/activity/components/activity-list.tsx:323
 msgid "Actions"
 msgstr "Actions"
 
@@ -86,11 +86,11 @@ msgstr "Add Member"
 msgid "Added"
 msgstr "Added"
 
-#: app/features/activity/components/activity-list.tsx:341
+#: app/features/activity/components/activity-list.tsx:353
 msgid "All read operations"
 msgstr "All read operations"
 
-#: app/features/activity/components/activity-list.tsx:335
+#: app/features/activity/components/activity-list.tsx:347
 msgid "All write operations"
 msgstr "All write operations"
 
@@ -268,7 +268,7 @@ msgstr "Content"
 #: app/routes/contact/create.tsx:14
 #: app/features/contact-group/components/contact-group-form.tsx:75
 #: app/features/contact/components/contact-form.tsx:191
-#: app/features/activity/components/activity-list.tsx:318
+#: app/features/activity/components/activity-list.tsx:330
 msgid "Create"
 msgstr "Create"
 
@@ -349,7 +349,7 @@ msgstr "Deactivation Reason:"
 #: app/routes/contact-group/detail/member.tsx:122
 #: app/routes/contact/index.tsx:111
 #: app/features/quota/components/quota-grant-list.tsx:146
-#: app/features/activity/components/activity-list.tsx:321
+#: app/features/activity/components/activity-list.tsx:333
 #: app/components/danger-zone-card/index.tsx:48
 #: app/components/danger-zone-card/index.tsx:76
 #: app/components/button/button-delete-action.tsx:42
@@ -470,7 +470,7 @@ msgstr "Email Activity"
 msgid "Email is required"
 msgstr "Email is required"
 
-#: app/components/date/date-range-picker.tsx:263
+#: app/components/date/date-range-picker.tsx:281
 msgid "End Time"
 msgstr "End Time"
 
@@ -518,7 +518,7 @@ msgstr "Failed to load DNS record status"
 msgid "Failed to load status"
 msgstr "Failed to load status"
 
-#: app/features/activity/components/activity-list.tsx:312
+#: app/features/activity/components/activity-list.tsx:324
 msgid "Filter by action"
 msgstr "Filter by action"
 
@@ -526,7 +526,7 @@ msgstr "Filter by action"
 msgid "Filter by approval"
 msgstr "Filter by approval"
 
-#: app/features/activity/components/activity-list.tsx:285
+#: app/features/activity/components/activity-list.tsx:300
 msgid "Filter by time range"
 msgstr "Filter by time range"
 
@@ -549,7 +549,7 @@ msgstr "Full Name"
 msgid "General"
 msgstr "General"
 
-#: app/features/activity/components/activity-list.tsx:315
+#: app/features/activity/components/activity-list.tsx:327
 msgid "Get"
 msgstr "Get"
 
@@ -642,7 +642,7 @@ msgstr "Light"
 msgid "Limit:"
 msgstr "Limit:"
 
-#: app/features/activity/components/activity-list.tsx:316
+#: app/features/activity/components/activity-list.tsx:328
 msgid "List"
 msgstr "List"
 
@@ -698,7 +698,7 @@ msgstr "Member deleted successfully"
 msgid "Members"
 msgstr "Members"
 
-#: app/features/activity/components/activity-list.tsx:48
+#: app/features/activity/components/activity-list.tsx:49
 msgid "Message"
 msgstr "Message"
 
@@ -804,7 +804,7 @@ msgstr "Organizations"
 msgid "Overview"
 msgstr "Overview"
 
-#: app/features/activity/components/activity-list.tsx:320
+#: app/features/activity/components/activity-list.tsx:332
 msgid "Patch"
 msgstr "Patch"
 
@@ -890,7 +890,7 @@ msgstr "Public"
 msgid "Query"
 msgstr "Query"
 
-#: app/components/date/date-range-picker.tsx:277
+#: app/components/date/date-range-picker.tsx:296
 msgid "Quick ranges"
 msgstr "Quick ranges"
 
@@ -988,7 +988,7 @@ msgstr "Schedule date and time is required"
 msgid "Schedule invitation to be sent at specific time"
 msgstr "Schedule invitation to be sent at specific time"
 
-#: app/features/activity/components/activity-list.tsx:278
+#: app/features/activity/components/activity-list.tsx:293
 msgid "Search activity..."
 msgstr "Search activity..."
 
@@ -1042,7 +1042,7 @@ msgstr "Sinks"
 msgid "Source"
 msgstr "Source"
 
-#: app/features/activity/components/activity-list.tsx:82
+#: app/features/activity/components/activity-list.tsx:83
 msgid "Source IP"
 msgstr "Source IP"
 
@@ -1050,7 +1050,7 @@ msgstr "Source IP"
 msgid "Sources"
 msgstr "Sources"
 
-#: app/components/date/date-range-picker.tsx:252
+#: app/components/date/date-range-picker.tsx:270
 msgid "Start Time"
 msgstr "Start Time"
 
@@ -1067,7 +1067,7 @@ msgstr "Start Time"
 #: app/routes/contact-group/index.tsx:51
 #: app/routes/contact/index.tsx:58
 #: app/features/quota/components/quota-grant-list.tsx:75
-#: app/features/activity/components/activity-list.tsx:106
+#: app/features/activity/components/activity-list.tsx:107
 msgid "Status"
 msgstr "Status"
 
@@ -1087,7 +1087,7 @@ msgstr "Temporarily prevent user from signing in. The user can be reactivated at
 msgid "These items are checked every few minutes. If you've already made changes, they should resolve shortly."
 msgstr "These items are checked every few minutes. If you've already made changes, they should resolve shortly."
 
-#: app/features/activity/components/activity-list.tsx:97
+#: app/features/activity/components/activity-list.tsx:98
 msgid "Timestamp"
 msgstr "Timestamp"
 
@@ -1111,7 +1111,7 @@ msgstr "Type a command or search..."
 #: app/features/quota/components/quota-bucket-list.tsx:152
 #: app/features/contact-group/components/contact-group-form.tsx:75
 #: app/features/contact/components/contact-form.tsx:191
-#: app/features/activity/components/activity-list.tsx:319
+#: app/features/activity/components/activity-list.tsx:331
 msgid "Update"
 msgstr "Update"
 
@@ -1210,7 +1210,7 @@ msgstr "Visibility"
 msgid "Warning"
 msgstr "Warning"
 
-#: app/features/activity/components/activity-list.tsx:317
+#: app/features/activity/components/activity-list.tsx:329
 msgid "Watch"
 msgstr "Watch"
 

--- a/app/modules/i18n/locales/fr.po
+++ b/app/modules/i18n/locales/fr.po
@@ -44,11 +44,11 @@ msgstr ""
 msgid "Account Management"
 msgstr ""
 
-#: app/features/activity/components/activity-list.tsx:93
+#: app/features/activity/components/activity-list.tsx:94
 msgid "Action"
 msgstr ""
 
-#: app/features/activity/components/activity-list.tsx:311
+#: app/features/activity/components/activity-list.tsx:323
 msgid "Actions"
 msgstr ""
 
@@ -86,11 +86,11 @@ msgstr ""
 msgid "Added"
 msgstr ""
 
-#: app/features/activity/components/activity-list.tsx:341
+#: app/features/activity/components/activity-list.tsx:353
 msgid "All read operations"
 msgstr ""
 
-#: app/features/activity/components/activity-list.tsx:335
+#: app/features/activity/components/activity-list.tsx:347
 msgid "All write operations"
 msgstr ""
 
@@ -268,7 +268,7 @@ msgstr ""
 #: app/routes/contact/create.tsx:14
 #: app/features/contact-group/components/contact-group-form.tsx:75
 #: app/features/contact/components/contact-form.tsx:191
-#: app/features/activity/components/activity-list.tsx:318
+#: app/features/activity/components/activity-list.tsx:330
 msgid "Create"
 msgstr ""
 
@@ -349,7 +349,7 @@ msgstr ""
 #: app/routes/contact-group/detail/member.tsx:122
 #: app/routes/contact/index.tsx:111
 #: app/features/quota/components/quota-grant-list.tsx:146
-#: app/features/activity/components/activity-list.tsx:321
+#: app/features/activity/components/activity-list.tsx:333
 #: app/components/danger-zone-card/index.tsx:48
 #: app/components/danger-zone-card/index.tsx:76
 #: app/components/button/button-delete-action.tsx:42
@@ -470,7 +470,7 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: app/components/date/date-range-picker.tsx:263
+#: app/components/date/date-range-picker.tsx:281
 msgid "End Time"
 msgstr ""
 
@@ -518,7 +518,7 @@ msgstr ""
 msgid "Failed to load status"
 msgstr ""
 
-#: app/features/activity/components/activity-list.tsx:312
+#: app/features/activity/components/activity-list.tsx:324
 msgid "Filter by action"
 msgstr ""
 
@@ -526,7 +526,7 @@ msgstr ""
 msgid "Filter by approval"
 msgstr ""
 
-#: app/features/activity/components/activity-list.tsx:285
+#: app/features/activity/components/activity-list.tsx:300
 msgid "Filter by time range"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: app/features/activity/components/activity-list.tsx:315
+#: app/features/activity/components/activity-list.tsx:327
 msgid "Get"
 msgstr ""
 
@@ -642,7 +642,7 @@ msgstr ""
 msgid "Limit:"
 msgstr ""
 
-#: app/features/activity/components/activity-list.tsx:316
+#: app/features/activity/components/activity-list.tsx:328
 msgid "List"
 msgstr ""
 
@@ -698,7 +698,7 @@ msgstr ""
 msgid "Members"
 msgstr ""
 
-#: app/features/activity/components/activity-list.tsx:48
+#: app/features/activity/components/activity-list.tsx:49
 msgid "Message"
 msgstr ""
 
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: app/features/activity/components/activity-list.tsx:320
+#: app/features/activity/components/activity-list.tsx:332
 msgid "Patch"
 msgstr ""
 
@@ -890,7 +890,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: app/components/date/date-range-picker.tsx:277
+#: app/components/date/date-range-picker.tsx:296
 msgid "Quick ranges"
 msgstr ""
 
@@ -988,7 +988,7 @@ msgstr ""
 msgid "Schedule invitation to be sent at specific time"
 msgstr ""
 
-#: app/features/activity/components/activity-list.tsx:278
+#: app/features/activity/components/activity-list.tsx:293
 msgid "Search activity..."
 msgstr ""
 
@@ -1042,7 +1042,7 @@ msgstr ""
 msgid "Source"
 msgstr ""
 
-#: app/features/activity/components/activity-list.tsx:82
+#: app/features/activity/components/activity-list.tsx:83
 msgid "Source IP"
 msgstr ""
 
@@ -1050,7 +1050,7 @@ msgstr ""
 msgid "Sources"
 msgstr ""
 
-#: app/components/date/date-range-picker.tsx:252
+#: app/components/date/date-range-picker.tsx:270
 msgid "Start Time"
 msgstr ""
 
@@ -1067,7 +1067,7 @@ msgstr ""
 #: app/routes/contact-group/index.tsx:51
 #: app/routes/contact/index.tsx:58
 #: app/features/quota/components/quota-grant-list.tsx:75
-#: app/features/activity/components/activity-list.tsx:106
+#: app/features/activity/components/activity-list.tsx:107
 msgid "Status"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgstr ""
 msgid "These items are checked every few minutes. If you've already made changes, they should resolve shortly."
 msgstr ""
 
-#: app/features/activity/components/activity-list.tsx:97
+#: app/features/activity/components/activity-list.tsx:98
 msgid "Timestamp"
 msgstr ""
 
@@ -1111,7 +1111,7 @@ msgstr ""
 #: app/features/quota/components/quota-bucket-list.tsx:152
 #: app/features/contact-group/components/contact-group-form.tsx:75
 #: app/features/contact/components/contact-form.tsx:191
-#: app/features/activity/components/activity-list.tsx:319
+#: app/features/activity/components/activity-list.tsx:331
 msgid "Update"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Warning"
 msgstr ""
 
-#: app/features/activity/components/activity-list.tsx:317
+#: app/features/activity/components/activity-list.tsx:329
 msgid "Watch"
 msgstr ""
 


### PR DESCRIPTION
Summary
- Add showClearButton prop to DateRangePicker so the clear icon can be toggled.
- Hide the clear button in activity-list since the table now has default values, avoiding the confusing “clear just resets to defaults” behavior.
- Ensure data-table filters apply default values even when no URL filters are present.

Ref: #220 