### PR TITLE
Loki API will be replaced by Activity API, not Clickhouse directly

### DIFF
--- a/app/server/routes/api.ts
+++ b/app/server/routes/api.ts
@@ -174,7 +174,8 @@ api.get('/activity', authMiddleware(), async (c) => {
       sourceIP: c.req.query('sourceIP') || undefined,
     };
 
-    // TODO: Temporary mock response, because Loki is not working, replace with clickhouse later
+    // TODO: Temporary mock response, because Loki is not working, replace with Activity API later:
+    //   https://github.com/datum-cloud/activity
     // const service = new LokiActivityLogsService(token);
     // const response = await service.getActivityLogs(queryParams);
 


### PR DESCRIPTION
Help clear up confusion from [Slack thread](https://datum-inc.slack.com/archives/C084W6XRVS7/p1766147561352649?thread_ts=1766147181.750059&cid=C084W6XRVS7) around intentions for post-Loki world.


