### PR TITLE
fix: resolve group and member name columns to human-readable values

### DIFF
--- a/app/modules/i18n/locales/en.po
+++ b/app/modules/i18n/locales/en.po
@@ -126,8 +126,8 @@ msgstr "Activity"
 msgid "Activity Feed"
 msgstr "Activity Feed"
 
-#: app/routes/group/member.tsx:123
-#: app/routes/group/member.tsx:146
+#: app/routes/group/member.tsx:141
+#: app/routes/group/member.tsx:164
 #: app/routes/contact-group/index.tsx:112
 #: app/routes/contact-group/detail/member.tsx:336
 #: app/routes/contact-group/detail/member.tsx:362
@@ -145,7 +145,7 @@ msgstr "Add a note"
 msgid "Add Group"
 msgstr "Add Group"
 
-#: app/routes/group/member.tsx:145
+#: app/routes/group/member.tsx:163
 #: app/routes/contact-group/detail/member.tsx:361
 msgid "Add Member"
 msgstr "Add Member"
@@ -256,7 +256,7 @@ msgid "Are you sure you want to delete group \"{0}\"? This action cannot be undo
 msgstr "Are you sure you want to delete group \"{0}\"? This action cannot be undone."
 
 #. placeholder {0}: selectedGroupMembership?.metadata?.name ?? ''
-#: app/routes/group/member.tsx:131
+#: app/routes/group/member.tsx:149
 msgid "Are you sure you want to delete member \"{0}\"? This action cannot be undone."
 msgstr "Are you sure you want to delete member \"{0}\"? This action cannot be undone."
 
@@ -332,8 +332,8 @@ msgstr "Back to evaluations"
 #: app/routes/user/detail/index.tsx:131
 #: app/routes/profile/session.tsx:106
 #: app/routes/organization/detail/member.tsx:85
-#: app/routes/group/member.tsx:133
-#: app/routes/group/member.tsx:147
+#: app/routes/group/member.tsx:151
+#: app/routes/group/member.tsx:165
 #: app/routes/fraud/policy.tsx:97
 #: app/routes/fraud/index.tsx:212
 #: app/routes/fraud/index.tsx:247
@@ -528,8 +528,8 @@ msgstr "Create Policy"
 #: app/routes/organization/index.tsx:43
 #: app/routes/organization/detail/project.tsx:50
 #: app/routes/organization/detail/index.tsx:54
-#: app/routes/group/member.tsx:98
-#: app/routes/group/index.tsx:40
+#: app/routes/group/member.tsx:116
+#: app/routes/group/index.tsx:35
 #: app/routes/fraud/providers/index.tsx:102
 #: app/routes/contact-group/index.tsx:89
 #: app/features/quota/components/quota-grant-list.tsx:114
@@ -612,8 +612,8 @@ msgstr "Degraded"
 
 #: app/routes/profile/session.tsx:41
 #: app/routes/profile/session.tsx:105
-#: app/routes/group/member.tsx:73
-#: app/routes/group/member.tsx:132
+#: app/routes/group/member.tsx:89
+#: app/routes/group/member.tsx:150
 #: app/routes/fraud/policy.tsx:96
 #: app/routes/fraud/index.tsx:92
 #: app/routes/fraud/index.tsx:246
@@ -681,7 +681,7 @@ msgstr "Delete Evaluation"
 msgid "Delete Grant"
 msgstr "Delete Grant"
 
-#: app/routes/group/member.tsx:130
+#: app/routes/group/member.tsx:148
 #: app/routes/contact-group/detail/member.tsx:343
 #: app/routes/contact/detail/group.tsx:158
 msgid "Delete Member"
@@ -882,7 +882,7 @@ msgstr "Enter reason for deactivation..."
 msgid "Enter reason for rejection..."
 msgstr "Enter reason for rejection..."
 
-#: app/routes/group/member.tsx:171
+#: app/routes/group/member.tsx:189
 #: app/routes/contact-group/detail/member.tsx:115
 #: app/features/contact/components/contact-form.tsx:199
 msgid "Enter the full email to search..."
@@ -1314,12 +1314,12 @@ msgstr "Manually sync this description with the one in Loops (used for opt-in pa
 msgid "Member"
 msgstr "Member"
 
