### PR TITLE
feat: show MaxMind risk score reasons on evaluation detail

### DIFF
--- a/app/features/fraud/detail/evaluation-sections.tsx
+++ b/app/features/fraud/detail/evaluation-sections.tsx
@@ -67,8 +67,24 @@ function RawResponseDialog({
   );
 }
 
+type RiskScoreReason = { multiplier: number; reasons: { code: string; reason: string }[] };
+
+function parseRiskScoreReasons(raw: string): RiskScoreReason[] {
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed?.risk_score_reasons) ? parsed.risk_score_reasons : [];
+  } catch {
+    return [];
+  }
+}
+
 function ProviderResultRow({ result }: { result: ProviderResult }) {
   const [rawOpen, setRawOpen] = useState(false);
+
+  const riskReasons =
+    result.provider === 'maxmind' && result.rawResponse
+      ? parseRiskScoreReasons(result.rawResponse)
+      : [];
 
   return (
     <>
@@ -80,30 +96,48 @@ function ProviderResultRow({ result }: { result: ProviderResult }) {
           raw={result.rawResponse}
         />
       )}
-      <div className="border-border flex items-center justify-between border-b py-2 last:border-0">
-        <div className="flex items-center gap-3">
-          <Text size="sm" weight="medium">
-            {result.provider}
-          </Text>
-          {result.failurePolicyApplied && (
-            <BadgeState state="warning" message={result.failurePolicyApplied} />
-          )}
-          {result.error && <BadgeState state="error" message={t`Error`} tooltip={result.error} />}
+      <div className="border-border border-b py-2 last:border-0">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Text size="sm" weight="medium">
+              {result.provider}
+            </Text>
+            {result.failurePolicyApplied && (
+              <BadgeState state="warning" message={result.failurePolicyApplied} />
+            )}
+            {result.error && (
+              <BadgeState state="error" message={t`Error`} tooltip={result.error} />
+            )}
+          </div>
+          <div className="flex items-center gap-4">
+            {result.duration && (
+              <span className="text-muted-foreground flex items-center gap-1 text-xs">
+                <Clock className="h-3 w-3" />
+                {result.duration}
+              </span>
+            )}
+            <Text className="font-mono text-sm font-medium">{result.score}</Text>
+            {result.rawResponse && (
+              <Button size="small" theme="outline" onClick={() => setRawOpen(true)}>
+                <Trans>View Raw Results</Trans>
+              </Button>
+            )}
+          </div>
         </div>
-        <div className="flex items-center gap-4">
-          {result.duration && (
-            <span className="text-muted-foreground flex items-center gap-1 text-xs">
-              <Clock className="h-3 w-3" />
-              {result.duration}
-            </span>
-          )}
-          <Text className="font-mono text-sm font-medium">{result.score}</Text>
-          {result.rawResponse && (
-            <Button size="small" theme="outline" onClick={() => setRawOpen(true)}>
-              <Trans>View Raw Results</Trans>
-            </Button>
-          )}
-        </div>
+        {riskReasons.length > 0 && (
+          <ul className="mt-2 space-y-1 pl-1">
+            {riskReasons.map((r, i) =>
+              r.reasons.map((reason, j) => (
+                <li key={`${i}-${j}`} className="text-muted-foreground flex items-start gap-2 text-xs">
+                  <span className="text-foreground mt-0.5 font-mono font-medium shrink-0">
+                    {r.multiplier}x
+                  </span>
+                  <span>{reason.reason}</span>
+                </li>
+              ))
+            )}
+          </ul>
+        )}
       </div>
     </>
   );

--- a/app/modules/i18n/locales/en.po
+++ b/app/modules/i18n/locales/en.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/features/fraud/detail/evaluation-sections.tsx:209
+#: app/features/fraud/detail/evaluation-sections.tsx:243
 msgid "(current)"
 msgstr "(current)"
 
@@ -189,7 +189,7 @@ msgstr "AI Edge"
 msgid "All evaluations are clear"
 msgstr "All evaluations are clear"
 
