### PR TITLE
fix: add horizontal scroll to SimpleTable for mobile

### DIFF
--- a/app/components/simple-table/index.tsx
+++ b/app/components/simple-table/index.tsx
@@ -55,7 +55,7 @@ export function SimpleTable<TData>({
   });
 
   return (
-    <div className={cn('overflow-hidden rounded-md border', className)} {...props}>
+    <div className={cn('overflow-x-auto rounded-md border', className)} {...props}>
       <Table>
         <TableHeader>
           {table.getHeaderGroups().map((headerGroup) => (


### PR DESCRIPTION
## Summary

Change `overflow-hidden` to `overflow-x-auto` on the SimpleTable wrapper so tables with 3+ columns scroll horizontally on mobile instead of clipping.

Only one usage exists: the nameservers table in `project/detail/dns/detail.tsx` (4 columns: Type, Value, DNS Host, Registrar). The sticky `actions` column pattern already works with this change.

Closes #407

## Test plan

- [ ] Visit a DNS zone detail page with nameservers → table scrolls horizontally on mobile
- [ ] Desktop: unchanged