### PR TITLE
fix: tighten AppToolbar breadcrumb layout for narrow viewports

### DIFF
--- a/app/components/app-toolbar/index.tsx
+++ b/app/components/app-toolbar/index.tsx
@@ -27,7 +27,7 @@ const AppToolbar = () => {
         'bg-background sticky top-0 z-10 flex h-14 shrink-0 items-center justify-between gap-2 border-b px-4 ease-linear',
         scrolled && 'shadow-sm'
       )}>
-      <div className="flex items-center gap-4">
+      <div className="flex min-w-0 items-center gap-4 overflow-hidden">
         <Breadcrumb />
         {navigation}
       </div>

--- a/app/components/breadcrumb/breadcrumb.tsx
+++ b/app/components/breadcrumb/breadcrumb.tsx
@@ -103,7 +103,7 @@ function renderBreadcrumbItem(item: BreadcrumbItem, isLast: boolean): React.Reac
 
   // If it's the last item or not clickable, render as page
   if (isLast || !item.clickable || !item.path) {
-    return <BreadcrumbPage>{item.label}</BreadcrumbPage>;
+    return <BreadcrumbPage className={isLast ? 'max-w-[200px] truncate' : undefined}>{item.label}</BreadcrumbPage>;
   }
 
   // Otherwise render as clickable link


### PR DESCRIPTION
## Summary

On tablet/narrow desktop viewports (768px–1200px), the breadcrumb trail could overflow into the action buttons area with no truncation.

- Add `min-w-0 overflow-hidden` to the left flex div in AppToolbar so breadcrumbs shrink instead of pushing into actions
- Add `max-w-[200px] truncate` to the last breadcrumb item so long names show ellipsis

Closes #408

## Test plan

- [ ] Navigate to a deep detail page (e.g. user activity audit logs) at ~900px width → breadcrumb truncates, actions stay visible
- [ ] Desktop wide: breadcrumb displays fully as before
- [ ] Mobile: MobileToolbar renders (unchanged)