### PR TITLE
feat: surface user identities and sessions on staff user detail

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,7 @@
 NODE_ENV=development
 APP_URL=http://localhost:3000
 API_URL=https://api.staging.env.datum.net
+GRAPHQL_URL=https://graphql.staging.env.datum.net
 DEBUG=true
 VERSION=dev
 

--- a/app/features/user/components/user-identity-card.tsx
+++ b/app/features/user/components/user-identity-card.tsx
@@ -1,14 +1,22 @@
 import { IdentityItem } from './identity-item';
 import { IdentityItemSkeleton } from './identity-item-skeleton';
+import { DateTime } from '@/components/date';
 import GitHubIcon from '@/components/icon/github';
 import GoogleIcon from '@/components/icon/google';
 import { useEnv } from '@/hooks';
-import { useIdentityListQuery } from '@/resources/request/client';
+import { useIdentityListQuery, useSessionListEnrichedQuery } from '@/resources/request/client';
 import { LinkButton } from '@datum-cloud/datum-ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@datum-cloud/datum-ui/card';
 import { Tooltip } from '@datum-cloud/datum-ui/tooltip';
+import { Text } from '@datum-cloud/datum-ui/typography';
 import { Trans } from '@lingui/react/macro';
-import { CircleAlertIcon, ExternalLinkIcon, FingerprintPattern, MailIcon } from 'lucide-react';
+import {
+  CircleAlertIcon,
+  ExternalLinkIcon,
+  FingerprintPattern,
+  GlobeIcon,
+  MailIcon,
+} from 'lucide-react';
 import { ComponentType, SVGProps } from 'react';
 
 const PROVIDERS: Record<string, { label: string; Icon: ComponentType<SVGProps<SVGSVGElement>> }> = {
@@ -17,8 +25,22 @@ const PROVIDERS: Record<string, { label: string; Icon: ComponentType<SVGProps<SV
   github: { label: 'GitHub', Icon: GitHubIcon },
 };
 
-export const UserIdentityCard = ({ userId }: { userId: string }) => {
+export const UserIdentityCard = ({
+  userId,
+  readOnly = false,
+  showSessions = false,
+}: {
+  userId: string;
+  readOnly?: boolean;
+  showSessions?: boolean;
+}) => {
   const { data: identities, isLoading: isLoadingIdentities } = useIdentityListQuery(userId);
+  const { data: sessionItems = [], isLoading: isLoadingSessions } = useSessionListEnrichedQuery(
+    showSessions ? userId : ''
+  );
+  const sortedSessions = [...sessionItems].sort((a, b) =>
+    (b.createdAt ?? '').localeCompare(a.createdAt ?? '')
+  );
   const env = useEnv();
 
   return (
@@ -56,67 +78,114 @@ export const UserIdentityCard = ({ userId }: { userId: string }) => {
                     undefined
                   }
                   rightContent={
-                    <>
-                      {provider === 'github' && (
-                        <Tooltip
-                          message={
-                            <div className="flex flex-col gap-3.5 p-4">
-                              <h4 className="text-sm font-semibold">
-                                <Trans>Updating email addresses for GitHub identities</Trans>
-                              </h4>
-                              <p className="text-xs text-wrap">
-                                <Trans>
-                                  Email addresses for GitHub identities should be updated through
-                                  GitHub
-                                </Trans>
-                              </p>
-                              <ul className="list-outside list-decimal space-y-3.5 pl-4 text-xs text-wrap">
-                                <li>
-                                  <Trans>Log out of Datum</Trans>
-                                </li>
-                                <li>
+                    readOnly ? undefined : (
+                      <>
+                        {provider === 'github' && (
+                          <Tooltip
+                            message={
+                              <div className="flex flex-col gap-3.5 p-4">
+                                <h4 className="text-sm font-semibold">
+                                  <Trans>Updating email addresses for GitHub identities</Trans>
+                                </h4>
+                                <p className="text-xs text-wrap">
                                   <Trans>
-                                    Change your Primary Email in GitHub (your primary email)
+                                    Email addresses for GitHub identities should be updated through
+                                    GitHub
                                   </Trans>
-                                </li>
-                                <li>
-                                  <Trans>Log out of GitHub</Trans>
-                                </li>
-                                <li>
-                                  <Trans>
-                                    Log back into GitHub (with the new, desired email set as
-                                    primary)
-                                  </Trans>
-                                </li>
-                                <li>
-                                  <Trans>Log back into Datum</Trans>
-                                </li>
-                              </ul>
+                                </p>
+                                <ul className="list-outside list-decimal space-y-3.5 pl-4 text-xs text-wrap">
+                                  <li>
+                                    <Trans>Log out of Datum</Trans>
+                                  </li>
+                                  <li>
+                                    <Trans>
+                                      Change your Primary Email in GitHub (your primary email)
+                                    </Trans>
+                                  </li>
+                                  <li>
+                                    <Trans>Log out of GitHub</Trans>
+                                  </li>
+                                  <li>
+                                    <Trans>
+                                      Log back into GitHub (with the new, desired email set as
+                                      primary)
+                                    </Trans>
+                                  </li>
+                                  <li>
+                                    <Trans>Log back into Datum</Trans>
+                                  </li>
+                                </ul>
+                              </div>
+                            }>
+                            <div className="pointer flex cursor-pointer items-center gap-2.5">
+                              <CircleAlertIcon size={12} className="text-primary" />
+                              <span className="text-primary text-xs underline">
+                                <Trans>How to update your GitHub email</Trans>
+                              </span>
                             </div>
-                          }>
-                          <div className="pointer flex cursor-pointer items-center gap-2.5">
-                            <CircleAlertIcon size={12} className="text-primary" />
-                            <span className="text-primary text-xs underline">
-                              <Trans>How to update your GitHub email</Trans>
-                            </span>
-                          </div>
-                        </Tooltip>
-                      )}
-                      <LinkButton
-                        href={`${env?.AUTH_OIDC_ISSUER}/ui/v2/login/idp/link`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        theme="outline"
-                        size="small"
-                        icon={<ExternalLinkIcon size={12} />}
-                        iconPosition="right">
-                        <Trans>Manage</Trans>
-                      </LinkButton>
-                    </>
+                          </Tooltip>
+                        )}
+                        <LinkButton
+                          href={`${env?.AUTH_OIDC_ISSUER}/ui/v2/login/idp/link`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          theme="outline"
+                          size="small"
+                          icon={<ExternalLinkIcon size={12} />}
+                          iconPosition="right">
+                          <Trans>Manage</Trans>
+                        </LinkButton>
+                      </>
+                    )
                   }
                 />
               );
             })}
+          </div>
+        )}
+
+        {showSessions && (
+          <div className="mt-6">
+            <Text size="sm" weight="medium" className="mb-3 block">
+              <Trans>Active Sessions</Trans>
+            </Text>
+            {isLoadingSessions ? (
+              <IdentityItemSkeleton count={1} showActions={false} />
+            ) : sessionItems.length === 0 ? (
+              <Text textColor="muted" size="sm">
+                <Trans>No active sessions.</Trans>
+              </Text>
+            ) : (
+              <div
+                // Cap visible rows at ~4 and scroll for the rest. Each
+                // IdentityItem is ~50px (size-[34px] icon + py-2), so
+                // max-h-[13rem] keeps the 5th+ row just out of view to
+                // hint there's more.
+                className="divide-stepper-line flex max-h-[13rem] flex-col divide-y overflow-y-auto pr-1">
+                {sortedSessions.map((session) => {
+                  const locationLabel = session.location?.formatted;
+                  const uaLabel = session.userAgent?.formatted;
+                  const sublabelParts = [uaLabel, locationLabel].filter(Boolean);
+                  return (
+                    <IdentityItem
+                      key={session.id}
+                      className="py-2"
+                      icon={<GlobeIcon className="size-3.5" />}
+                      label={session.ipAddress ?? 'Unknown IP'}
+                      sublabel={sublabelParts.length ? sublabelParts.join(' · ') : session.id}
+                      middleContent={
+                        session.createdAt ? (
+                          <span className="text-foreground/80 text-center text-xs">
+                            <Trans>Created</Trans>{' '}
+                            <DateTime date={session.createdAt} variant="relative" />
+                          </span>
+                        ) : undefined
+                      }
+                    />
+                  );
+                })}
+              </div>
+            )}
           </div>
         )}
       </CardContent>

