### PR TITLE
feat(user): Surface MaxMind signals on user detail page

### DIFF
--- a/app/features/fraud/detail/maxmind-rows.tsx
+++ b/app/features/fraud/detail/maxmind-rows.tsx
@@ -1,0 +1,275 @@
+import type { MaxmindInsights } from './maxmind';
+import { BadgeState } from '@/components/badge';
+import { ButtonCopy } from '@/components/button';
+import { DateTime } from '@/components/date';
+import type { DescriptionListItem } from '@/components/description-list';
+import { LinkButton } from '@datum-cloud/datum-ui/button';
+import { Text } from '@datum-cloud/datum-ui/typography';
+import { cn } from '@datum-cloud/datum-ui/utils';
+import { Trans } from '@lingui/react/macro';
+import { ExternalLinkIcon } from 'lucide-react';
+
+function ipRiskColor(score: number | undefined): string {
+  if (score == null) return '';
+  if (score >= 75) return 'text-red-600 dark:text-red-400';
+  if (score >= 25) return 'text-yellow-600 dark:text-yellow-400';
+  return 'text-green-600 dark:text-green-400';
+}
+
+// MaxMind reports common datacentre / proxy categories under user_type. We
+// flag those visually so staff don't have to memorise the list.
+const ELEVATED_USER_TYPES = new Set([
+  'hosting',
+  'cellular',
+  'traveler',
+  'business',
+  'dialup',
+  'public',
+  'school',
+  'router',
+]);
+
+function userTypeBadgeState(userType: string | undefined): string {
+  if (!userType) return 'unknown';
+  return ELEVATED_USER_TYPES.has(userType.toLowerCase()) ? 'warning' : 'info';
+}
+
+function formatLocation(insights: MaxmindInsights): string | null {
+  const ip = insights.ip_address;
+  const parts = [
+    ip?.city?.names?.en,
+    ip?.subdivisions?.[0]?.iso_code ?? ip?.subdivisions?.[0]?.names?.en,
+    ip?.country?.names?.en ?? ip?.country?.iso_code,
+  ].filter(Boolean);
+  return parts.length ? parts.join(', ') : null;
+}
+
+export interface MaxmindRowGroups {
+  network: DescriptionListItem[];
+  location: DescriptionListItem[];
+  email: DescriptionListItem[];
+}
+
+/**
+ * Build MaxMind signal rows split into three logical groups so callers can
+ * decide their own layout (two columns, separate cards, etc.). The function
+ * returns only data rows — the caller is responsible for rendering section
+ * titles (e.g. as a card header).
+ *
+ * Returns three empty arrays when there's nothing useful to show.
+ */
+export function buildMaxmindRowGroups(insights: MaxmindInsights | null): MaxmindRowGroups {
+  const empty: MaxmindRowGroups = { network: [], location: [], email: [] };
+  if (!insights) return empty;
+
+  const ip = insights.ip_address;
+  const traits = ip?.traits;
+  const location = ip?.location;
+  const email = insights.email;
+
+  const hasIpBlock =
+    !!traits?.ip_address ||
+    !!traits?.network ||
+    !!traits?.isp ||
+    !!traits?.organization ||
+    !!traits?.autonomous_system_number ||
+    !!traits?.connection_type ||
+    !!traits?.user_type ||
+    typeof ip?.risk === 'number';
+
+  const locationText = formatLocation(insights);
+  const hasLocationBlock =
+    !!locationText ||
+    !!ip?.postal?.code ||
+    typeof location?.latitude === 'number' ||
+    !!location?.time_zone ||
+    !!location?.local_time;
+
+  const hasEmailBlock =
+    !!traits?.domain || // ip-traits domain is the IP-side; email-side comes from email.domain
+    !!email?.domain?.classification ||
+    !!email?.first_seen ||
+    !!email?.domain?.first_seen ||
+    !!email?.is_disposable ||
+    !!email?.is_high_risk ||
+    !!email?.is_free ||
+    !!email?.domain?.visit?.has_redirect;
+
+  if (!hasIpBlock && !hasLocationBlock && !hasEmailBlock) return empty;
+
+  const network: DescriptionListItem[] = [];
+  const locationRows: DescriptionListItem[] = [];
+  const emailRows: DescriptionListItem[] = [];
+
+  // -------- IP & Network --------
+  if (hasIpBlock) {
+    network.push({
+      key: 'mm-ip-address',
+      label: <Trans>IP Address</Trans>,
+      value: traits?.ip_address ? (
+        <div className="flex items-center gap-2">
+          <Text className="font-mono">{traits.ip_address}</Text>
+          <ButtonCopy value={traits.ip_address} />
+        </div>
+      ) : null,
+      hidden: !traits?.ip_address,
+    });
+
+    network.push({
+      key: 'mm-network',
+      label: <Trans>Network</Trans>,
+      value: traits?.network ? <Text className="font-mono">{traits.network}</Text> : null,
+      hidden: !traits?.network,
+    });
+
+    const ispLine = traits?.isp ?? traits?.organization;
+    network.push({
+      key: 'mm-isp',
+      label: <Trans>ISP</Trans>,
+      value: ispLine ? <Text>{ispLine}</Text> : null,
+      hidden: !ispLine,
+    });
+
+    network.push({
+      key: 'mm-asn',
+      label: <Trans>ASN</Trans>,
+      value: traits?.autonomous_system_number ? (
+        <Text>
+          AS{traits.autonomous_system_number}
+          {traits.autonomous_system_organization
+            ? ` — ${traits.autonomous_system_organization}`
+            : ''}
+        </Text>
+      ) : null,
+      hidden: !traits?.autonomous_system_number,
+    });
+
+    network.push({
+      key: 'mm-connection',
+      label: <Trans>Connection</Trans>,
+      value: traits?.connection_type ? <Text>{traits.connection_type}</Text> : null,
+      hidden: !traits?.connection_type,
+    });
+
+    network.push({
+      key: 'mm-user-type',
+      label: <Trans>User Type</Trans>,
+      value: traits?.user_type ? (
+        <BadgeState state={userTypeBadgeState(traits.user_type)} message={traits.user_type} />
+      ) : null,
+      hidden: !traits?.user_type,
+    });
+
+    network.push({
+      key: 'mm-ip-risk',
+      label: <Trans>IP Risk</Trans>,
+      value:
+        typeof ip?.risk === 'number' ? (
+          <Text className={cn('font-mono font-medium', ipRiskColor(ip.risk))}>{ip.risk}</Text>
+        ) : null,
+      hidden: typeof ip?.risk !== 'number',
+    });
+  }
+
+  // -------- Location --------
+  if (hasLocationBlock) {
+    locationRows.push({
+      key: 'mm-location',
+      label: <Trans>Location</Trans>,
+      value: locationText ? <Text>{locationText}</Text> : null,
+      hidden: !locationText,
+    });
+
+    locationRows.push({
+      key: 'mm-postal',
+      label: <Trans>Postal Code</Trans>,
+      value: ip?.postal?.code ? <Text>{ip.postal.code}</Text> : null,
+      hidden: !ip?.postal?.code,
+    });
+
+    locationRows.push({
+      key: 'mm-coords',
+      label: <Trans>Coordinates</Trans>,
+      value:
+        typeof location?.latitude === 'number' && typeof location?.longitude === 'number' ? (
+          <LinkButton
+            href={`https://www.openstreetmap.org/?mlat=${location.latitude}&mlon=${location.longitude}#map=10/${location.latitude}/${location.longitude}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            theme="outline"
+            type="secondary"
+            size="xs"
+            icon={<ExternalLinkIcon size={14} />}
+            iconPosition="right">
+            {location.latitude.toFixed(4)}, {location.longitude.toFixed(4)}
+          </LinkButton>
+        ) : null,
+      hidden: typeof location?.latitude !== 'number' || typeof location?.longitude !== 'number',
+    });
+
+    locationRows.push({
+      key: 'mm-timezone',
+      label: <Trans>Timezone</Trans>,
+      value: location?.time_zone ? <Text>{location.time_zone}</Text> : null,
+      hidden: !location?.time_zone,
+    });
+
+    locationRows.push({
+      key: 'mm-local-time',
+      label: <Trans>Local Time</Trans>,
+      value: location?.local_time ? (
+        <Text>
+          <DateTime date={location.local_time} variant="both" />
+        </Text>
+      ) : null,
+      hidden: !location?.local_time,
+    });
+  }
+
+  // -------- Email domain --------
+  if (hasEmailBlock) {
+    // Render the email-side domain only when MaxMind returned the domain
+    // block. The IP-traits domain (`traits.domain`) is the network domain and
+    // doesn't belong here.
+    const domainName = traits?.domain ?? undefined;
+    emailRows.push({
+      key: 'mm-email-domain',
+      label: <Trans>Domain</Trans>,
+      value: domainName ? <Text>{domainName}</Text> : null,
+      hidden: !domainName,
+    });
+
+    emailRows.push({
+      key: 'mm-email-classification',
+      label: <Trans>Classification</Trans>,
+      value: email?.domain?.classification ? (
+        <BadgeState state={email.domain.classification} message={email.domain.classification} />
+      ) : null,
+      hidden: !email?.domain?.classification,
+    });
+
+    emailRows.push({
+      key: 'mm-email-first-seen',
+      label: <Trans>Email First Seen</Trans>,
+      value: email?.first_seen ? (
+        <Text>
+          <DateTime date={email.first_seen} variant="absolute" />
+        </Text>
+      ) : null,
+      hidden: !email?.first_seen,
+    });
+
+    emailRows.push({
+      key: 'mm-domain-first-seen',
+      label: <Trans>Domain First Seen</Trans>,
+      value: email?.domain?.first_seen ? (
+        <Text>
+          <DateTime date={email.domain.first_seen} variant="absolute" />
+        </Text>
+      ) : null,
+      hidden: !email?.domain?.first_seen,
+    });
+  }
+
+  return { network, location: locationRows, email: emailRows };
+}

--- a/app/features/fraud/detail/maxmind.test.ts
+++ b/app/features/fraud/detail/maxmind.test.ts
@@ -1,0 +1,213 @@
+import {
+  extractMaxmindInsights,
+  getMaxmindTransactionId,
+  parseMaxmindRawResponse,
+} from './maxmind';
+import type { FraudEvaluation } from './types';
+import { describe, expect, test } from 'vitest';
+
+const SAMPLE_RAW = JSON.stringify({
+  email: {
+    domain: {
+      first_seen: '2023-09-07',
+      classification: 'business',
+      volume: 0.091,
+      visit: {
+        status: 'live',
+        last_visited_on: '2026-04-13',
+        has_redirect: true,
+      },
+    },
+    first_seen: '2025-12-04',
+    is_disposable: false,
+    is_free: false,
+    is_high_risk: false,
+  },
+  ip_address: {
+    risk: 0.01,
+    country: { iso_code: 'US', names: { en: 'United States' } },
+    location: {
+      latitude: 36.3403,
+      longitude: -86.7195,
+      time_zone: 'America/Chicago',
+      local_time: '2026-04-27T15:45:34-05:00',
+    },
+    city: { names: { en: 'Goodlettsville' } },
+    postal: { code: '37072' },
+    subdivisions: [{ iso_code: 'TN', names: { en: 'Tennessee' } }],
+    traits: {
+      autonomous_system_number: 7018,
+      autonomous_system_organization: 'AT&T Enterprises, LLC',
+      connection_type: 'Cable/DSL',
+      domain: 'sbcglobal.net',
+      isp: 'AT&T Internet',
+      organization: 'AT&T Internet',
+      ip_address: '162.233.226.65',
+      network: '162.233.226.64/26',
+      user_type: 'residential',
+      static_ip_score: 60.8,
+    },
+  },
+  id: '6f55918d-3935-4525-a900-3ac3cd5201eb',
+  risk_score: 0.12,
+  funds_remaining: 3.955,
+  queries_remaining: 197,
+});
+
+function buildEvaluation(
+  stageResults: NonNullable<FraudEvaluation['status']>['stageResults']
+): FraudEvaluation {
+  return {
+    apiVersion: 'fraud.miloapis.com/v1alpha1',
+    kind: 'FraudEvaluation',
+    metadata: { name: 'eval-1' },
+    spec: {
+      userRef: { name: 'user-1' },
+      policyRef: { name: 'policy-1' },
+    },
+    status: {
+      stageResults,
+    },
+  } as FraudEvaluation;
+}
+
+describe('parseMaxmindRawResponse', () => {
+  test('returns null for undefined input', () => {
+    expect(parseMaxmindRawResponse(undefined)).toBeNull();
+  });
+
+  test('returns null for invalid JSON instead of throwing', () => {
+    expect(parseMaxmindRawResponse('{not json')).toBeNull();
+  });
+
+  test('parses a valid response into a typed shape', () => {
+    const parsed = parseMaxmindRawResponse(SAMPLE_RAW);
+    expect(parsed?.id).toBe('6f55918d-3935-4525-a900-3ac3cd5201eb');
+    expect(parsed?.ip_address?.traits?.ip_address).toBe('162.233.226.65');
+    expect(parsed?.email?.domain?.classification).toBe('business');
+  });
+
+  test('returns null for non-object JSON (e.g. a bare string)', () => {
+    expect(parseMaxmindRawResponse('"hello"')).toBeNull();
+  });
+});
+
+describe('extractMaxmindInsights', () => {
+  test('returns null when evaluation is undefined', () => {
+    expect(extractMaxmindInsights(undefined)).toBeNull();
+  });
+
+  test('returns null when evaluation has no stage results', () => {
+    expect(extractMaxmindInsights(buildEvaluation([]))).toBeNull();
+  });
+
+  test('extracts the maxmind raw response when present', () => {
+    const evaluation = buildEvaluation([
+      {
+        name: 'identity',
+        skipped: false,
+        providerResults: [{ provider: 'maxmind', score: '12', rawResponse: SAMPLE_RAW }],
+      },
+    ]);
+    const insights = extractMaxmindInsights(evaluation);
+    expect(insights?.ip_address?.traits?.isp).toBe('AT&T Internet');
+    expect(insights?.email?.first_seen).toBe('2025-12-04');
+  });
+
+  test('skips maxmind results that errored', () => {
+    const evaluation = buildEvaluation([
+      {
+        name: 'identity',
+        skipped: false,
+        providerResults: [
+          { provider: 'maxmind', score: '0', rawResponse: SAMPLE_RAW, error: 'timeout' },
+        ],
+      },
+    ]);
+    expect(extractMaxmindInsights(evaluation)).toBeNull();
+  });
+
+  test('skips maxmind results that fell back to a failure policy', () => {
+    const evaluation = buildEvaluation([
+      {
+        name: 'identity',
+        skipped: false,
+        providerResults: [
+          {
+            provider: 'maxmind',
+            score: '0',
+            rawResponse: SAMPLE_RAW,
+            failurePolicyApplied: 'FailOpen',
+          },
+        ],
+      },
+    ]);
+    expect(extractMaxmindInsights(evaluation)).toBeNull();
+  });
+
+  test('skips skipped stages and ignores non-maxmind providers', () => {
+    const evaluation = buildEvaluation([
+      {
+        name: 'pre-check',
+        skipped: true,
+        providerResults: [],
+      },
+      {
+        name: 'identity',
+        skipped: false,
+        providerResults: [
+          { provider: 'sift', score: '10', rawResponse: '{"foo":"bar"}' },
+          { provider: 'maxmind', score: '12', rawResponse: SAMPLE_RAW },
+        ],
+      },
+    ]);
+    const insights = extractMaxmindInsights(evaluation);
+    expect(insights?.id).toBe('6f55918d-3935-4525-a900-3ac3cd5201eb');
+  });
+
+  test('returns the latest maxmind result when more than one is present', () => {
+    const evaluation = buildEvaluation([
+      {
+        name: 'first',
+        skipped: false,
+        providerResults: [
+          {
+            provider: 'maxmind',
+            score: '5',
+            rawResponse: JSON.stringify({
+              id: 'older',
+              ip_address: { traits: { isp: 'Old ISP' } },
+            }),
+          },
+        ],
+      },
+      {
+        name: 'second',
+        skipped: false,
+        providerResults: [
+          {
+            provider: 'maxmind',
+            score: '12',
+            rawResponse: JSON.stringify({
+              id: 'newer',
+              ip_address: { traits: { isp: 'New ISP' } },
+            }),
+          },
+        ],
+      },
+    ]);
+    const insights = extractMaxmindInsights(evaluation);
+    expect(insights?.id).toBe('newer');
+    expect(insights?.ip_address?.traits?.isp).toBe('New ISP');
+  });
+});
+
+describe('getMaxmindTransactionId', () => {
+  test('returns the id from insights', () => {
+    expect(getMaxmindTransactionId({ id: 'tx-1' })).toBe('tx-1');
+  });
+
+  test('returns undefined for null insights', () => {
+    expect(getMaxmindTransactionId(null)).toBeUndefined();
+  });
+});

--- a/app/features/fraud/detail/maxmind.ts
+++ b/app/features/fraud/detail/maxmind.ts
@@ -1,0 +1,165 @@
+import type { FraudEvaluation, ProviderResult } from './types';
+
+/**
+ * Subset of the MaxMind minFraud Insights / Factors response that we surface
+ * in the staff portal. All fields are optional — MaxMind omits them freely
+ * depending on plan, request data, and what it could resolve.
+ *
+ * Reference shape provided by minFraud's JSON response.
+ */
+export type MaxmindLocalizedNames = Partial<{
+  en: string;
+  de: string;
+  es: string;
+  fr: string;
+  ja: string;
+  'pt-BR': string;
+  ru: string;
+  'zh-CN': string;
+}>;
+
+export type MaxmindCountry = Partial<{
+  is_high_risk: boolean;
+  confidence: number;
+  iso_code: string;
+  geoname_id: number;
+  names: MaxmindLocalizedNames;
+}>;
+
+export type MaxmindCity = Partial<{
+  confidence: number;
+  geoname_id: number;
+  names: MaxmindLocalizedNames;
+}>;
+
+export type MaxmindSubdivision = Partial<{
+  confidence: number;
+  iso_code: string;
+  geoname_id: number;
+  names: MaxmindLocalizedNames;
+}>;
+
+export type MaxmindPostal = Partial<{
+  confidence: number;
+  code: string;
+}>;
+
+export type MaxmindIpLocation = Partial<{
+  local_time: string;
+  average_income: number;
+  population_density: number;
+  accuracy_radius: number;
+  latitude: number;
+  longitude: number;
+  metro_code: number;
+  time_zone: string;
+}>;
+
+export type MaxmindIpTraits = Partial<{
+  static_ip_score: number;
+  user_type: string;
+  autonomous_system_number: number;
+  autonomous_system_organization: string;
+  connection_type: string;
+  domain: string;
+  isp: string;
+  organization: string;
+  ip_address: string;
+  network: string;
+}>;
+
+export type MaxmindIpAddress = Partial<{
+  risk: number;
+  country: MaxmindCountry;
+  registered_country: MaxmindCountry;
+  location: MaxmindIpLocation;
+  city: MaxmindCity;
+  continent: Partial<{ code: string; geoname_id: number; names: MaxmindLocalizedNames }>;
+  postal: MaxmindPostal;
+  subdivisions: MaxmindSubdivision[];
+  traits: MaxmindIpTraits;
+}>;
+
+export type MaxmindEmailDomainVisit = Partial<{
+  status: string;
+  last_visited_on: string;
+  has_redirect: boolean;
+}>;
+
+export type MaxmindEmailDomain = Partial<{
+  first_seen: string;
+  classification: string;
+  volume: number;
+  visit: MaxmindEmailDomainVisit;
+}>;
+
+export type MaxmindEmail = Partial<{
+  domain: MaxmindEmailDomain;
+  first_seen: string;
+  is_disposable: boolean;
+  is_free: boolean;
+  is_high_risk: boolean;
+}>;
+
+export type MaxmindRiskScoreReason = {
+  multiplier: number;
+  reasons: { code: string; reason: string }[];
+};
+
+export type MaxmindInsights = Partial<{
+  id: string;
+  risk_score: number;
+  risk_score_reasons: MaxmindRiskScoreReason[];
+  funds_remaining: number;
+  queries_remaining: number;
+  email: MaxmindEmail;
+  ip_address: MaxmindIpAddress;
+}>;
+
+const MAXMIND_PROVIDER = 'maxmind';
+
+function pickLatestMaxmindResult(evaluation: FraudEvaluation | undefined): ProviderResult | null {
+  const stages = evaluation?.status?.stageResults;
+  if (!stages?.length) return null;
+
+  // Walk in declared order; stages later in the pipeline overwrite earlier
+  // ones so the final retained result is the most recent successful maxmind call.
+  let latest: ProviderResult | null = null;
+  for (const stage of stages) {
+    if (stage.skipped || !stage.providerResults?.length) continue;
+    for (const result of stage.providerResults) {
+      if (result.provider !== MAXMIND_PROVIDER) continue;
+      if (result.error) continue;
+      if (result.failurePolicyApplied) continue;
+      if (!result.rawResponse) continue;
+      latest = result;
+    }
+  }
+  return latest;
+}
+
+export function parseMaxmindRawResponse(raw: string | undefined): MaxmindInsights | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as MaxmindInsights) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function extractMaxmindInsights(
+  evaluation: FraudEvaluation | undefined
+): MaxmindInsights | null {
+  const result = pickLatestMaxmindResult(evaluation);
+  return parseMaxmindRawResponse(result?.rawResponse);
+}
+
+/**
+ * MaxMind transaction id used to deep-link into the minFraud Interactive UI.
+ * Kept here so callers can build the deep-link URL without re-parsing the raw
+ * JSON.
+ */
+export function getMaxmindTransactionId(insights: MaxmindInsights | null): string | undefined {
+  return typeof insights?.id === 'string' ? insights.id : undefined;
+}

--- a/app/features/fraud/index.ts
+++ b/app/features/fraud/index.ts
@@ -1,3 +1,5 @@
 export * from './policy/policy-detail';
 export * from './policy/policy-form';
 export * from './detail/evaluation-sections';
+export * from './detail/maxmind';
+export * from './detail/maxmind-rows';

--- a/app/routes/user/detail/index.tsx
+++ b/app/routes/user/detail/index.tsx
@@ -8,6 +8,7 @@ import { DateTime } from '@/components/date';
 import { DescriptionList } from '@/components/description-list';
 import { DialogForm } from '@/components/dialog';
 import { PageHeader } from '@/components/page-header';
+import { buildMaxmindRowGroups, extractMaxmindInsights } from '@/features/fraud';
 import { UserRejectDialog, useUserApproval } from '@/features/user';
 import { useEnv } from '@/hooks';
 import { useApp } from '@/providers/app.provider';
@@ -35,11 +36,15 @@ import { Trans, useLingui } from '@lingui/react/macro';
 import {
   CheckIcon,
   ExternalLinkIcon,
+  Globe,
+  Mail,
+  MapPin,
   RotateCcw,
   Shield,
   ShieldAlert,
   ShieldCheckIcon,
   ShieldXIcon,
+  UserIcon,
   XIcon,
 } from 'lucide-react';
 import { useState } from 'react';
@@ -96,6 +101,8 @@ export default function Page() {
     data.metadata?.name ? { search: data.metadata.name } : undefined
   );
   const latestEval = fraudEvalData?.items?.[0];
+  const maxmindInsights = extractMaxmindInsights(latestEval);
+  const maxmindGroups = buildMaxmindRowGroups(maxmindInsights);
   const sentryIssuesUrl = getSentryIssuesUrl(env?.SENTRY_UI_URL, data?.metadata?.name ?? '');
 
   const handleDeleteUser = async () => {
@@ -227,120 +234,171 @@ export default function Page() {
           }
         />
 
-        <Card className="mt-4 shadow-none">
-          <CardContent>
-            <DescriptionList
-              items={[
-                {
-                  label: <Trans>ID</Trans>,
-                  value: (
-                    <div className="flex items-center gap-2">
-                      <Text>{data?.metadata?.name}</Text>
-                      <ButtonCopy value={data?.metadata?.name ?? ''} />
-                    </div>
-                  ),
-                },
-                {
-                  label: <Trans>Full Name</Trans>,
-                  value: (
-                    <Text>
-                      {data?.spec?.givenName} {data?.spec?.familyName}
-                    </Text>
-                  ),
-                },
-                {
-                  label: <Trans>Email</Trans>,
-                  value: <Text>{data?.spec?.email}</Text>,
-                },
-                {
-                  label: <Trans>Registration Approval</Trans>,
-                  value: <BadgeState state={data?.status?.registrationApproval ?? 'Unknown'} />,
-                },
-                {
-                  label: <Trans>Status</Trans>,
-                  value: <BadgeState state={data?.status?.state ?? 'Active'} />,
-                },
-                {
-                  label: <Trans>Created</Trans>,
-                  value: (
-                    <Text>
-                      <DateTime date={data?.metadata?.creationTimestamp} variant="both" />
-                    </Text>
-                  ),
-                },
-              ]}
-            />
-          </CardContent>
-        </Card>
+        <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2 md:[&>:last-child:nth-child(odd)]:col-span-2">
+          <Card className="shadow-none">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <UserIcon className="h-4 w-4" />
+                <Trans>User</Trans>
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <DescriptionList
+                labelWidth="40%"
+                items={[
+                  {
+                    label: <Trans>ID</Trans>,
+                    value: (
+                      <div className="flex items-center gap-2">
+                        <Text>{data?.metadata?.name}</Text>
+                        <ButtonCopy value={data?.metadata?.name ?? ''} />
+                      </div>
+                    ),
+                  },
+                  {
+                    label: <Trans>Full Name</Trans>,
+                    value: (
+                      <Text>
+                        {data?.spec?.givenName} {data?.spec?.familyName}
+                      </Text>
+                    ),
+                  },
+                  {
+                    label: <Trans>Email</Trans>,
+                    value: <Text>{data?.spec?.email}</Text>,
+                  },
+                  {
+                    label: <Trans>Registration Approval</Trans>,
+                    value: <BadgeState state={data?.status?.registrationApproval ?? 'Unknown'} />,
+                  },
+                  {
+                    label: <Trans>Status</Trans>,
+                    value: <BadgeState state={data?.status?.state ?? 'Active'} />,
+                  },
+                  {
+                    label: <Trans>Created</Trans>,
+                    value: (
+                      <Text>
+                        <DateTime date={data?.metadata?.creationTimestamp} variant="both" />
+                      </Text>
+                    ),
+                  },
+                ]}
+              />
+            </CardContent>
+          </Card>
 
-        <Card className="mt-4 shadow-none">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <ShieldAlert className="h-4 w-4" />
-              <Trans>Fraud Assessment</Trans>
-            </CardTitle>
-            <CardDescription>
-              <Trans>Latest fraud evaluation for this user</Trans>
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            {isFraudLoading ? (
-              <Text textColor="muted" size="sm">
-                <Trans>Loading...</Trans>
-              </Text>
-            ) : latestEval ? (
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-6">
-                  <div className="flex flex-col gap-1">
-                    <Text textColor="muted" size="sm">
-                      <Trans>Score</Trans>
-                    </Text>
-                    <span
-                      className={`font-mono text-2xl font-bold ${getScoreColor(latestEval.status?.decision)}`}>
-                      {latestEval.status?.compositeScore ?? '-'}
-                    </span>
+          {maxmindGroups.network.length > 0 && (
+            <Card className="shadow-none">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Globe className="h-4 w-4" />
+                  <Trans>IP & Network</Trans>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <DescriptionList labelWidth="40%" items={maxmindGroups.network} />
+              </CardContent>
+            </Card>
+          )}
+
+          {maxmindGroups.location.length > 0 && (
+            <Card className="shadow-none">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <MapPin className="h-4 w-4" />
+                  <Trans>Location</Trans>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <DescriptionList labelWidth="40%" items={maxmindGroups.location} />
+              </CardContent>
+            </Card>
+          )}
+
+          {maxmindGroups.email.length > 0 && (
+            <Card className="shadow-none">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Mail className="h-4 w-4" />
+                  <Trans>Email Domain</Trans>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <DescriptionList labelWidth="40%" items={maxmindGroups.email} />
+              </CardContent>
+            </Card>
+          )}
+
+          <Card className="shadow-none">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <ShieldAlert className="h-4 w-4" />
+                <Trans>Fraud Assessment</Trans>
+              </CardTitle>
+              <CardDescription>
+                <Trans>Latest fraud evaluation for this user</Trans>
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {isFraudLoading ? (
+                <Text textColor="muted" size="sm">
+                  <Trans>Loading...</Trans>
+                </Text>
+              ) : latestEval ? (
+                <div className="flex flex-wrap items-end justify-between gap-4">
+                  <div className="flex flex-wrap items-start gap-x-6 gap-y-3">
+                    <div className="flex flex-col gap-1">
+                      <Text textColor="muted" size="sm">
+                        <Trans>Score</Trans>
+                      </Text>
+                      <span
+                        className={`font-mono text-2xl font-bold ${getScoreColor(latestEval.status?.decision)}`}>
+                        {latestEval.status?.compositeScore ?? '-'}
+                      </span>
+                    </div>
+                    <div className="flex flex-col gap-1">
+                      <Text textColor="muted" size="sm">
+                        <Trans>Decision</Trans>
+                      </Text>
+                      <BadgeState
+                        state={
+                          latestEval.status?.decision === 'DEACTIVATE'
+                            ? 'error'
+                            : latestEval.status?.decision === 'REVIEW'
+                              ? 'warning'
+                              : 'pending'
+                        }
+                        message={latestEval.status?.decision ?? 'NONE'}
+                      />
+                    </div>
+                    <div className="flex flex-col gap-1">
+                      <Text textColor="muted" size="sm">
+                        <Trans>Last Evaluated</Trans>
+                      </Text>
+                      <Text size="sm">
+                        <DateTime date={latestEval.status?.lastEvaluationTime} variant="both" />
+                      </Text>
+                    </div>
                   </div>
-                  <div className="flex flex-col gap-1">
-                    <Text textColor="muted" size="sm">
-                      <Trans>Decision</Trans>
-                    </Text>
-                    <BadgeState
-                      state={
-                        latestEval.status?.decision === 'DEACTIVATE'
-                          ? 'error'
-                          : latestEval.status?.decision === 'REVIEW'
-                            ? 'warning'
-                            : 'pending'
-                      }
-                      message={latestEval.status?.decision ?? 'NONE'}
-                    />
-                  </div>
-                  <div className="flex flex-col gap-1">
-                    <Text textColor="muted" size="sm">
-                      <Trans>Last Evaluated</Trans>
-                    </Text>
-                    <Text size="sm">
-                      <DateTime date={latestEval.status?.lastEvaluationTime} variant="both" />
-                    </Text>
-                  </div>
+                  <Button
+                    theme="outline"
+                    size="small"
+                    icon={<ExternalLinkIcon size={16} />}
+                    onClick={() =>
+                      navigate(fraudRoutes.evaluations.detail(latestEval.metadata?.name ?? ''))
+                    }>
+                    <Trans>View Evaluation</Trans>
+                  </Button>
                 </div>
-                <Button
-                  theme="outline"
-                  size="small"
-                  icon={<ExternalLinkIcon size={16} />}
-                  onClick={() =>
-                    navigate(fraudRoutes.evaluations.detail(latestEval.metadata?.name ?? ''))
-                  }>
-                  <Trans>View Evaluation</Trans>
-                </Button>
-              </div>
-            ) : (
-              <Text textColor="muted" size="sm">
-                <Trans>No fraud evaluations found for this user.</Trans>
-              </Text>
-            )}
-          </CardContent>
-        </Card>
+              ) : (
+                <Text textColor="muted" size="sm">
+                  <Trans>No fraud evaluations found for this user.</Trans>
+                </Text>
+              )}
+            </CardContent>
+          </Card>
+        </div>
 
         <Card className="mt-4 shadow-none">
           <CardHeader>


### PR DESCRIPTION
## Summary

Staff currently have to click into a fraud evaluation and open *View Raw Results* to see the rich identity signals MaxMind returns (IP, ISP, ASN, geolocation, email-domain reputation). For approval and abuse triage that's one click too many — the data is already on each `FraudEvaluation`'s `status.stageResults[*].providerResults[*].rawResponse`, so this PR lifts the most useful fields onto the user detail page itself.

The user info area is now a responsive 2-column grid of up to five cards: **User**, **IP & Network**, **Location**, **Email Domain**, **Fraud Assessment**. Cards with no data are omitted; when the visible count is odd, the last card spans both columns via a CSS-only nth-child rule, so the grid stays balanced regardless of how much MaxMind data the latest evaluation contains.

Key behaviours:

- `extractMaxmindInsights` walks stage results and picks the most recent successful `maxmind` provider result. Errors and failure-policy fallbacks are skipped. All parsed fields are `Partial<>` since MaxMind omits fields freely.
- `buildMaxmindRowGroups` returns three independent `DescriptionListItem[]` arrays (network / location / email) so the page owns layout decisions.
- The Fraud Assessment card uses `flex-wrap` for its inner score / decision / last-evaluated row so the *View Evaluation* button reflows below the metrics when the card is half-width.
- Coordinates render as a small outline link to OpenStreetMap; the user-type badge highlights non-residential connection types (hosting, cellular, traveler, etc.).
- 13 unit tests cover the parser: full sample response, missing/invalid input, error/failure-policy skipping, non-maxmind providers, and "latest result wins" ordering.

No new network requests — the page already calls `useFraudEvaluationListQuery` for the existing Fraud Assessment summary; this just parses what comes back.

## Screenshots

<img width="1624" height="1061" alt="Screenshot 2026-05-01 at 16 52 39" src="https://github.com/user-attachments/assets/8fdc5da6-7f5f-4176-b60a-545d480f264c" />