-#: app/features/fraud/detail/evaluation-sections.tsx:193
+#: app/features/fraud/detail/evaluation-sections.tsx:227
 msgid "All Evaluations for this User"
 msgstr "All Evaluations for this User"
 
@@ -324,7 +324,7 @@ msgstr "Available"
 msgid "Back"
 msgstr "Back"
 
-#: app/features/fraud/detail/evaluation-sections.tsx:248
+#: app/features/fraud/detail/evaluation-sections.tsx:282
 msgid "Back to evaluations"
 msgstr "Back to evaluations"
 
@@ -397,7 +397,7 @@ msgid "Configuration"
 msgstr "Configuration"
 
 #: app/routes/contact-group/detail/member.tsx:68
-#: app/features/fraud/detail/evaluation-sections.tsx:290
+#: app/features/fraud/detail/evaluation-sections.tsx:324
 msgid "Contact"
 msgstr "Contact"
 
@@ -606,7 +606,7 @@ msgstr "Deactivation Reason"
 #: app/routes/fraud/index.tsx:151
 #: app/routes/fraud/index.tsx:304
 #: app/routes/fraud/index.tsx:320
-#: app/features/fraud/detail/evaluation-sections.tsx:324
+#: app/features/fraud/detail/evaluation-sections.tsx:358
 #: app/features/dashboard/components/fraud-alerts-widget.tsx:150
 msgid "Decision"
 msgstr "Decision"
@@ -862,7 +862,7 @@ msgid "Endpoint"
 msgstr "Endpoint"
 
 #: app/routes/fraud/index.tsx:166
-#: app/features/fraud/detail/evaluation-sections.tsx:339
+#: app/features/fraud/detail/evaluation-sections.tsx:373
 msgid "Enforcement"
 msgstr "Enforcement"
 
@@ -898,12 +898,12 @@ msgid "Enter the word <0>{confirmationText}</0> to perform this action."
 msgstr "Enter the word <0>{confirmationText}</0> to perform this action."
 
 #: app/routes/fraud/index.tsx:299
-#: app/features/fraud/detail/evaluation-sections.tsx:91
+#: app/features/fraud/detail/evaluation-sections.tsx:108
 msgid "Error"
 msgstr "Error"
 
 #: app/routes/fraud/index.tsx:180
-#: app/features/fraud/detail/evaluation-sections.tsx:354
+#: app/features/fraud/detail/evaluation-sections.tsx:388
 msgid "Evaluated"
 msgstr "Evaluated"
 
@@ -911,7 +911,7 @@ msgstr "Evaluated"
 msgid "Evaluation deleted successfully"
 msgstr "Evaluation deleted successfully"
 
-#: app/features/fraud/detail/evaluation-sections.tsx:145
+#: app/features/fraud/detail/evaluation-sections.tsx:179
 msgid "Evaluation History"
 msgstr "Evaluation History"
 
@@ -919,7 +919,7 @@ msgstr "Evaluation History"
 msgid "Evaluation not found."
 msgstr "Evaluation not found."
 
-#: app/features/fraud/detail/evaluation-sections.tsx:266
+#: app/features/fraud/detail/evaluation-sections.tsx:300
 msgid "Evaluation Overview"
 msgstr "Evaluation Overview"
 
@@ -1550,8 +1550,8 @@ msgstr "No users found."
 msgid "No users yet"
 msgstr "No users yet"
 
-#: app/features/fraud/detail/evaluation-sections.tsx:333
-#: app/features/fraud/detail/evaluation-sections.tsx:348
+#: app/features/fraud/detail/evaluation-sections.tsx:367
+#: app/features/fraud/detail/evaluation-sections.tsx:382
 msgid "None"
 msgstr "None"
 
@@ -1663,7 +1663,7 @@ msgstr "Personal"
 #: app/routes/fraud/index.tsx:127
 #: app/routes/fraud/index.tsx:293
 #: app/routes/fraud/index.tsx:319
-#: app/features/fraud/detail/evaluation-sections.tsx:318
+#: app/features/fraud/detail/evaluation-sections.tsx:352
 msgid "Phase"
 msgstr "Phase"
 