--- a/app/modules/graphql/client.ts
+++ b/app/modules/graphql/client.ts
@@ -1,0 +1,42 @@
+/**
+ * Minimal browser-side GraphQL client for the staff portal.
+ *
+ * Talks to the Hono `/api/graphql` proxy which forwards to the
+ * graphql-gateway with the caller's bearer token. Returns the parsed
+ * `data` field or throws on transport / GraphQL errors.
+ *
+ * We deliberately skip a full client (urql/apollo) and codegen: staff
+ * portal only consumes one enrichment query today. If more queries
+ * land, lift the cloud-portal pattern at that point.
+ */
+
+const GRAPHQL_PROXY_URL = '/api/graphql';
+
+interface GraphQLResponse<T> {
+  data?: T;
+  errors?: Array<{ message: string }>;
+}
+
+export async function gqlRequest<T>(
+  query: string,
+  variables?: Record<string, unknown>
+): Promise<T> {
+  const response = await fetch(GRAPHQL_PROXY_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`GraphQL request failed: ${response.status} ${response.statusText}`);
+  }
+
+  const body = (await response.json()) as GraphQLResponse<T>;
+  if (body.errors?.length) {
+    throw new Error(body.errors.map((e) => e.message).join('; '));
+  }
+  if (body.data === undefined) {
+    throw new Error('GraphQL response missing data');
+  }
+  return body.data;
+}

