### PR TITLE
fix: drop shadow from Account Identities card on user detail page

### DIFF
--- a/app/features/user/components/user-identity-card.tsx
+++ b/app/features/user/components/user-identity-card.tsx
@@ -29,10 +29,12 @@ export const UserIdentityCard = ({
   userId,
   readOnly = false,
   showSessions = false,
+  className,
 }: {
   userId: string;
   readOnly?: boolean;
   showSessions?: boolean;
+  className?: string;
 }) => {
   const { data: identities, isLoading: isLoadingIdentities } = useIdentityListQuery(userId);
   const { data: sessionItems = [], isLoading: isLoadingSessions } = useSessionListEnrichedQuery(
@@ -44,7 +46,7 @@ export const UserIdentityCard = ({
   const env = useEnv();
 
   return (
-    <Card>
+    <Card className={className}>
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <FingerprintPattern className="h-4 w-4" />

--- a/app/routes/user/detail/index.tsx
+++ b/app/routes/user/detail/index.tsx
@@ -289,7 +289,12 @@ export default function Page() {
             </CardContent>
           </Card>
 
-          <UserIdentityCard userId={data?.metadata?.name ?? ''} readOnly showSessions />
+          <UserIdentityCard
+            userId={data?.metadata?.name ?? ''}
+            readOnly
+            showSessions
+            className="shadow-none"
+          />
 
           {maxmindGroups.network.length > 0 && (
             <Card className="shadow-none">


### PR DESCRIPTION
Every other card on the staff user detail page sets `shadow-none`, but `UserIdentityCard` (added in #457) used a bare `<Card>` and inherited the default shadow — visually inconsistent with the rest of the page.

Adds an optional `className` prop forwarded to the inner `<Card>`, and passes `shadow-none` from the user-detail mount point. `/profile/setting` (self-service) keeps the default shadow since that layout looks fine with it.

Follow-up to #457.