-#: app/routes/group/member.tsx:157
+#: app/routes/group/member.tsx:175
 #: app/routes/contact-group/detail/member.tsx:322
 msgid "Member added successfully"
 msgstr "Member added successfully"
 
-#: app/routes/group/member.tsx:138
+#: app/routes/group/member.tsx:156
 #: app/routes/contact-group/detail/member.tsx:351
 msgid "Member deleted successfully"
 msgstr "Member deleted successfully"
@@ -1369,7 +1369,7 @@ msgstr "My Profile"
 #: app/routes/organization/detail/project.tsx:35
 #: app/routes/organization/detail/member.tsx:103
 #: app/routes/organization/detail/index.tsx:46
-#: app/routes/group/member.tsx:82
+#: app/routes/group/member.tsx:98
 #: app/routes/group/index.tsx:24
 #: app/routes/fraud/providers/index.tsx:55
 #: app/routes/fraud/providers/create.tsx:88
@@ -1472,7 +1472,7 @@ msgstr "No fraud providers configured."
 msgid "No grants found."
 msgstr "No grants found."
 
-#: app/routes/group/index.tsx:71
+#: app/routes/group/index.tsx:68
 #: app/routes/contact/detail/group.tsx:219
 msgid "No groups found."
 msgstr "No groups found."
@@ -1482,7 +1482,7 @@ msgstr "No groups found."
 msgid "No members found."
 msgstr "No members found."
 
-#: app/routes/group/member.tsx:202
+#: app/routes/group/member.tsx:220
 msgid "No members in this group."
 msgstr "No members in this group."
 
@@ -1994,14 +1994,14 @@ msgstr "Search for an existing contact by email..."
 msgid "Search grants..."
 msgstr "Search grants..."
 
-#: app/routes/group/index.tsx:64
+#: app/routes/group/index.tsx:61
 #: app/routes/contact/detail/group.tsx:182
 #: app/routes/contact/detail/group.tsx:213
 msgid "Search groups..."
 msgstr "Search groups..."
 
 #: app/routes/organization/detail/member.tsx:168
-#: app/routes/group/member.tsx:195
+#: app/routes/group/member.tsx:213
 #: app/routes/contact-group/detail/member.tsx:410
 msgid "Search members..."
 msgstr "Search members..."

--- a/app/modules/i18n/locales/fr.po
+++ b/app/modules/i18n/locales/fr.po
@@ -126,8 +126,8 @@ msgstr ""
 msgid "Activity Feed"
 msgstr ""
 
-#: app/routes/group/member.tsx:123
-#: app/routes/group/member.tsx:146
+#: app/routes/group/member.tsx:141
+#: app/routes/group/member.tsx:164
 #: app/routes/contact-group/index.tsx:112
 #: app/routes/contact-group/detail/member.tsx:336
 #: app/routes/contact-group/detail/member.tsx:362
@@ -145,7 +145,7 @@ msgstr ""
 msgid "Add Group"
 msgstr ""
 
-#: app/routes/group/member.tsx:145
+#: app/routes/group/member.tsx:163
 #: app/routes/contact-group/detail/member.tsx:361
 msgid "Add Member"
 msgstr ""
@@ -256,7 +256,7 @@ msgid "Are you sure you want to delete group \"{0}\"? This action cannot be undo
 msgstr ""
 
 #. placeholder {0}: selectedGroupMembership?.metadata?.name ?? ''
-#: app/routes/group/member.tsx:131
+#: app/routes/group/member.tsx:149
 msgid "Are you sure you want to delete member \"{0}\"? This action cannot be undone."
 msgstr ""
 
@@ -332,8 +332,8 @@ msgstr ""
 #: app/routes/user/detail/index.tsx:131
 #: app/routes/profile/session.tsx:106
 #: app/routes/organization/detail/member.tsx:85
-#: app/routes/group/member.tsx:133
-#: app/routes/group/member.tsx:147
+#: app/routes/group/member.tsx:151
+#: app/routes/group/member.tsx:165
 #: app/routes/fraud/policy.tsx:97
 #: app/routes/fraud/index.tsx:212
 #: app/routes/fraud/index.tsx:247
@@ -528,8 +528,8 @@ msgstr ""
 #: app/routes/organization/index.tsx:43
 #: app/routes/organization/detail/project.tsx:50
 #: app/routes/organization/detail/index.tsx:54