--- a/app/modules/graphql/sessions.ts
+++ b/app/modules/graphql/sessions.ts
@@ -1,0 +1,64 @@
+import { gqlRequest } from './client';
+
+export interface ExtendedSession {
+  id: string;
+  userUID: string;
+  provider: string;
+  ipAddress: string | null;
+  fingerprintID: string | null;
+  createdAt: string;
+  lastUpdatedAt: string | null;
+  userAgent: {
+    browser: string | null;
+    os: string | null;
+    formatted: string;
+  } | null;
+  location: {
+    city: string | null;
+    country: string | null;
+    countryCode: string | null;
+    formatted: string;
+  } | null;
+}
+
+const SESSIONS_QUERY = /* GraphQL */ `
+  query Sessions($userID: ID) {
+    sessions(userID: $userID) {
+      id
+      userUID
+      provider
+      ipAddress
+      fingerprintID
+      createdAt
+      lastUpdatedAt
+      userAgent {
+        browser
+        os
+        formatted
+      }
+      location {
+        city
+        country
+        countryCode
+        formatted
+      }
+    }
+  }
+`;
+
+/**
+ * Lists sessions enriched with parsed user-agent and geolocation.
+ *
+ * When userID is omitted (or matches the caller's UID), returns the
+ * caller's own sessions. When it differs, the gateway forwards a
+ * status.userUID field selector and the auth-provider-zitadel REST
+ * handler authorizes the cross-user lookup via SubjectAccessReview
+ * against iam.miloapis.com/users/<userID>. Callers without that
+ * permission get an empty list (the underlying 403 is logged).
+ */
+export async function listSessions(userID?: string): Promise<ExtendedSession[]> {
+  const data = await gqlRequest<{ sessions: ExtendedSession[] }>(SESSIONS_QUERY, {
+    userID: userID ?? null,
+  });
+  return data.sessions;
+}

