### PR TITLE
Implement Automatic Redirect to Originally Requested Protected Page

### DIFF
--- a/app/layouts/private.layout.tsx
+++ b/app/layouts/private.layout.tsx
@@ -6,6 +6,7 @@ import { authenticator } from '@/modules/auth';
 import { SidebarInset, SidebarProvider } from '@/modules/shadcn/ui/sidebar';
 import { AppProvider } from '@/providers/app.provider';
 import { userDetailQuery } from '@/resources/request/server';
+import { getLoginUrl, getRedirectToPath } from '@/utils/cookies';
 import { metaObject } from '@/utils/helpers';
 import { data, Outlet, redirect, useLoaderData } from 'react-router';
 
@@ -16,7 +17,7 @@ export const meta: Route.MetaFunction = () => {
 export async function loader({ request }: Route.LoaderArgs) {
   const isAuthenticated = await authenticator.isAuthenticated(request);
   if (!isAuthenticated) {
-    return redirect('/login');
+    return redirect(getLoginUrl(getRedirectToPath(request.url)));
   }
 
   const isValid = await authenticator.isValidSession(request);

--- a/app/modules/i18n/locales/en.po
+++ b/app/modules/i18n/locales/en.po
@@ -775,8 +775,8 @@ msgid "Loading status..."
 msgstr "Loading status..."
 
 #: app/routes/auth/logout.tsx:36
-#: app/routes/auth/login.tsx:19
-#: app/routes/auth/callback.tsx:59
+#: app/routes/auth/login.tsx:41
+#: app/routes/auth/callback.tsx:71
 msgid "Loading..."
 msgstr "Loading..."
 

--- a/app/modules/i18n/locales/fr.po
+++ b/app/modules/i18n/locales/fr.po
@@ -775,8 +775,8 @@ msgid "Loading status..."
 msgstr ""
 
 #: app/routes/auth/logout.tsx:36
-#: app/routes/auth/login.tsx:19
-#: app/routes/auth/callback.tsx:59
+#: app/routes/auth/login.tsx:41
+#: app/routes/auth/callback.tsx:71
 msgid "Loading..."
 msgstr ""
 

--- a/app/routes/auth/callback.tsx
+++ b/app/routes/auth/callback.tsx
@@ -1,6 +1,11 @@
 import type { Route } from './+types/callback';
 import { authenticator } from '@/modules/auth';
-import { sessionCookie, tokenCookie } from '@/utils/cookies';
+import {
+  getRedirectDestination,
+  redirectToCookie,
+  sessionCookie,
+  tokenCookie,
+} from '@/utils/cookies';
 import { AuthenticationError } from '@/utils/errors';
 import { combineHeaders } from '@/utils/helpers';
 import logger from '@/utils/logger';
@@ -31,8 +36,15 @@ export async function loader({ request, context }: Route.LoaderArgs) {
       idToken: credentials.idToken,
     });
 
-    return redirect('/', {
-      headers: combineHeaders(session.headers, token.headers),
+    // Redirect to originally requested page if stored in cookie
+    const redirectTo = await redirectToCookie.parse(request.headers.get('Cookie') ?? '');
+    const destination = getRedirectDestination(redirectTo);
+    const clearRedirectCookie = await redirectToCookie.serialize('', { maxAge: 0 });
+
+    return redirect(destination, {
+      headers: combineHeaders(session.headers, token.headers, {
+        'Set-Cookie': clearRedirectCookie,
+      }),
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';

--- a/app/routes/auth/login.tsx
+++ b/app/routes/auth/login.tsx
@@ -1,6 +1,8 @@
 import type { Route } from './+types/login';
 import { authenticator } from '@/modules/auth';
+import { isRedirectResponse, isValidRedirectPath, redirectToCookie } from '@/utils/cookies';
 import { Trans } from '@lingui/react/macro';
+import { redirect } from 'react-router';
 
 export function meta({}: Route.MetaFunction) {
   return [
@@ -9,8 +11,28 @@ export function meta({}: Route.MetaFunction) {
   ];
 }
 
-export function loader({ request }: Route.LoaderArgs) {
-  return authenticator.authenticate('zitadel', request);
+export async function loader({ request }: Route.LoaderArgs) {
+  const url = new URL(request.url);
+  const redirectTo = url.searchParams.get('redirectTo');
+
+  try {
+    return await authenticator.authenticate('zitadel', request);
+  } catch (error) {
+    // OAuth strategy throws redirect to IdP - set or clear redirectTo cookie
+    if (isRedirectResponse(error)) {
+      const headers = new Headers(error.headers);
+      if (redirectTo && isValidRedirectPath(redirectTo)) {
+        const cookie = await redirectToCookie.serialize(redirectTo);
+        headers.append('Set-Cookie', cookie);
+      } else {
+        // Clear stale cookie when no redirectTo (user came directly to login)
+        const clearCookie = await redirectToCookie.serialize('', { maxAge: 0 });
+        headers.append('Set-Cookie', clearCookie);
+      }
+      return redirect(error.headers.get('Location') ?? '/', { headers });
+    }
+    throw error;
+  }
 }
 
 export default function Login() {

--- a/app/utils/cookies/index.ts
+++ b/app/utils/cookies/index.ts
@@ -2,3 +2,4 @@ export * from './session';
 export * from './token';
 
 export * from './locale';
+export * from './redirect';

--- a/app/utils/cookies/redirect.ts
+++ b/app/utils/cookies/redirect.ts
@@ -1,0 +1,54 @@
+import { env } from '@/utils/config/env.server';
+import { createCookie } from 'react-router';
+
+/**
+ * Extracts path (pathname + search) from a URL string.
+ */
+export function getRedirectToPath(url: string): string {
+  const { pathname, search } = new URL(url);
+  return pathname + search;
+}
+
+/**
+ * Validates that a path is safe for redirect (prevents open redirects).
+ * Only allows relative paths starting with / but not //.
+ */
+export function isValidRedirectPath(path: string): boolean {
+  return path.startsWith('/') && !path.startsWith('//');
+}
+
+/**
+ * Returns the redirect destination from a raw cookie value.
+ * Returns '/' if the value is invalid or not a safe path.
+ */
+export function getRedirectDestination(value: unknown): string {
+  return typeof value === 'string' && isValidRedirectPath(value) ? value : '/';
+}
+
+/**
+ * Builds the login URL with optional redirectTo param.
+ * Returns '/login' when redirectTo is '/' or empty.
+ */
+export function getLoginUrl(redirectTo: string): string {
+  return redirectTo === '/' || !redirectTo
+    ? '/login'
+    : `/login?redirectTo=${encodeURIComponent(redirectTo)}`;
+}
+
+/** Type guard for redirect Response thrown by OAuth strategy. */
+export function isRedirectResponse(error: unknown): error is Response {
+  return error instanceof Response && error.status >= 300 && error.status < 400;
+}
+
+/**
+ * Cookie to persist the original URL for redirect-after-login.
+ * Short-lived (5 min) - only needed during the OAuth flow.
+ */
+export const redirectToCookie = createCookie('redirect_to', {
+  path: '/',
+  domain: new URL(env.APP_URL).hostname,
+  httpOnly: true,
+  sameSite: 'lax',
+  maxAge: 60 * 5, // 5 minutes
+  secrets: [env.SESSION_SECRET],
+});


### PR DESCRIPTION
When an unauthenticated user visits a protected route, they are redirected to login. After successful authentication, they are now sent back to the originally requested page instead of always landing on /.
Uses a short-lived cookie to store the intended destination during the OAuth flow.