### PR TITLE
Implement default sorting by creation timestamp across various data tables

### DIFF
--- a/app/features/email/components/email-list.tsx
+++ b/app/features/email/components/email-list.tsx
@@ -39,6 +39,7 @@ export default function EmailList({
   const tableState = useClientDataTableQuery<ComMiloapisNotificationV1Alpha1EmailList>({
     queryKeyPrefix,
     fetchFn,
+    defaultSort: ['metadata.creationTimestamp:desc'],
     useSorting: true,
     useFilters: true,
     useSearch: true,
@@ -68,7 +69,6 @@ export default function EmailList({
           <BadgeState
             state={condition?.status?.toLowerCase() ?? ''}
             message={startCase(condition?.reason ?? '')}
-            tooltip={condition?.message}
           />
         );
       },
@@ -87,6 +87,7 @@ export default function EmailList({
       },
     }),
     columnHelper.accessor('metadata.creationTimestamp', {
+      id: 'metadata.creationTimestamp',
       header: () => <Trans>Sent</Trans>,
       cell: ({ getValue }) => {
         return <DateTime date={getValue()} />;

--- a/app/modules/datum-ui/client-data-table/hooks/useClientDataTableQuery.tsx
+++ b/app/modules/datum-ui/client-data-table/hooks/useClientDataTableQuery.tsx
@@ -30,6 +30,8 @@ export interface UseClientDataTableQueryOptions<TQuery> {
   queryKeyPrefix: string | string[];
   fetchFn: (args?: FetchArgs) => Promise<TQuery>;
   initialPageSize?: number;
+  /** Default sort when no sort param in URL. Each item: "columnId:asc" or "columnId:desc" */
+  defaultSort?: string[];
   useSorting?: boolean;
   useFilters?: boolean;
   useSearch?: boolean;
@@ -116,6 +118,7 @@ export function useClientDataTableQuery<TQuery>({
   queryKeyPrefix,
   fetchFn,
   initialPageSize = 20,
+  defaultSort,
   useSorting = true,
   useFilters = false,
   useSearch = false,
@@ -138,7 +141,7 @@ export function useClientDataTableQuery<TQuery>({
   );
   const [sortRaw, setSortRaw] = useQueryState(
     getParamName('sort'),
-    parseAsArrayOf(parseAsString).withDefault([])
+    parseAsArrayOf(parseAsString).withDefault(defaultSort ?? [])
   );
   const [filtersRaw, setFiltersRaw] = useQueryState(
     getParamName('filters'),

--- a/app/modules/i18n/locales/en.po
+++ b/app/modules/i18n/locales/en.po
@@ -75,10 +75,10 @@ msgstr "Activity"
 
 #: app/routes/group/member.tsx:130
 #: app/routes/group/member.tsx:156
-#: app/routes/contact-group/index.tsx:101
+#: app/routes/contact-group/index.tsx:103
 #: app/routes/contact-group/detail/member.tsx:147
 #: app/routes/contact-group/detail/member.tsx:173
-#: app/routes/contact/index.tsx:109
+#: app/routes/contact/index.tsx:111
 msgid "Add"
 msgstr "Add"
 
@@ -103,20 +103,20 @@ msgstr "All write operations"
 msgid "Allocation"
 msgstr "Allocation"
 
-#: app/routes/user/index.tsx:95
+#: app/routes/user/index.tsx:97
 #: app/routes/user/detail/index.tsx:189
 msgid "Approve"
 msgstr "Approve"
 
-#: app/routes/user/index.tsx:263
-#: app/routes/user/index.tsx:282
+#: app/routes/user/index.tsx:265
+#: app/routes/user/index.tsx:284
 msgid "Approved"
 msgstr "Approved"
 
 #. placeholder {0}: selectedContactGroup?.spec?.displayName ?? ''
 #. placeholder {0}: selectedContact?.metadata?.name ?? ''
-#: app/routes/contact-group/index.tsx:109
-#: app/routes/contact/index.tsx:117
+#: app/routes/contact-group/index.tsx:111
+#: app/routes/contact/index.tsx:119
 msgid "Are you sure you want to delete contact \"{0}\"? This action cannot be undone."
 msgstr "Are you sure you want to delete contact \"{0}\"? This action cannot be undone."
 
@@ -173,16 +173,16 @@ msgstr "Auto-managed by grant creation policy. Cannot be deleted."
 msgid "Auto-managed by policy \"{policyName}\". Cannot be deleted."
 msgstr "Auto-managed by policy \"{policyName}\". Cannot be deleted."
 
-#: app/routes/user/index.tsx:171
+#: app/routes/user/index.tsx:173
 #: app/routes/user/detail/index.tsx:129
 #: app/routes/profile/session.tsx:100
 #: app/routes/organization/detail/member.tsx:122
 #: app/routes/group/member.tsx:140
 #: app/routes/group/member.tsx:157
-#: app/routes/contact-group/index.tsx:111
+#: app/routes/contact-group/index.tsx:113
 #: app/routes/contact-group/detail/member.tsx:157
 #: app/routes/contact-group/detail/member.tsx:174
-#: app/routes/contact/index.tsx:119
+#: app/routes/contact/index.tsx:121
 #: app/features/user/components/user-reject-dialog.tsx:30
 #: app/features/quota/components/quota-grant-list.tsx:147
 #: app/features/quota/components/quota-bucket-list.tsx:153
@@ -219,7 +219,7 @@ msgstr "Configuration"
 msgid "Contact created successfully"
 msgstr "Contact created successfully"
 
-#: app/routes/contact/index.tsx:127
+#: app/routes/contact/index.tsx:129
 msgid "Contact deleted successfully"
 msgstr "Contact deleted successfully"
 
@@ -227,7 +227,7 @@ msgstr "Contact deleted successfully"
 msgid "Contact group created successfully"
 msgstr "Contact group created successfully"
 
-#: app/routes/contact-group/index.tsx:119
+#: app/routes/contact-group/index.tsx:121
 msgid "Contact Group deleted successfully"
 msgstr "Contact Group deleted successfully"
 
@@ -283,9 +283,9 @@ msgstr "Content"
 msgid "Create"
 msgstr "Create"
 
-#: app/routes/user/index.tsx:67
+#: app/routes/user/index.tsx:68
 #: app/routes/user/detail/index.tsx:288
-#: app/routes/project/index.tsx:51
+#: app/routes/project/index.tsx:52
 #: app/routes/project/detail/index.tsx:74
 #: app/routes/project/detail/httpproxy/index.tsx:59
 #: app/routes/project/detail/httpproxy/detail.tsx:123
@@ -295,13 +295,13 @@ msgstr "Create"
 #: app/routes/project/detail/domain/detail.tsx:129
 #: app/routes/project/detail/dns/index.tsx:77
 #: app/routes/profile/session.tsx:56
-#: app/routes/organization/index.tsx:48
-#: app/routes/organization/detail/project.tsx:50
+#: app/routes/organization/index.tsx:49
+#: app/routes/organization/detail/project.tsx:51
 #: app/routes/organization/detail/index.tsx:73
 #: app/routes/group/member.tsx:68
-#: app/routes/group/index.tsx:43
-#: app/routes/contact-group/index.tsx:64
-#: app/routes/contact/index.tsx:70
+#: app/routes/group/index.tsx:44
+#: app/routes/contact-group/index.tsx:65
+#: app/routes/contact/index.tsx:71
 #: app/features/quota/components/quota-grant-list.tsx:81
 #: app/features/quota/components/quota-bucket-list.tsx:84
 msgid "Created"
@@ -359,9 +359,9 @@ msgstr "Deactivation Reason:"
 #: app/routes/profile/session.tsx:85
 #: app/routes/profile/session.tsx:99
 #: app/routes/group/member.tsx:139
-#: app/routes/contact-group/index.tsx:110
+#: app/routes/contact-group/index.tsx:112
 #: app/routes/contact-group/detail/member.tsx:156
-#: app/routes/contact/index.tsx:118
+#: app/routes/contact/index.tsx:120
 #: app/features/quota/components/quota-grant-list.tsx:146
 #: app/features/activity/components/activity-list.tsx:387
 #: app/features/activity/components/activity-list.tsx:441
@@ -382,8 +382,8 @@ msgstr "Delete {itemType}"
 msgid "Delete Collection"
 msgstr "Delete Collection"
 
-#: app/routes/contact-group/index.tsx:108
-#: app/routes/contact/index.tsx:116
+#: app/routes/contact-group/index.tsx:110
+#: app/routes/contact/index.tsx:118
 msgid "Delete Contact"
 msgstr "Delete Contact"
 
@@ -415,8 +415,8 @@ msgstr "Delete Session"
 msgid "Delete User"
 msgstr "Delete User"
 
-#: app/features/email/components/email-list.tsx:147
-#: app/features/email/components/email-list.tsx:177
+#: app/features/email/components/email-list.tsx:148
+#: app/features/email/components/email-list.tsx:178
 msgid "Delivered"
 msgstr "Delivered"
 
@@ -482,7 +482,7 @@ msgstr "Domains"
 msgid "Edit Quota"
 msgstr "Edit Quota"
 
-#: app/routes/user/index.tsx:208
+#: app/routes/user/index.tsx:210
 #: app/routes/user/detail/index.tsx:254
 #: app/routes/contact-group/detail/member.tsx:64
 #: app/routes/contact/index.tsx:55
@@ -506,7 +506,7 @@ msgstr "Email addresses for GitHub identities should be updated through GitHub"
 msgid "Email HTML preview"
 msgstr "Email HTML preview"
 
-#: app/routes/user/index.tsx:141
+#: app/routes/user/index.tsx:143
 msgid "Email is required"
 msgstr "Email is required"
 
@@ -551,8 +551,8 @@ msgstr "Expires"
 msgid "Export Policies"
 msgstr "Export Policies"
 
-#: app/features/email/components/email-list.tsx:148
-#: app/features/email/components/email-list.tsx:178
+#: app/features/email/components/email-list.tsx:149
+#: app/features/email/components/email-list.tsx:179
 msgid "Failed"
 msgstr "Failed"
 
@@ -576,15 +576,15 @@ msgstr "Failed to update timezone"
 msgid "Filter by action"
 msgstr "Filter by action"
 
-#: app/routes/user/index.tsx:261
+#: app/routes/user/index.tsx:263
 msgid "Filter by approval"
 msgstr "Filter by approval"
 
-#: app/features/email/components/email-list.tsx:135
+#: app/features/email/components/email-list.tsx:136
 msgid "Filter by priority"
 msgstr "Filter by priority"
 
-#: app/features/email/components/email-list.tsx:145
+#: app/features/email/components/email-list.tsx:146
 msgid "Filter by status"
 msgstr "Filter by status"
 
@@ -592,7 +592,7 @@ msgstr "Filter by status"
 msgid "Filter by time range"
 msgstr "Filter by time range"
 
-#: app/routes/organization/index.tsx:87
+#: app/routes/organization/index.tsx:89
 msgid "Filter by type"
 msgstr "Filter by type"
 
@@ -600,12 +600,12 @@ msgstr "Filter by type"
 msgid "Fingerprint ID"
 msgstr "Fingerprint ID"
 
-#: app/routes/user/index.tsx:206
+#: app/routes/user/index.tsx:208
 #: app/features/contact/components/contact-form.tsx:120
 msgid "First Name"
 msgstr "First Name"
 
-#: app/routes/user/index.tsx:139
+#: app/routes/user/index.tsx:141
 #: app/features/profile/components/profile-form.tsx:15
 #: app/features/contact/components/contact-form.tsx:41
 msgid "First name is required"
@@ -645,8 +645,8 @@ msgstr "Grants"
 msgid "Groups"
 msgstr "Groups"
 
-#: app/features/email/components/email-list.tsx:138
-#: app/features/email/components/email-list.tsx:168
+#: app/features/email/components/email-list.tsx:139
+#: app/features/email/components/email-list.tsx:169
 msgid "High"
 msgstr "High"
 
@@ -672,7 +672,7 @@ msgstr "HTTP Proxies"
 msgid "ID"
 msgstr "ID"
 
-#: app/routes/user/index.tsx:141
+#: app/routes/user/index.tsx:143
 #: app/features/contact/components/contact-form.tsx:43
 msgid "Invalid email address"
 msgstr "Invalid email address"
@@ -685,12 +685,12 @@ msgstr "Invitation cancelled successfully"
 msgid "Invitation resend successfully"
 msgstr "Invitation resend successfully"
 
-#: app/routes/user/index.tsx:170
+#: app/routes/user/index.tsx:172
 msgid "Invite"
 msgstr "Invite"
 
-#: app/routes/user/index.tsx:162
-#: app/routes/user/index.tsx:169
+#: app/routes/user/index.tsx:164
+#: app/routes/user/index.tsx:171
 msgid "Invite User"
 msgstr "Invite User"
 
@@ -702,7 +702,7 @@ msgstr "IP"
 msgid "Irreversible and destructive actions"
 msgstr "Irreversible and destructive actions"
 
-#: app/routes/user/detail/organization.tsx:46
+#: app/routes/user/detail/organization.tsx:47
 #: app/routes/contact/detail/group.tsx:69
 msgid "Joined"
 msgstr "Joined"
@@ -711,12 +711,12 @@ msgstr "Joined"
 msgid "Last 10 new users who joined Datum"
 msgstr "Last 10 new users who joined Datum"
 
-#: app/routes/user/index.tsx:207
+#: app/routes/user/index.tsx:209
 #: app/features/contact/components/contact-form.tsx:121
 msgid "Last Name"
 msgstr "Last Name"
 
-#: app/routes/user/index.tsx:140
+#: app/routes/user/index.tsx:142
 #: app/features/profile/components/profile-form.tsx:16
 #: app/features/contact/components/contact-form.tsx:42
 msgid "Last name is required"
@@ -771,8 +771,8 @@ msgstr "Log out of Datum"
 msgid "Log out of GitHub"
 msgstr "Log out of GitHub"
 
-#: app/features/email/components/email-list.tsx:139
-#: app/features/email/components/email-list.tsx:169
+#: app/features/email/components/email-list.tsx:140
+#: app/features/email/components/email-list.tsx:170
 msgid "Low"
 msgstr "Low"
 
@@ -780,7 +780,7 @@ msgstr "Low"
 msgid "Mail Lists"
 msgstr "Mail Lists"
 
-#: app/routes/user/index.tsx:90
+#: app/routes/user/index.tsx:92
 #: app/features/user/components/user-identity-card.tsx:113
 msgid "Manage"
 msgstr "Manage"
@@ -814,7 +814,7 @@ msgstr "Members"
 msgid "MetricsQL"
 msgstr "MetricsQL"
 
-#: app/routes/user/index.tsx:119
+#: app/routes/user/index.tsx:121
 #: app/routes/user/detail/index.tsx:216
 msgid "Move to Pending"
 msgstr "Move to Pending"
@@ -880,8 +880,8 @@ msgstr "No results found."
 msgid "No users yet"
 msgstr "No users yet"
 
-#: app/features/email/components/email-list.tsx:137
-#: app/features/email/components/email-list.tsx:167
+#: app/features/email/components/email-list.tsx:138
+#: app/features/email/components/email-list.tsx:168
 msgid "Normal"
 msgstr "Normal"
 
@@ -902,12 +902,12 @@ msgstr "Organization"
 msgid "Organization deleted successfully"
 msgstr "Organization deleted successfully"
 
-#: app/routes/organization/index.tsx:86
-#: app/routes/organization/index.tsx:101
+#: app/routes/organization/index.tsx:88
+#: app/routes/organization/index.tsx:103
 msgid "Organization Type"
 msgstr "Organization Type"
 
-#: app/routes/user/detail/organization.tsx:52
+#: app/routes/user/detail/organization.tsx:53
 #: app/routes/user/detail/layout.tsx:37
 #: app/routes/project/detail/layout.tsx:46
 #: app/routes/organization/layout.tsx:5
@@ -928,10 +928,10 @@ msgstr "Overview"
 msgid "Patch"
 msgstr "Patch"
 
-#: app/routes/user/index.tsx:265
-#: app/routes/user/index.tsx:284
-#: app/features/email/components/email-list.tsx:149
-#: app/features/email/components/email-list.tsx:179
+#: app/routes/user/index.tsx:267
+#: app/routes/user/index.tsx:286
+#: app/features/email/components/email-list.tsx:150
+#: app/features/email/components/email-list.tsx:180
 msgid "Pending"
 msgstr "Pending"
 
@@ -951,8 +951,8 @@ msgstr "Permanently delete this project and all associated data"
 msgid "Permanently delete this user and all associated data"
 msgstr "Permanently delete this user and all associated data"
 
-#: app/routes/organization/index.tsx:89
-#: app/routes/organization/index.tsx:106
+#: app/routes/organization/index.tsx:91
+#: app/routes/organization/index.tsx:108
 msgid "Personal"
 msgstr "Personal"
 
@@ -985,8 +985,8 @@ msgstr "Portal Preferences"
 msgid "Preview"
 msgstr "Preview"
 
-#: app/features/email/components/email-list.tsx:134
-#: app/features/email/components/email-list.tsx:161
+#: app/features/email/components/email-list.tsx:135
+#: app/features/email/components/email-list.tsx:162
 #: app/features/email/components/email-detail.tsx:93
 msgid "Priority"
 msgstr "Priority"
@@ -1072,7 +1072,7 @@ msgstr "Reason for deactivation"
 msgid "Reason for rejection"
 msgstr "Reason for rejection"
 
-#: app/features/email/components/email-list.tsx:49
+#: app/features/email/components/email-list.tsx:50
 msgid "Recipient"
 msgstr "Recipient"
 
@@ -1087,13 +1087,13 @@ msgid "Registrar"
 msgstr "Registrar"
 
 #: app/routes/user/index.tsx:63
-#: app/routes/user/index.tsx:260
-#: app/routes/user/index.tsx:277
+#: app/routes/user/index.tsx:262
+#: app/routes/user/index.tsx:279
 #: app/routes/user/detail/index.tsx:264
 msgid "Registration Approval"
 msgstr "Registration Approval"
 
-#: app/routes/user/index.tsx:112
+#: app/routes/user/index.tsx:114
 #: app/routes/user/detail/index.tsx:197
 #: app/features/user/components/user-reject-dialog.tsx:29
 msgid "Reject"
@@ -1103,8 +1103,8 @@ msgstr "Reject"
 msgid "Reject User"
 msgstr "Reject User"
 
-#: app/routes/user/index.tsx:264
-#: app/routes/user/index.tsx:283
+#: app/routes/user/index.tsx:266
+#: app/routes/user/index.tsx:285
 msgid "Rejected"
 msgstr "Rejected"
 
@@ -1133,11 +1133,11 @@ msgstr "Role"
 msgid "Save"
 msgstr "Save"
 
-#: app/routes/user/index.tsx:153
+#: app/routes/user/index.tsx:155
 msgid "Schedule date and time is required"
 msgstr "Schedule date and time is required"
 
-#: app/routes/user/index.tsx:211
+#: app/routes/user/index.tsx:213
 msgid "Schedule invitation to be sent at specific time"
 msgstr "Schedule invitation to be sent at specific time"
 
@@ -1149,19 +1149,19 @@ msgstr "Search"
 msgid "Search activity..."
 msgstr "Search activity..."
 
-#: app/routes/contact-group/index.tsx:137
+#: app/routes/contact-group/index.tsx:139
 msgid "Search contact groups..."
 msgstr "Search contact groups..."
 
-#: app/routes/contact/index.tsx:148
+#: app/routes/contact/index.tsx:150
 msgid "Search contacts..."
 msgstr "Search contacts..."
 
-#: app/features/email/components/email-list.tsx:131
+#: app/features/email/components/email-list.tsx:132
 msgid "Search email activity..."
 msgstr "Search email activity..."
 
-#: app/routes/group/index.tsx:66
+#: app/routes/group/index.tsx:68
 msgid "Search groups..."
 msgstr "Search groups..."
 
@@ -1169,17 +1169,17 @@ msgstr "Search groups..."
 msgid "Search members..."
 msgstr "Search members..."
 
-#: app/routes/user/detail/organization.tsx:87
-#: app/routes/organization/index.tsx:83
+#: app/routes/user/detail/organization.tsx:89
+#: app/routes/organization/index.tsx:85
 msgid "Search organizations..."
 msgstr "Search organizations..."
 
-#: app/routes/project/index.tsx:81
-#: app/routes/organization/detail/project.tsx:80
+#: app/routes/project/index.tsx:83
+#: app/routes/organization/detail/project.tsx:82
 msgid "Search projects..."
 msgstr "Search projects..."
 
-#: app/routes/user/index.tsx:257
+#: app/routes/user/index.tsx:259
 msgid "Search users..."
 msgstr "Search users..."
 
@@ -1209,7 +1209,7 @@ msgstr "Select visibility..."
 msgid "Selected Filters"
 msgstr "Selected Filters"
 
-#: app/features/email/components/email-list.tsx:90
+#: app/features/email/components/email-list.tsx:91
 #: app/features/email/components/email-detail.tsx:81
 msgid "Sent"
 msgstr "Sent"
@@ -1239,8 +1239,8 @@ msgstr "Source"
 msgid "Sources"
 msgstr "Sources"
 
-#: app/routes/organization/index.tsx:90
-#: app/routes/organization/index.tsx:107
+#: app/routes/organization/index.tsx:92
+#: app/routes/organization/index.tsx:109
 msgid "Standard"
 msgstr "Standard"
 
@@ -1262,9 +1262,9 @@ msgstr "Start Time"
 #: app/routes/contact/index.tsx:64
 #: app/routes/contact/detail/group.tsx:55
 #: app/features/quota/components/quota-grant-list.tsx:75
-#: app/features/email/components/email-list.tsx:63
-#: app/features/email/components/email-list.tsx:144
-#: app/features/email/components/email-list.tsx:162
+#: app/features/email/components/email-list.tsx:64
+#: app/features/email/components/email-list.tsx:145
+#: app/features/email/components/email-list.tsx:163
 #: app/features/email/components/email-detail.tsx:57
 msgid "Status"
 msgstr "Status"
@@ -1364,7 +1364,7 @@ msgstr "User deactivated successfully"
 msgid "User deleted successfully"
 msgstr "User deleted successfully"
 
-#: app/routes/user/index.tsx:199
+#: app/routes/user/index.tsx:201
 msgid "User invited successfully"
 msgstr "User invited successfully"
 

--- a/app/modules/i18n/locales/fr.po
+++ b/app/modules/i18n/locales/fr.po
@@ -75,10 +75,10 @@ msgstr ""
 
 #: app/routes/group/member.tsx:130
 #: app/routes/group/member.tsx:156
-#: app/routes/contact-group/index.tsx:101
+#: app/routes/contact-group/index.tsx:103
 #: app/routes/contact-group/detail/member.tsx:147
 #: app/routes/contact-group/detail/member.tsx:173
-#: app/routes/contact/index.tsx:109
+#: app/routes/contact/index.tsx:111
 msgid "Add"
 msgstr ""
 
@@ -103,20 +103,20 @@ msgstr ""
 msgid "Allocation"
 msgstr ""
 
-#: app/routes/user/index.tsx:95
+#: app/routes/user/index.tsx:97
 #: app/routes/user/detail/index.tsx:189
 msgid "Approve"
 msgstr ""
 
-#: app/routes/user/index.tsx:263
-#: app/routes/user/index.tsx:282
+#: app/routes/user/index.tsx:265
+#: app/routes/user/index.tsx:284
 msgid "Approved"
 msgstr ""
 
 #. placeholder {0}: selectedContactGroup?.spec?.displayName ?? ''
 #. placeholder {0}: selectedContact?.metadata?.name ?? ''
-#: app/routes/contact-group/index.tsx:109
-#: app/routes/contact/index.tsx:117
+#: app/routes/contact-group/index.tsx:111
+#: app/routes/contact/index.tsx:119
 msgid "Are you sure you want to delete contact \"{0}\"? This action cannot be undone."
 msgstr ""
 
@@ -173,16 +173,16 @@ msgstr ""
 msgid "Auto-managed by policy \"{policyName}\". Cannot be deleted."
 msgstr ""
 
-#: app/routes/user/index.tsx:171
+#: app/routes/user/index.tsx:173
 #: app/routes/user/detail/index.tsx:129
 #: app/routes/profile/session.tsx:100
 #: app/routes/organization/detail/member.tsx:122
 #: app/routes/group/member.tsx:140
 #: app/routes/group/member.tsx:157
-#: app/routes/contact-group/index.tsx:111
+#: app/routes/contact-group/index.tsx:113
 #: app/routes/contact-group/detail/member.tsx:157
 #: app/routes/contact-group/detail/member.tsx:174
-#: app/routes/contact/index.tsx:119
+#: app/routes/contact/index.tsx:121
 #: app/features/user/components/user-reject-dialog.tsx:30
 #: app/features/quota/components/quota-grant-list.tsx:147
 #: app/features/quota/components/quota-bucket-list.tsx:153
@@ -219,7 +219,7 @@ msgstr ""
 msgid "Contact created successfully"
 msgstr ""
 
-#: app/routes/contact/index.tsx:127
+#: app/routes/contact/index.tsx:129
 msgid "Contact deleted successfully"
 msgstr ""
 
@@ -227,7 +227,7 @@ msgstr ""
 msgid "Contact group created successfully"
 msgstr ""
 
-#: app/routes/contact-group/index.tsx:119
+#: app/routes/contact-group/index.tsx:121
 msgid "Contact Group deleted successfully"
 msgstr ""
 
@@ -283,9 +283,9 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: app/routes/user/index.tsx:67
+#: app/routes/user/index.tsx:68
 #: app/routes/user/detail/index.tsx:288
-#: app/routes/project/index.tsx:51
+#: app/routes/project/index.tsx:52
 #: app/routes/project/detail/index.tsx:74
 #: app/routes/project/detail/httpproxy/index.tsx:59
 #: app/routes/project/detail/httpproxy/detail.tsx:123
@@ -295,13 +295,13 @@ msgstr ""
 #: app/routes/project/detail/domain/detail.tsx:129
 #: app/routes/project/detail/dns/index.tsx:77
 #: app/routes/profile/session.tsx:56
-#: app/routes/organization/index.tsx:48
-#: app/routes/organization/detail/project.tsx:50
+#: app/routes/organization/index.tsx:49
+#: app/routes/organization/detail/project.tsx:51
 #: app/routes/organization/detail/index.tsx:73
 #: app/routes/group/member.tsx:68
-#: app/routes/group/index.tsx:43
-#: app/routes/contact-group/index.tsx:64
-#: app/routes/contact/index.tsx:70
+#: app/routes/group/index.tsx:44
+#: app/routes/contact-group/index.tsx:65
+#: app/routes/contact/index.tsx:71
 #: app/features/quota/components/quota-grant-list.tsx:81
 #: app/features/quota/components/quota-bucket-list.tsx:84
 msgid "Created"
@@ -359,9 +359,9 @@ msgstr ""
 #: app/routes/profile/session.tsx:85
 #: app/routes/profile/session.tsx:99
 #: app/routes/group/member.tsx:139
-#: app/routes/contact-group/index.tsx:110
+#: app/routes/contact-group/index.tsx:112
 #: app/routes/contact-group/detail/member.tsx:156
-#: app/routes/contact/index.tsx:118
+#: app/routes/contact/index.tsx:120
 #: app/features/quota/components/quota-grant-list.tsx:146
 #: app/features/activity/components/activity-list.tsx:387
 #: app/features/activity/components/activity-list.tsx:441
@@ -382,8 +382,8 @@ msgstr ""
 msgid "Delete Collection"
 msgstr ""
 
-#: app/routes/contact-group/index.tsx:108
-#: app/routes/contact/index.tsx:116
+#: app/routes/contact-group/index.tsx:110
+#: app/routes/contact/index.tsx:118
 msgid "Delete Contact"
 msgstr ""
 
@@ -415,8 +415,8 @@ msgstr ""
 msgid "Delete User"
 msgstr ""
 
-#: app/features/email/components/email-list.tsx:147
-#: app/features/email/components/email-list.tsx:177
+#: app/features/email/components/email-list.tsx:148
+#: app/features/email/components/email-list.tsx:178
 msgid "Delivered"
 msgstr ""
 
@@ -482,7 +482,7 @@ msgstr ""
 msgid "Edit Quota"
 msgstr ""
 
-#: app/routes/user/index.tsx:208
+#: app/routes/user/index.tsx:210
 #: app/routes/user/detail/index.tsx:254
 #: app/routes/contact-group/detail/member.tsx:64
 #: app/routes/contact/index.tsx:55
@@ -506,7 +506,7 @@ msgstr ""
 msgid "Email HTML preview"
 msgstr ""
 
-#: app/routes/user/index.tsx:141
+#: app/routes/user/index.tsx:143
 msgid "Email is required"
 msgstr ""
 
@@ -551,8 +551,8 @@ msgstr ""
 msgid "Export Policies"
 msgstr ""
 
-#: app/features/email/components/email-list.tsx:148
-#: app/features/email/components/email-list.tsx:178
+#: app/features/email/components/email-list.tsx:149
+#: app/features/email/components/email-list.tsx:179
 msgid "Failed"
 msgstr ""
 
@@ -576,15 +576,15 @@ msgstr ""
 msgid "Filter by action"
 msgstr ""
 
-#: app/routes/user/index.tsx:261
+#: app/routes/user/index.tsx:263
 msgid "Filter by approval"
 msgstr ""
 
-#: app/features/email/components/email-list.tsx:135
+#: app/features/email/components/email-list.tsx:136
 msgid "Filter by priority"
 msgstr ""
 
-#: app/features/email/components/email-list.tsx:145
+#: app/features/email/components/email-list.tsx:146
 msgid "Filter by status"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Filter by time range"
 msgstr ""
 
-#: app/routes/organization/index.tsx:87
+#: app/routes/organization/index.tsx:89
 msgid "Filter by type"
 msgstr ""
 
@@ -600,12 +600,12 @@ msgstr ""
 msgid "Fingerprint ID"
 msgstr ""
 
-#: app/routes/user/index.tsx:206
+#: app/routes/user/index.tsx:208
 #: app/features/contact/components/contact-form.tsx:120
 msgid "First Name"
 msgstr ""
 
-#: app/routes/user/index.tsx:139
+#: app/routes/user/index.tsx:141
 #: app/features/profile/components/profile-form.tsx:15
 #: app/features/contact/components/contact-form.tsx:41
 msgid "First name is required"
@@ -645,8 +645,8 @@ msgstr ""
 msgid "Groups"
 msgstr ""
 
-#: app/features/email/components/email-list.tsx:138
-#: app/features/email/components/email-list.tsx:168
+#: app/features/email/components/email-list.tsx:139
+#: app/features/email/components/email-list.tsx:169
 msgid "High"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: app/routes/user/index.tsx:141
+#: app/routes/user/index.tsx:143
 #: app/features/contact/components/contact-form.tsx:43
 msgid "Invalid email address"
 msgstr ""
@@ -685,12 +685,12 @@ msgstr ""
 msgid "Invitation resend successfully"
 msgstr ""
 
-#: app/routes/user/index.tsx:170
+#: app/routes/user/index.tsx:172
 msgid "Invite"
 msgstr ""
 
-#: app/routes/user/index.tsx:162
-#: app/routes/user/index.tsx:169
+#: app/routes/user/index.tsx:164
+#: app/routes/user/index.tsx:171
 msgid "Invite User"
 msgstr ""
 
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Irreversible and destructive actions"
 msgstr ""
 
-#: app/routes/user/detail/organization.tsx:46
+#: app/routes/user/detail/organization.tsx:47
 #: app/routes/contact/detail/group.tsx:69
 msgid "Joined"
 msgstr ""
@@ -711,12 +711,12 @@ msgstr ""
 msgid "Last 10 new users who joined Datum"
 msgstr ""
 
-#: app/routes/user/index.tsx:207
+#: app/routes/user/index.tsx:209
 #: app/features/contact/components/contact-form.tsx:121
 msgid "Last Name"
 msgstr ""
 
-#: app/routes/user/index.tsx:140
+#: app/routes/user/index.tsx:142
 #: app/features/profile/components/profile-form.tsx:16
 #: app/features/contact/components/contact-form.tsx:42
 msgid "Last name is required"
@@ -771,8 +771,8 @@ msgstr ""
 msgid "Log out of GitHub"
 msgstr ""
 
-#: app/features/email/components/email-list.tsx:139
-#: app/features/email/components/email-list.tsx:169
+#: app/features/email/components/email-list.tsx:140
+#: app/features/email/components/email-list.tsx:170
 msgid "Low"
 msgstr ""
 
@@ -780,7 +780,7 @@ msgstr ""
 msgid "Mail Lists"
 msgstr ""
 
-#: app/routes/user/index.tsx:90
+#: app/routes/user/index.tsx:92
 #: app/features/user/components/user-identity-card.tsx:113
 msgid "Manage"
 msgstr ""
@@ -814,7 +814,7 @@ msgstr ""
 msgid "MetricsQL"
 msgstr ""
 
-#: app/routes/user/index.tsx:119
+#: app/routes/user/index.tsx:121
 #: app/routes/user/detail/index.tsx:216
 msgid "Move to Pending"
 msgstr ""
@@ -880,8 +880,8 @@ msgstr ""
 msgid "No users yet"
 msgstr ""
 
-#: app/features/email/components/email-list.tsx:137
-#: app/features/email/components/email-list.tsx:167
+#: app/features/email/components/email-list.tsx:138
+#: app/features/email/components/email-list.tsx:168
 msgid "Normal"
 msgstr ""
 
@@ -902,12 +902,12 @@ msgstr ""
 msgid "Organization deleted successfully"
 msgstr ""
 
-#: app/routes/organization/index.tsx:86
-#: app/routes/organization/index.tsx:101
+#: app/routes/organization/index.tsx:88
+#: app/routes/organization/index.tsx:103
 msgid "Organization Type"
 msgstr ""
 
-#: app/routes/user/detail/organization.tsx:52
+#: app/routes/user/detail/organization.tsx:53
 #: app/routes/user/detail/layout.tsx:37
 #: app/routes/project/detail/layout.tsx:46
 #: app/routes/organization/layout.tsx:5
@@ -928,10 +928,10 @@ msgstr ""
 msgid "Patch"
 msgstr ""
 
-#: app/routes/user/index.tsx:265
-#: app/routes/user/index.tsx:284
-#: app/features/email/components/email-list.tsx:149
-#: app/features/email/components/email-list.tsx:179
+#: app/routes/user/index.tsx:267
+#: app/routes/user/index.tsx:286
+#: app/features/email/components/email-list.tsx:150
+#: app/features/email/components/email-list.tsx:180
 msgid "Pending"
 msgstr ""
 
@@ -951,8 +951,8 @@ msgstr ""
 msgid "Permanently delete this user and all associated data"
 msgstr ""
 
-#: app/routes/organization/index.tsx:89
-#: app/routes/organization/index.tsx:106
+#: app/routes/organization/index.tsx:91
+#: app/routes/organization/index.tsx:108
 msgid "Personal"
 msgstr ""
 
@@ -985,8 +985,8 @@ msgstr ""
 msgid "Preview"
 msgstr ""
 
-#: app/features/email/components/email-list.tsx:134
-#: app/features/email/components/email-list.tsx:161
+#: app/features/email/components/email-list.tsx:135
+#: app/features/email/components/email-list.tsx:162
 #: app/features/email/components/email-detail.tsx:93
 msgid "Priority"
 msgstr ""
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Reason for rejection"
 msgstr ""
 
-#: app/features/email/components/email-list.tsx:49
+#: app/features/email/components/email-list.tsx:50
 msgid "Recipient"
 msgstr ""
 
@@ -1087,13 +1087,13 @@ msgid "Registrar"
 msgstr ""
 
 #: app/routes/user/index.tsx:63
-#: app/routes/user/index.tsx:260
-#: app/routes/user/index.tsx:277
+#: app/routes/user/index.tsx:262
+#: app/routes/user/index.tsx:279
 #: app/routes/user/detail/index.tsx:264
 msgid "Registration Approval"
 msgstr ""
 
-#: app/routes/user/index.tsx:112
+#: app/routes/user/index.tsx:114
 #: app/routes/user/detail/index.tsx:197
 #: app/features/user/components/user-reject-dialog.tsx:29
 msgid "Reject"
@@ -1103,8 +1103,8 @@ msgstr ""
 msgid "Reject User"
 msgstr ""
 
-#: app/routes/user/index.tsx:264
-#: app/routes/user/index.tsx:283
+#: app/routes/user/index.tsx:266
+#: app/routes/user/index.tsx:285
 msgid "Rejected"
 msgstr ""
 
@@ -1133,11 +1133,11 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: app/routes/user/index.tsx:153
+#: app/routes/user/index.tsx:155
 msgid "Schedule date and time is required"
 msgstr ""
 
-#: app/routes/user/index.tsx:211
+#: app/routes/user/index.tsx:213
 msgid "Schedule invitation to be sent at specific time"
 msgstr ""
 
@@ -1149,19 +1149,19 @@ msgstr ""
 msgid "Search activity..."
 msgstr ""
 
-#: app/routes/contact-group/index.tsx:137
+#: app/routes/contact-group/index.tsx:139
 msgid "Search contact groups..."
 msgstr ""
 
-#: app/routes/contact/index.tsx:148
+#: app/routes/contact/index.tsx:150
 msgid "Search contacts..."
 msgstr ""
 
-#: app/features/email/components/email-list.tsx:131
+#: app/features/email/components/email-list.tsx:132
 msgid "Search email activity..."
 msgstr ""
 
-#: app/routes/group/index.tsx:66
+#: app/routes/group/index.tsx:68
 msgid "Search groups..."
 msgstr ""
 
@@ -1169,17 +1169,17 @@ msgstr ""
 msgid "Search members..."
 msgstr ""
 
-#: app/routes/user/detail/organization.tsx:87
-#: app/routes/organization/index.tsx:83
+#: app/routes/user/detail/organization.tsx:89
+#: app/routes/organization/index.tsx:85
 msgid "Search organizations..."
 msgstr ""
 
-#: app/routes/project/index.tsx:81
-#: app/routes/organization/detail/project.tsx:80
+#: app/routes/project/index.tsx:83
+#: app/routes/organization/detail/project.tsx:82
 msgid "Search projects..."
 msgstr ""
 
-#: app/routes/user/index.tsx:257
+#: app/routes/user/index.tsx:259
 msgid "Search users..."
 msgstr ""
 
@@ -1209,7 +1209,7 @@ msgstr ""
 msgid "Selected Filters"
 msgstr ""
 
-#: app/features/email/components/email-list.tsx:90
+#: app/features/email/components/email-list.tsx:91
 #: app/features/email/components/email-detail.tsx:81
 msgid "Sent"
 msgstr ""
@@ -1239,8 +1239,8 @@ msgstr ""
 msgid "Sources"
 msgstr ""
 
-#: app/routes/organization/index.tsx:90
-#: app/routes/organization/index.tsx:107
+#: app/routes/organization/index.tsx:92
+#: app/routes/organization/index.tsx:109
 msgid "Standard"
 msgstr ""
 
@@ -1262,9 +1262,9 @@ msgstr ""
 #: app/routes/contact/index.tsx:64
 #: app/routes/contact/detail/group.tsx:55
 #: app/features/quota/components/quota-grant-list.tsx:75
-#: app/features/email/components/email-list.tsx:63
-#: app/features/email/components/email-list.tsx:144
-#: app/features/email/components/email-list.tsx:162
+#: app/features/email/components/email-list.tsx:64
+#: app/features/email/components/email-list.tsx:145
+#: app/features/email/components/email-list.tsx:163
 #: app/features/email/components/email-detail.tsx:57
 msgid "Status"
 msgstr ""
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "User deleted successfully"
 msgstr ""
 
-#: app/routes/user/index.tsx:199
+#: app/routes/user/index.tsx:201
 msgid "User invited successfully"
 msgstr ""
 

--- a/app/routes/contact-group/index.tsx
+++ b/app/routes/contact-group/index.tsx
@@ -61,6 +61,7 @@ const columns = [
     ),
   }),
   columnHelper.accessor('metadata.creationTimestamp', {
+    id: 'metadata.creationTimestamp',
     header: () => <Trans>Created</Trans>,
     cell: ({ getValue }) => <DateTime date={getValue()} />,
   }),
@@ -71,6 +72,7 @@ export default function Page() {
   const [selectedContactGroup, setSelectedContactGroup] =
     useState<ComMiloapisNotificationV1Alpha1ContactGroup | null>(null);
   const tableState = useClientDataTableQuery<ComMiloapisNotificationV1Alpha1ContactGroupList>({
+    defaultSort: ['metadata.creationTimestamp:desc'],
     useSorting: true,
     useSearch: true,
     queryKeyPrefix: 'contact-groups',

--- a/app/routes/contact/index.tsx
+++ b/app/routes/contact/index.tsx
@@ -67,6 +67,7 @@ const columns = [
     ),
   }),
   columnHelper.accessor('metadata.creationTimestamp', {
+    id: 'metadata.creationTimestamp',
     header: () => <Trans>Created</Trans>,
     cell: ({ getValue }) => <DateTime date={getValue()} />,
   }),
@@ -77,6 +78,7 @@ export default function Page() {
   const [selectedContact, setSelectedContact] =
     useState<ComMiloapisNotificationV1Alpha1Contact | null>(null);
   const tableState = useClientDataTableQuery<ComMiloapisNotificationV1Alpha1ContactList>({
+    defaultSort: ['metadata.creationTimestamp:desc'],
     useSorting: true,
     useSearch: true,
     queryKeyPrefix: 'contacts',

--- a/app/routes/group/index.tsx
+++ b/app/routes/group/index.tsx
@@ -40,6 +40,7 @@ const columns = [
     },
   }),
   columnHelper.accessor('metadata.creationTimestamp', {
+    id: 'metadata.creationTimestamp',
     header: () => <Trans>Created</Trans>,
     cell: ({ getValue }) => <DateTime date={getValue()} />,
   }),
@@ -49,6 +50,7 @@ export default function Page() {
   const tableState = useClientDataTableQuery<ComMiloapisIamV1Alpha1GroupList>({
     queryKeyPrefix: 'groups',
     fetchFn: () => groupListQuery(),
+    defaultSort: ['metadata.creationTimestamp:desc'],
     useSorting: true,
     useSearch: true,
   });

--- a/app/routes/organization/detail/project.tsx
+++ b/app/routes/organization/detail/project.tsx
@@ -47,6 +47,7 @@ const columns = [
     },
   }),
   columnHelper.accessor('metadata.creationTimestamp', {
+    id: 'metadata.creationTimestamp',
     header: () => <Trans>Created</Trans>,
     cell: ({ getValue }) => {
       return <DateTime date={getValue()} />;
@@ -60,6 +61,7 @@ export default function Page() {
   const tableState = useClientDataTableQuery<ComMiloapisResourcemanagerV1Alpha1ProjectList>({
     queryKeyPrefix: ['organizations', data.metadata?.name ?? '', 'projects'],
     fetchFn: () => orgProjectListQuery(data.metadata?.name ?? ''),
+    defaultSort: ['metadata.creationTimestamp:desc'],
     useSorting: true,
     useSearch: true,
   });

--- a/app/routes/organization/index.tsx
+++ b/app/routes/organization/index.tsx
@@ -45,6 +45,7 @@ const columns = [
     },
   }),
   columnHelper.accessor('metadata.creationTimestamp', {
+    id: 'metadata.creationTimestamp',
     header: () => <Trans>Created</Trans>,
     cell: ({ getValue }) => <DateTime date={getValue()} />,
   }),
@@ -54,6 +55,7 @@ export default function Page() {
   const tableState = useClientDataTableQuery<ComMiloapisResourcemanagerV1Alpha1OrganizationList>({
     queryKeyPrefix: 'orgs',
     fetchFn: orgListQuery,
+    defaultSort: ['metadata.creationTimestamp:desc'],
     useSorting: true,
     useSearch: true,
     useFilters: true,

--- a/app/routes/project/index.tsx
+++ b/app/routes/project/index.tsx
@@ -48,6 +48,7 @@ const columns = [
     },
   }),
   columnHelper.accessor('metadata.creationTimestamp', {
+    id: 'metadata.creationTimestamp',
     header: () => <Trans>Created</Trans>,
     cell: ({ getValue }) => {
       return <DateTime date={getValue()} />;
@@ -59,6 +60,7 @@ export default function Page() {
   const tableState = useClientDataTableQuery<ComMiloapisResourcemanagerV1Alpha1ProjectList>({
     queryKeyPrefix: 'projects',
     fetchFn: projectListQuery,
+    defaultSort: ['metadata.creationTimestamp:desc'],
     useSorting: true,
     useSearch: true,
   });

--- a/app/routes/user/detail/organization.tsx
+++ b/app/routes/user/detail/organization.tsx
@@ -43,6 +43,7 @@ const columns = [
     cell: ({ getValue }) => <BadgeState state={getValue() ?? ''} />,
   }),
   columnHelper.accessor('metadata.creationTimestamp', {
+    id: 'metadata.creationTimestamp',
     header: () => <Trans>Joined</Trans>,
     cell: ({ getValue }) => <DateTime date={getValue()} />,
   }),
@@ -64,6 +65,7 @@ export default function Page() {
     useClientDataTableQuery<ComMiloapisResourcemanagerV1Alpha1OrganizationMembershipList>({
       queryKeyPrefix: ['users', data.metadata?.name ?? '', 'organizations'],
       fetchFn: () => userOrgListQuery(data.metadata?.name ?? ''),
+      defaultSort: ['metadata.creationTimestamp:desc'],
       useSorting: true,
       useSearch: true,
     });

--- a/app/routes/user/index.tsx
+++ b/app/routes/user/index.tsx
@@ -64,6 +64,7 @@ const columns = [
     cell: ({ getValue }) => <BadgeState state={getValue() ?? 'Unknown'} />,
   }),
   columnHelper.accessor('metadata.creationTimestamp', {
+    id: 'metadata.creationTimestamp',
     header: () => <Trans>Created</Trans>,
     cell: ({ getValue }) => <DateTime date={getValue()} />,
   }),
@@ -80,6 +81,7 @@ export default function Page() {
   const tableState = useClientDataTableQuery<ComMiloapisIamV1Alpha1UserList>({
     queryKeyPrefix: 'users',
     fetchFn: userListQuery,
+    defaultSort: ['metadata.creationTimestamp:desc'],
     useSorting: true,
     useFilters: true,
     useSearch: true,


### PR DESCRIPTION
Add configurable default sorting to the client data table and default email activity to newest-first.

Addressing the feedback: https://github.com/datum-cloud/staff-portal/issues/310#issuecomment-3847705831
