### PR TITLE
Temporarily disable Loki activity logs request and mock response

### DIFF
--- a/app/server/routes/api.ts
+++ b/app/server/routes/api.ts
@@ -174,8 +174,20 @@ api.get('/activity', authMiddleware(), async (c) => {
       sourceIP: c.req.query('sourceIP') || undefined,
     };
 
-    const service = new LokiActivityLogsService(token);
-    const response = await service.getActivityLogs(queryParams);
+    // TODO: Temporary mock response, because Loki is not working, replace with clickhouse later
+    // const service = new LokiActivityLogsService(token);
+    // const response = await service.getActivityLogs(queryParams);
+
+    const response = {
+      logs: [],
+      query: '',
+      timeRange: {
+        start: '',
+        end: '',
+      },
+      nextPageToken: false,
+      hasNextPage: false,
+    };
 
     const duration = Math.round(performance.now() - startTime);
 


### PR DESCRIPTION
Temporarily disabled the Loki activity logs service request in the `/api/activity` endpoint and replaced it with a mock response to prevent errors while Loki is not working.

## Impact
- The `/api/activity` endpoint will no longer throw errors
- The endpoint returns an empty response structure instead of actual activity logs
- Frontend should continue to work without breaking, but will not display activity data