--- a/app/resources/request/client/apis/identity.api.ts
+++ b/app/resources/request/client/apis/identity.api.ts
@@ -6,13 +6,25 @@ import {
   listIdentityMiloapisComV1Alpha1UserIdentity,
 } from '@openapi/identity.miloapis.com/v1alpha1';
 
+// Cross-user lookups are gated server-side by a SAR against milo on
+// `get iam.miloapis.com/users/<userId>`. When userId equals the caller's
+// own UID the selector is a no-op (handler short-circuits to self).
+const buildUserScopedFieldSelector = (userId: string, extra?: string): string => {
+  const parts = [`status.userUID=${userId}`];
+  if (extra) parts.push(extra);
+  return parts.join(',');
+};
+
 export const sessionListQuery = async (userId: string, params?: ListQueryParams) => {
   const response = await listIdentityMiloapisComV1Alpha1Session({
     baseURL: `${PROXY_URL}/apis/iam.miloapis.com/v1alpha1/users/${userId}/control-plane`,
     query: {
       ...(params?.limit && { limit: params.limit }),
       ...(params?.cursor && { continue: params.cursor }),
-      ...(params?.search && { fieldSelector: `metadata.name=${params.search}` }),
+      fieldSelector: buildUserScopedFieldSelector(
+        userId,
+        params?.search ? `metadata.name=${params.search}` : undefined
+      ),
     },
   });
   return response.data.data;
@@ -31,6 +43,7 @@ export const identityListQuery = async (userId: string, params?: ListQueryParams
     query: {
       ...(params?.limit && { limit: params.limit }),
       ...(params?.cursor && { continue: params.cursor }),
+      fieldSelector: buildUserScopedFieldSelector(userId),
     },
   });
 };

--- a/app/resources/request/client/queries/identity.queries.ts
+++ b/app/resources/request/client/queries/identity.queries.ts
@@ -1,5 +1,6 @@
 import { identityListQuery, sessionListQuery } from '../apis/identity.api';
 import { sessionDeleteMutation } from '../apis/identity.api';
+import { listSessions, type ExtendedSession } from '@/modules/graphql/sessions';
 import { ListQueryParams } from '@/resources/schemas';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