@@ -1968,7 +1968,7 @@ msgstr "Schedule invitation to be sent at specific time"
 
 #: app/routes/user/detail/index.tsx:296
 #: app/routes/fraud/index.tsx:131
-#: app/features/fraud/detail/evaluation-sections.tsx:309
+#: app/features/fraud/detail/evaluation-sections.tsx:343
 #: app/features/dashboard/components/fraud-alerts-widget.tsx:145
 msgid "Score"
 msgstr "Score"
@@ -2138,7 +2138,7 @@ msgstr "Short-circuit Below"
 msgid "Sinks"
 msgstr "Sinks"
 
-#: app/features/fraud/detail/evaluation-sections.tsx:123
+#: app/features/fraud/detail/evaluation-sections.tsx:157
 msgid "Skipped"
 msgstr "Skipped"
 
@@ -2159,7 +2159,7 @@ msgstr "Stage {0}"
 msgid "Stage Name"
 msgstr "Stage Name"
 
-#: app/features/fraud/detail/evaluation-sections.tsx:371
+#: app/features/fraud/detail/evaluation-sections.tsx:405
 msgid "Stage Results"
 msgstr "Stage Results"
 
@@ -2311,7 +2311,7 @@ msgstr "Usage"
 
 #: app/routes/fraud/index.tsx:101
 #: app/routes/contact-group/detail/member.tsx:108
-#: app/features/fraud/detail/evaluation-sections.tsx:273
+#: app/features/fraud/detail/evaluation-sections.tsx:307
 #: app/features/dashboard/components/fraud-alerts-widget.tsx:140
 #: app/features/activity/components/activity-list.tsx:117
 #: app/features/activity/components/activity-list.tsx:392
@@ -2422,7 +2422,7 @@ msgstr "View in Cloud Portal"
 msgid "View in Sentry"
 msgstr "View in Sentry"
 
-#: app/features/fraud/detail/evaluation-sections.tsx:103
+#: app/features/fraud/detail/evaluation-sections.tsx:120
 msgid "View Raw Results"
 msgstr "View Raw Results"
 

--- a/app/modules/i18n/locales/fr.po
+++ b/app/modules/i18n/locales/fr.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/features/fraud/detail/evaluation-sections.tsx:209
+#: app/features/fraud/detail/evaluation-sections.tsx:243
 msgid "(current)"
 msgstr ""
 
@@ -189,7 +189,7 @@ msgstr ""
 msgid "All evaluations are clear"
 msgstr ""
 
-#: app/features/fraud/detail/evaluation-sections.tsx:193
+#: app/features/fraud/detail/evaluation-sections.tsx:227
 msgid "All Evaluations for this User"
 msgstr ""
 
@@ -324,7 +324,7 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: app/features/fraud/detail/evaluation-sections.tsx:248
+#: app/features/fraud/detail/evaluation-sections.tsx:282
 msgid "Back to evaluations"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgid "Configuration"
 msgstr ""
 
 #: app/routes/contact-group/detail/member.tsx:68
-#: app/features/fraud/detail/evaluation-sections.tsx:290
+#: app/features/fraud/detail/evaluation-sections.tsx:324
 msgid "Contact"
 msgstr ""
 
@@ -606,7 +606,7 @@ msgstr ""
 #: app/routes/fraud/index.tsx:151
 #: app/routes/fraud/index.tsx:304
 #: app/routes/fraud/index.tsx:320
-#: app/features/fraud/detail/evaluation-sections.tsx:324
+#: app/features/fraud/detail/evaluation-sections.tsx:358
 #: app/features/dashboard/components/fraud-alerts-widget.tsx:150
 msgid "Decision"
 msgstr ""
@@ -862,7 +862,7 @@ msgid "Endpoint"
 msgstr ""
 
 #: app/routes/fraud/index.tsx:166
-#: app/features/fraud/detail/evaluation-sections.tsx:339
+#: app/features/fraud/detail/evaluation-sections.tsx:373
 msgid "Enforcement"
 msgstr ""
 
@@ -898,12 +898,12 @@ msgid "Enter the word <0>{confirmationText}</0> to perform this action."
 msgstr ""
 
 #: app/routes/fraud/index.tsx:299