-#: app/routes/group/member.tsx:98
-#: app/routes/group/index.tsx:40
+#: app/routes/group/member.tsx:116
+#: app/routes/group/index.tsx:35
 #: app/routes/fraud/providers/index.tsx:102
 #: app/routes/contact-group/index.tsx:89
 #: app/features/quota/components/quota-grant-list.tsx:114
@@ -612,8 +612,8 @@ msgstr ""
 
 #: app/routes/profile/session.tsx:41
 #: app/routes/profile/session.tsx:105
-#: app/routes/group/member.tsx:73
-#: app/routes/group/member.tsx:132
+#: app/routes/group/member.tsx:89
+#: app/routes/group/member.tsx:150
 #: app/routes/fraud/policy.tsx:96
 #: app/routes/fraud/index.tsx:92
 #: app/routes/fraud/index.tsx:246
@@ -681,7 +681,7 @@ msgstr ""
 msgid "Delete Grant"
 msgstr ""
 
-#: app/routes/group/member.tsx:130
+#: app/routes/group/member.tsx:148
 #: app/routes/contact-group/detail/member.tsx:343
 #: app/routes/contact/detail/group.tsx:158
 msgid "Delete Member"
@@ -882,7 +882,7 @@ msgstr ""
 msgid "Enter reason for rejection..."
 msgstr ""
 
-#: app/routes/group/member.tsx:171
+#: app/routes/group/member.tsx:189
 #: app/routes/contact-group/detail/member.tsx:115
 #: app/features/contact/components/contact-form.tsx:199
 msgid "Enter the full email to search..."
@@ -1314,12 +1314,12 @@ msgstr ""
 msgid "Member"
 msgstr ""
 
-#: app/routes/group/member.tsx:157
+#: app/routes/group/member.tsx:175
 #: app/routes/contact-group/detail/member.tsx:322
 msgid "Member added successfully"
 msgstr ""
 
-#: app/routes/group/member.tsx:138
+#: app/routes/group/member.tsx:156
 #: app/routes/contact-group/detail/member.tsx:351
 msgid "Member deleted successfully"
 msgstr ""
@@ -1369,7 +1369,7 @@ msgstr ""
 #: app/routes/organization/detail/project.tsx:35
 #: app/routes/organization/detail/member.tsx:103
 #: app/routes/organization/detail/index.tsx:46
-#: app/routes/group/member.tsx:82
+#: app/routes/group/member.tsx:98
 #: app/routes/group/index.tsx:24
 #: app/routes/fraud/providers/index.tsx:55
 #: app/routes/fraud/providers/create.tsx:88
@@ -1472,7 +1472,7 @@ msgstr ""
 msgid "No grants found."
 msgstr ""
 
-#: app/routes/group/index.tsx:71
+#: app/routes/group/index.tsx:68
 #: app/routes/contact/detail/group.tsx:219
 msgid "No groups found."
 msgstr ""
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "No members found."
 msgstr ""
 
-#: app/routes/group/member.tsx:202
+#: app/routes/group/member.tsx:220
 msgid "No members in this group."
 msgstr ""
 
@@ -1994,14 +1994,14 @@ msgstr ""
 msgid "Search grants..."
 msgstr ""
 
-#: app/routes/group/index.tsx:64
+#: app/routes/group/index.tsx:61
 #: app/routes/contact/detail/group.tsx:182
 #: app/routes/contact/detail/group.tsx:213
 msgid "Search groups..."
 msgstr ""
 
 #: app/routes/organization/detail/member.tsx:168
-#: app/routes/group/member.tsx:195
+#: app/routes/group/member.tsx:213
 #: app/routes/contact-group/detail/member.tsx:410
 msgid "Search members..."
 msgstr ""