@@ -17,6 +18,21 @@ export const useSessionListQuery = (userId: string, params?: ListQueryParams) =>
   return useQuery({
     queryKey: sessionQueryKeys.list(userId, params),
     queryFn: () => sessionListQuery(userId, params),
+    enabled: Boolean(userId),
+    staleTime: 5 * 60 * 1000,
+  });
+};
+
+/**
+ * Sessions enriched with parsed user-agent and geolocation, served by
+ * the graphql-gateway. Use this where you want browser/OS/city info;
+ * use {@link useSessionListQuery} for the raw K8s shape (which still
+ * carries `metadata.creationTimestamp`, `status.expiresAt`, etc.).
+ */
+export const useSessionListEnrichedQuery = (userId: string) => {
+  return useQuery<ExtendedSession[]>({
+    queryKey: ['sessions', 'enriched', userId] as const,
+    queryFn: () => listSessions(userId),
     enabled: Boolean(userId),
     staleTime: 5 * 60 * 1000,
   });

--- a/app/routes/user/detail/index.tsx
+++ b/app/routes/user/detail/index.tsx
@@ -10,6 +10,7 @@ import { DialogForm } from '@/components/dialog';
 import { PageHeader } from '@/components/page-header';
 import { buildMaxmindRowGroups, extractMaxmindInsights } from '@/features/fraud';
 import { UserRejectDialog, useUserApproval } from '@/features/user';
+import { UserIdentityCard } from '@/features/user/components/user-identity-card';
 import { useEnv } from '@/hooks';
 import { useApp } from '@/providers/app.provider';
 import {
@@ -287,6 +288,8 @@ export default function Page() {
               />
             </CardContent>
           </Card>
+
+          <UserIdentityCard userId={data?.metadata?.name ?? ''} readOnly showSessions />
 
           {maxmindGroups.network.length > 0 && (
             <Card className="shadow-none">

--- a/app/server/routes/api.ts
+++ b/app/server/routes/api.ts
@@ -7,6 +7,7 @@ import { authMiddleware, getToken } from '@/server/middleware';
 import { createErrorResponse, createSuccessResponse } from '@/server/response';
 import { assistantRoutes } from '@/server/routes/assistant';
 import { clusterRoutes } from '@/server/routes/cluster';
+import { graphqlRoutes } from '@/server/routes/graphql';
 import { env } from '@/utils/config/env.server';
 import { captureApiError, createRequestLogger } from '@/utils/logger';
 import { Hono } from 'hono';
@@ -267,5 +268,6 @@ api.post('/metrics', authMiddleware(), async (c) => {
 
 api.route('/assistant', assistantRoutes);
 api.route('/cluster', clusterRoutes);
+api.route('/graphql', graphqlRoutes);
 
 export { api, API_BASENAME };

--- a/app/server/routes/graphql.ts
+++ b/app/server/routes/graphql.ts
@@ -1,0 +1,40 @@
+import { EnvVariables } from '@/server/iface';
+import { authMiddleware, getToken } from '@/server/middleware';
+import { env } from '@/utils/config/env.server';
+import { Hono } from 'hono';
+
+/**
+ * GraphQL proxy route. Forwards POST requests from the browser to the
+ * graphql-gateway with the caller's bearer token attached. Single global
+ * endpoint — staff-portal does not use the user/org/project scoped paths
+ * cloud-portal exposes.
+ */
+export const graphqlRoutes = new Hono<{ Variables: EnvVariables }>();
+
+graphqlRoutes.all('/', authMiddleware(), async (c) => {
+  const token = getToken(c);
+
+  const controller = new AbortController();
+  c.req.raw.signal?.addEventListener('abort', () => controller.abort());
+
+  try {
+    const response = await fetch(`${env.GRAPHQL_URL}/graphql`, {
+      method: c.req.method,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        'X-Request-ID': c.get('requestId') ?? '',
+      },
+      body: c.req.method !== 'GET' ? await c.req.text() : undefined,
+      signal: controller.signal,
+    });
+
+    const data = await response.json();
+    return c.json(data, response.status as 200);
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      return new Response(null, { status: 499 });
+    }
+    return c.json({ error: error instanceof Error ? error.message : 'Proxy error' }, 502);
+  }
+});

--- a/app/utils/config/env.server.ts
+++ b/app/utils/config/env.server.ts
@@ -5,6 +5,7 @@ const envSchema = z.object({
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
   APP_URL: z.url(),
   API_URL: z.url(),
+  GRAPHQL_URL: z.url(),
   AUTH_OIDC_ISSUER: z.url(),
   AUTH_OIDC_CLIENT_ID: z.string(),
   SESSION_SECRET: z.string().min(32),


### PR DESCRIPTION
## Summary

Adds a read-only **Account Identities** card to the staff user detail page so support staff can see which social providers a user has linked and the sessions they currently have active. Previously this information was only visible to the end user themselves on \`/profile/setting\`.

- \`UserIdentityCard\` gains \`readOnly\` and \`showSessions\` props. \`readOnly\` hides the per-identity *Manage* button and the GitHub-email tooltip (both end-user-facing). \`showSessions\` renders an *Active Sessions* list beneath the identities, sorted by \`createdAt\` desc and capped at ~4 visible rows with overflow scroll.
- \`identityListQuery\` + \`sessionListQuery\` now pass \`?fieldSelector=status.userUID=<userId>\` so the auth-provider-zitadel REST handler routes through its SAR-gated cross-user code path. For self-service callers this is a no-op (server short-circuits when target == caller).
- New \`useSessionListEnrichedQuery\` calls a new \`/api/graphql\` Hono proxy → graphql-gateway's \`sessions(userID)\` query. Returns sessions enriched with parsed user-agent (browser/OS) and geolocation (city/country) so staff see e.g. *Chrome on macOS · Mountain View, US* alongside the IP. \`/profile/session\` still uses the raw K8s shape for fields the gateway does not expose (\`status.expiresAt\`).
- Adds \`GRAPHQL_URL\` env var and a minimal \`fetch\`-based GraphQL client. No codegen yet — single query in flight; we can lift the cloud-portal \`@/modules/graphql\` + codegen pattern once more queries land.

<img width="1624" height="1061" alt="Screenshot 2026-05-11 at 10 56 42" src="https://github.com/user-attachments/assets/27c9cab2-dbd5-4646-89ab-3688e0c54f4b" />

## Related PRs

Cross-user identity/session lookups required parallel work across four other repos. All five PRs land together:

| Repo | PR | Purpose | Status |
| --- | --- | --- | --- |
| \`datum-cloud/zitadel-provider\` | [#108](https://github.com/datum-cloud/zitadel-provider/pull/108) | Re-register \`status.userUID\` field selector for \`UserIdentity\` in the auth-provider-zitadel apiserver scheme | ✅ Merged 2026-05-10 |
| \`datum-cloud/milo\` | [#608](https://github.com/datum-cloud/milo/pull/608) | Register \`status.userUID\` for \`UserIdentity\` in milo's host scheme + forward field selectors from the milo \`useridentities\` REST handler to the backend (was dropping them) | ✅ Merged 2026-05-10 |
| \`datum-cloud/graphql-gateway\` | [#33](https://github.com/datum-cloud/graphql-gateway/pull/33) | Extend \`Query.sessions\` with an optional \`userID\` argument, forwarded to milo as a \`status.userUID\` field selector | ✅ Merged 2026-05-11 |
| \`datum-cloud/infra\` | [#2411](https://github.com/datum-cloud/infra/pull/2411) | Wire \`GRAPHQL_URL\` to the internal \`graphql-gateway.graphql-gateway.svc\` and inject the CA trust bundle so the staff-portal pod can reach it over TLS | Open |
| \`datum-cloud/staff-portal\` | _this PR_ | Wire the UI + GraphQL client | — |

### Why four other repos?

The \`identity.miloapis.com\` API is not a pure aggregated API. Requests flow:

1. **milo host apiserver** owns the URL space and pre-validates field selectors against its own scheme; its REST handler decides whether selectors get forwarded.
2. **auth-provider-zitadel apiserver** is the backing handler — talks to Zitadel SDK, runs the SAR check against milo for cross-user lookups.
3. **graphql-gateway** wraps milo's session endpoint with user-agent + geolocation enrichment.
4. **infra** wires the staff-portal pod to the in-cluster gateway with the right CA trust.

A fix in any single layer alone wouldn't have worked — the April 29 cross-user PRs registered \`Session\` everywhere but deferred \`UserIdentity\`, so identities still 400'd at the milo aggregator until #608 + #108 both landed.

## Test plan

- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bunx prettier --check\` — clean
- [x] \`bunx eslint .\` — clean
- [x] \`bun run i18n:extract\` — no new strings to translate (all already in en.po / fr.po)
- [ ] Open the user detail page for a target user known to have a Google or GitHub identity → card shows the target user's IdPs (not the staff user's)
- [ ] Same page → active sessions list shows the target user's sessions enriched with browser/OS/location, capped at ~4 visible with scroll for more
- [ ] Open \`/profile/setting\` as a staff user → existing self-service card unchanged (Manage button still present, identities are the staff user's own)
- [ ] Verify a staff user without the \`iam.miloapis.com/users.get\` permission gets an empty list rather than a confusing error (negative case)