-#: app/features/fraud/detail/evaluation-sections.tsx:91
+#: app/features/fraud/detail/evaluation-sections.tsx:108
 msgid "Error"
 msgstr ""
 
 #: app/routes/fraud/index.tsx:180
-#: app/features/fraud/detail/evaluation-sections.tsx:354
+#: app/features/fraud/detail/evaluation-sections.tsx:388
 msgid "Evaluated"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Evaluation deleted successfully"
 msgstr ""
 
-#: app/features/fraud/detail/evaluation-sections.tsx:145
+#: app/features/fraud/detail/evaluation-sections.tsx:179
 msgid "Evaluation History"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Evaluation not found."
 msgstr ""
 
-#: app/features/fraud/detail/evaluation-sections.tsx:266
+#: app/features/fraud/detail/evaluation-sections.tsx:300
 msgid "Evaluation Overview"
 msgstr ""
 
@@ -1550,8 +1550,8 @@ msgstr ""
 msgid "No users yet"
 msgstr ""
 
-#: app/features/fraud/detail/evaluation-sections.tsx:333
-#: app/features/fraud/detail/evaluation-sections.tsx:348
+#: app/features/fraud/detail/evaluation-sections.tsx:367
+#: app/features/fraud/detail/evaluation-sections.tsx:382
 msgid "None"
 msgstr ""
 
@@ -1663,7 +1663,7 @@ msgstr ""
 #: app/routes/fraud/index.tsx:127
 #: app/routes/fraud/index.tsx:293
 #: app/routes/fraud/index.tsx:319
-#: app/features/fraud/detail/evaluation-sections.tsx:318
+#: app/features/fraud/detail/evaluation-sections.tsx:352
 msgid "Phase"
 msgstr ""
 
@@ -1968,7 +1968,7 @@ msgstr ""
 
 #: app/routes/user/detail/index.tsx:296
 #: app/routes/fraud/index.tsx:131
-#: app/features/fraud/detail/evaluation-sections.tsx:309
+#: app/features/fraud/detail/evaluation-sections.tsx:343
 #: app/features/dashboard/components/fraud-alerts-widget.tsx:145
 msgid "Score"
 msgstr ""
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Sinks"
 msgstr ""
 
-#: app/features/fraud/detail/evaluation-sections.tsx:123
+#: app/features/fraud/detail/evaluation-sections.tsx:157
 msgid "Skipped"
 msgstr ""
 
@@ -2159,7 +2159,7 @@ msgstr ""
 msgid "Stage Name"
 msgstr ""
 
-#: app/features/fraud/detail/evaluation-sections.tsx:371
+#: app/features/fraud/detail/evaluation-sections.tsx:405
 msgid "Stage Results"
 msgstr ""
 
@@ -2311,7 +2311,7 @@ msgstr ""
 
 #: app/routes/fraud/index.tsx:101
 #: app/routes/contact-group/detail/member.tsx:108
-#: app/features/fraud/detail/evaluation-sections.tsx:273
+#: app/features/fraud/detail/evaluation-sections.tsx:307
 #: app/features/dashboard/components/fraud-alerts-widget.tsx:140
 #: app/features/activity/components/activity-list.tsx:117
 #: app/features/activity/components/activity-list.tsx:392
@@ -2422,7 +2422,7 @@ msgstr ""
 msgid "View in Sentry"
 msgstr ""
 
-#: app/features/fraud/detail/evaluation-sections.tsx:103
+#: app/features/fraud/detail/evaluation-sections.tsx:120
 msgid "View Raw Results"
 msgstr ""
 


### PR DESCRIPTION
## Summary

- Parses `risk_score_reasons` from the MaxMind raw response on the evaluation detail page
- When present, renders a bulleted list below the provider result row showing the multiplier and reason for each risk factor
- Only shown for the maxmind provider; silently omitted when the field is absent (low-risk transactions)

## Test plan

- [ ] Open an evaluation detail page for a high-risk user (score in REVIEW or DEACTIVATE range)
- [ ] Confirm risk reasons appear below the MaxMind provider row with multiplier and description
- [ ] Open an evaluation for a low-risk user and confirm no reasons are shown