--- a/app/routes/group/index.tsx
+++ b/app/routes/group/index.tsx
@@ -24,12 +24,13 @@ export default function Page() {
       header: ({ column }) => <DataTable.ColumnHeader column={column} title={t`Name`} />,
       cell: ({ row }) => {
         const groupName = row.original.metadata?.name ?? '';
-        const displayName = row.original.metadata?.namespace;
+        const displayName =
+          row.original.metadata?.annotations?.['kubernetes.io/display-name'] || groupName;
 
         return (
           <DisplayName
-            displayName={groupName}
-            name={displayName || groupName}
+            displayName={displayName}
+            name={groupName}
             to={`./${groupName}`}
           />
         );
@@ -54,8 +55,10 @@ export default function Page() {
         const q = search.trim().toLowerCase();
         if (!q) return true;
         const name = (row.metadata?.name ?? '').toLowerCase();
-        const ns = (row.metadata?.namespace ?? '').toLowerCase();
-        return name.includes(q) || ns.includes(q);
+        const displayName = (
+          row.metadata?.annotations?.['kubernetes.io/display-name'] ?? ''
+        ).toLowerCase();
+        return name.includes(q) || displayName.includes(q);
       }}>
       <Card className="m-4 py-4 shadow-none">
         <CardContent className="flex flex-col gap-2 px-4">

--- a/app/routes/group/member.tsx
+++ b/app/routes/group/member.tsx
@@ -11,6 +11,7 @@ import {
   useCreateGroupMembershipMutation,
   useDeleteGroupMembershipMutation,
   useGroupMembershipListQuery,
+  useUserListQuery,
 } from '@/resources/request/client';
 import { groupDetailQuery } from '@/resources/request/server';
 import { userRoutes } from '@/utils/config/routes.config';
@@ -27,7 +28,7 @@ import {
 } from '@openapi/iam.miloapis.com/v1alpha1';
 import { createColumnHelper } from '@tanstack/react-table';
 import { PlusCircleIcon, Trash2Icon } from 'lucide-react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import z from 'zod';
 
 export const meta: Route.MetaFunction = ({ matches }) => {
@@ -55,8 +56,23 @@ export default function Page() {
   const group = useGroupDetailData();
   const groupName = group.metadata?.name ?? '';
   const tableQuery = useGroupMembershipListQuery(groupName);
+  const userListQueryResult = useUserListQuery({ limit: 500 });
   const createMembershipMutation = useCreateGroupMembershipMutation();
   const deleteMembershipMutation = useDeleteGroupMembershipMutation();
+
+  const userMap = useMemo(() => {
+    const map = new Map<string, { displayName: string; email: string }>();
+    for (const user of userListQueryResult.data?.items ?? []) {
+      const name = user.metadata?.name ?? '';
+      if (name) {
+        map.set(name, {
+          displayName: `${user.spec?.givenName ?? ''} ${user.spec?.familyName ?? ''}`.trim() || name,
+          email: user.spec?.email ?? '',
+        });
+      }
+    }
+    return map;
+  }, [userListQueryResult.data]);
 
   const [selectedGroupMembership, setSelectedGroupMembership] =
     useState<ComMiloapisIamV1Alpha1GroupMembership | null>(null);
@@ -81,14 +97,16 @@ export default function Page() {
     columnHelper.accessor('metadata.name', {
       header: ({ column }) => <DataTable.ColumnHeader column={column} title={t`Name`} />,
       cell: ({ row }) => {
-        const name = row.original.metadata?.name ?? '';
-        const displayName = row.original.metadata?.namespace;
+        const userRefName = row.original.spec?.userRef?.name ?? '';
+        const user = userMap.get(userRefName);
+        const displayName = user?.displayName || userRefName;
+        const email = user?.email ?? '';
 
         return (
           <DisplayName
-            displayName={name}
-            name={displayName || name}
-            to={userRoutes.detail(row.original.spec?.userRef?.name ?? '')}
+            displayName={displayName}
+            name={email || userRefName}
+            to={userRoutes.detail(userRefName)}
           />
         );
       },


### PR DESCRIPTION
## Summary

- Group list (`/groups`) now reads `kubernetes.io/display-name` annotation as the primary display name instead of showing the raw system-generated `metadata.name` (e.g. `staff-users-327293583252002829`)
- Member list (`/groups/:name`) fetches the full user list and maps each `userRef.name` to the user's full name and email, replacing the opaque GroupMembership `metadata.name` with a human-readable identity

## Test plan

- [ ] Visit `/groups` and confirm group names show human-readable labels (e.g. "Staff Users") with the system name as subtext
- [ ] Visit `/groups/staff-users` (Members tab) and confirm each row shows the user's full name and email instead of the membership ID
- [ ] Confirm search on the group list works against the display name annotation
- [ ] Confirm member row links navigate correctly to the user detail page


<img width="800" alt="Screenshot 2026-04-21 at 3 40 32 PM" src="https://github.com/user-attachments/assets/05519cce-cbc0-4286-8333-42ccb5897d2a" />
