### PR TITLE
fix: filter sheet modal, form card width, and timezone label overflow on mobile

### DIFF
--- a/app/components/data-table-toolbar/index.tsx
+++ b/app/components/data-table-toolbar/index.tsx
@@ -83,7 +83,7 @@ export function DataTableToolbar({ search, filters, extras, className }: DataTab
             )}
           </Button>
 
-          <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+          <Sheet open={sheetOpen} onOpenChange={setSheetOpen} modal={false}>
             <SheetContent side="bottom" className="flex max-h-[85svh] flex-col gap-0 p-0">
               <VisuallyHidden>
                 <SheetDescription>{t`Filter options`}</SheetDescription>

--- a/app/components/select/autocomplete-grouped.tsx
+++ b/app/components/select/autocomplete-grouped.tsx
@@ -84,8 +84,10 @@ export function GroupedSelectAutocomplete({
           role="combobox"
           aria-expanded={open}
           disabled={disabled}
-          className={cn(width, 'justify-between', triggerClassName, className)}>
-          {selectedOption ? selectedOption.label : placeholder}
+          className={cn(width, 'justify-between overflow-hidden', triggerClassName, className)}>
+          <span className="min-w-0 truncate">
+            {selectedOption ? selectedOption.label : placeholder}
+          </span>
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>

--- a/app/routes/contact-group/create.tsx
+++ b/app/routes/contact-group/create.tsx
@@ -18,7 +18,7 @@ export default function Page() {
   return (
     <div className="m-4">
       <Row className="mb-4">
-        <Col span={12} offset={6}>
+        <Col xs={24} md={{ span: 12, offset: 6 }}>
           <Card>
             <CardHeader>
               <CardTitle>

--- a/app/routes/contact-group/detail/index.tsx
+++ b/app/routes/contact-group/detail/index.tsx
@@ -17,7 +17,7 @@ export default function Page() {
   return (
     <div className="m-4">
       <Row className="mb-4">
-        <Col span={12} offset={6}>
+        <Col xs={24} md={{ span: 12, offset: 6 }}>
           <Card>
             <CardHeader>
               <CardTitle>

--- a/app/routes/contact/create.tsx
+++ b/app/routes/contact/create.tsx
@@ -18,7 +18,7 @@ export default function Page() {
   return (
     <div className="m-4">
       <Row className="mb-4">
-        <Col span={12} offset={6}>
+        <Col xs={24} md={{ span: 12, offset: 6 }}>
           <Card>
             <CardHeader>
               <CardTitle>

--- a/app/routes/contact/detail/index.tsx
+++ b/app/routes/contact/detail/index.tsx
@@ -17,7 +17,7 @@ export default function Page() {
   return (
     <div className="m-4">
       <Row className="mb-4">
-        <Col span={12} offset={6}>
+        <Col xs={24} md={{ span: 12, offset: 6 }}>
           <Card>
             <CardHeader>
               <CardTitle>

--- a/app/routes/profile/setting.tsx
+++ b/app/routes/profile/setting.tsx
@@ -20,19 +20,19 @@ export default function Page() {
   return (
     <div className="m-4">
       <Row className="mb-4">
-        <Col span={12} offset={6}>
+        <Col xs={24} md={{ span: 12, offset: 6 }}>
           <ProfileForm />
         </Col>
       </Row>
 
       <Row className="mb-4">
-        <Col span={12} offset={6}>
+        <Col xs={24} md={{ span: 12, offset: 6 }}>
           <UserIdentityCard userId={user?.metadata?.name ?? ''} />
         </Col>
       </Row>
 
       <Row>
-        <Col span={12} offset={6}>
+        <Col xs={24} md={{ span: 12, offset: 6 }}>
           <PreferencesForm />
         </Col>
       </Row>


### PR DESCRIPTION
## Summary

Follow-up fixes from the responsive mobile improvements (#409).

- **Filter sheet**: set `modal={false}` on the DataTableToolbar Sheet so portaled Radix dropdowns (SelectFilter options) receive clicks instead of being blocked by the modal overlay
- **Form card width**: `Col span={12} offset={6}` → `Col xs={24} md={{ span: 12, offset: 6 }}` so form cards use full width on mobile (5 pages: contact create/detail, contact-group create/detail, profile settings)
- **Timezone select**: wrap label in `truncate` span to prevent long timezone labels from overlapping the chevron icon

## Test plan

- [ ] Filter sheet: open filter → tap dropdown option → value selects correctly (users, organizations, fraud, email, activity pages)
- [ ] Form pages at mobile width: /contacts/create, /contact-groups/create, /profile → card fills viewport
- [ ] Timezone select at /profile: selected label truncates with ellipsis, chevron visible
- [ ] Desktop: all pages unchanged