### PR TITLE
fix(usage): move usage panel from project to org level

### DIFF
--- a/app/routes.ts
+++ b/app/routes.ts
@@ -44,6 +44,7 @@ export default [
             route('grants', 'routes/organization/detail/quota/grant.tsx'),
             route('feature-flags', 'routes/organization/detail/quota/feature-flags.tsx'),
           ]),
+          route('usage', 'routes/organization/detail/usage/index.tsx'),
         ]),
       ]),
 
@@ -80,7 +81,6 @@ export default [
             route('grants', 'routes/project/detail/quota/grant.tsx'),
           ]),
           route('secrets', 'routes/project/detail/secret.tsx'),
-          route('usage', 'routes/project/detail/usage/index.tsx'),
         ]),
       ]),
     ]),

--- a/app/routes/organization/detail/layout.tsx
+++ b/app/routes/organization/detail/layout.tsx
@@ -8,7 +8,15 @@ import { orgRoutes } from '@/utils/config/routes.config';
 import { LinkButton } from '@datum-cloud/datum-ui/button';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { ComMiloapisResourcemanagerV1Alpha1Organization } from '@openapi/resourcemanager.miloapis.com/v1alpha1';
-import { CircleGauge, ExternalLink, FileText, Folders, SquareActivity, Users } from 'lucide-react';
+import {
+  BarChart3,
+  CircleGauge,
+  ExternalLink,
+  FileText,
+  Folders,
+  SquareActivity,
+  Users,
+} from 'lucide-react';
 import { useMemo } from 'react';
 import { Outlet, useLoaderData, useLocation } from 'react-router';
 
@@ -70,6 +78,11 @@ export default function Layout() {
       title: t`Members`,
       href: orgRoutes.member(orgName),
       icon: Users,
+    },
+    {
+      title: t`Usage`,
+      href: orgRoutes.usage(orgName),
+      icon: BarChart3,
     },
     {
       title: t`Quotas`,

--- a/app/routes/organization/detail/usage/index.tsx
+++ b/app/routes/organization/detail/usage/index.tsx
@@ -1,14 +1,10 @@
-import { getProjectDetailMetadata } from '../../shared';
+import { getOrganizationDetailMetadata } from '../../shared';
 import type { Route } from './+types/index';
 import { authenticator } from '@/modules/auth';
 import { getOrgControlPlaneBaseURL } from '@/resources/request/client/apis/control-plane';
-import { projectDetailQuery } from '@/resources/request/server';
 import { env } from '@/utils/config/env.server';
 import { metaObject } from '@/utils/helpers';
-import {
-  listBillingMiloapisComV1Alpha1NamespacedBillingAccountBinding,
-  readBillingMiloapisComV1Alpha1NamespacedBillingAccount,
-} from '@openapi/billing.miloapis.com/v1alpha1';
+import { listBillingMiloapisComV1Alpha1NamespacedBillingAccount } from '@openapi/billing.miloapis.com/v1alpha1';
 import { UnwrapProxyResponse } from '@openapi/shared/core/types.gen';
 import { format } from 'date-fns';
 import { BarChart3 } from 'lucide-react';
@@ -28,8 +24,8 @@ export const handle = {
 };
 
 export const meta: Route.MetaFunction = ({ matches }) => {
-  const { projectName } = getProjectDetailMetadata(matches);
-  return metaObject(`Usage - ${projectName}`);
+  const { organizationName } = getOrganizationDetailMetadata(matches);
+  return metaObject(`Usage - ${organizationName}`);
 };
 
 interface MeterSeries {
@@ -39,7 +35,10 @@ interface MeterSeries {
 }
 
 interface MeterDefinition {
-  meterName: string;
+  // Amberflo meterApiName, which the amberflo-provider sets to the
+  // MeterDefinition's metadata.uid (not spec.meterName) for charset/length
+  // safety. See milo-os/amberflo-provider meterdefinition_controller.go.
+  meterApiName: string;
   displayName: string;
 }
 
@@ -56,15 +55,18 @@ async function listMeterDefinitions(token: string): Promise<MeterDefinition[]> {
     });
     if (!resp.ok) return [];
     const json = (await resp.json()) as {
-      items?: { spec?: { meterName?: string; displayName?: string } }[];
+      items?: {
+        metadata?: { uid?: string };
+        spec?: { meterName?: string; displayName?: string };
+      }[];
     };
     const items = json.items ?? [];
     return items
       .map((item) => ({
-        meterName: item.spec?.meterName ?? '',
+        meterApiName: item.metadata?.uid ?? '',
         displayName: item.spec?.displayName ?? item.spec?.meterName ?? '',
       }))
-      .filter((m) => m.meterName);
+      .filter((m) => m.meterApiName);
   } catch {
     return [];
   }
@@ -74,21 +76,11 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
   const session = await authenticator.getSession(request);
   const token = session?.accessToken ?? '';
 
-  // Resolve the org name via the parent layout's pre-fetched project data.
-  // We have projectName from params; we read the project to get its ownerRef.
-  const projectName = params.projectName;
-  if (!projectName) {
-    return data({ status: 'unconfigured' as const, meters: [] });
-  }
-
-  const project = await projectDetailQuery(token, projectName);
-  const orgName = project?.spec?.ownerRef?.name;
-
+  const orgName = params.orgName;
   if (!orgName) {
     return data({ status: 'unconfigured' as const, meters: [] });
   }
 
-  // Gate: if AMBERFLO_API_KEY is not configured, tell the operator rather than crash.
   const apiKey = env.amberfloApiKey;
   if (!apiKey) {
     return data({ status: 'unconfigured' as const, meters: [] });
@@ -97,11 +89,12 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
   const orgNamespace = `organization-${orgName}`;
   const orgBaseURL = getOrgControlPlaneBaseURL(orgName);
 
-  // List BillingAccountBindings in the org namespace, filtered by projectRef.name.
-  // 401/403 means staff principal lacks billing IAM grants — show a clear state.
-  let bindingsResp;
+  // List BillingAccounts in the org namespace. Every account in the org rolls
+  // up here since the Amberflo data only carries customerId (= account uid);
+  // there is no per-project dimension on submitted events today.
+  let accountsResp;
   try {
-    bindingsResp = await listBillingMiloapisComV1Alpha1NamespacedBillingAccountBinding({
+    accountsResp = await listBillingMiloapisComV1Alpha1NamespacedBillingAccount({
       baseURL: orgBaseURL,
       path: { namespace: orgNamespace },
       headers: {
@@ -116,88 +109,66 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
     throw err;
   }
 
-  const bindings = bindingsResp.data as unknown as UnwrapProxyResponse<typeof bindingsResp.data>;
-  const binding = bindings?.items?.find((b) => b.spec?.projectRef?.name === projectName);
+  const accounts = accountsResp.data as unknown as UnwrapProxyResponse<typeof accountsResp.data>;
+  const customerIds = (accounts?.items ?? [])
+    .map((a) => a.metadata?.uid)
+    .filter((uid): uid is string => !!uid);
 
-  if (!binding) {
+  if (customerIds.length === 0) {
     return data({ status: 'no-billing-account' as const, meters: [] });
   }
 
-  const billingAccountName = binding.spec?.billingAccountRef?.name;
-  if (!billingAccountName) {
-    return data({ status: 'no-billing-account' as const, meters: [] });
-  }
-
-  // Read the BillingAccount to get its uid (= Amberflo customerId).
-  let accountResp;
-  try {
-    accountResp = await readBillingMiloapisComV1Alpha1NamespacedBillingAccount({
-      baseURL: orgBaseURL,
-      path: { namespace: orgNamespace, name: billingAccountName },
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
-  } catch (err: unknown) {
-    const status = (err as { response?: { status?: number } })?.response?.status;
-    if (status === 401 || status === 403) {
-      return data({ status: 'insufficient-permissions' as const, meters: [] });
-    }
-    throw err;
-  }
-
-  const account = accountResp.data as unknown as UnwrapProxyResponse<typeof accountResp.data>;
-  const customerId = account?.metadata?.uid;
-  if (!customerId) {
-    return data({ status: 'no-billing-account' as const, meters: [] });
-  }
-
-  // Discover meter definitions cluster-scoped from the billing API.
   const meterDefs = await listMeterDefinitions(token);
   if (meterDefs.length === 0) {
     return data({ status: 'no-meters' as const, meters: [] });
   }
 
-  // Fetch 30-day usage from Amberflo for each meter.
   const amberfloBaseUrl = env.amberfloBaseUrl;
   const nowSec = Math.floor(Date.now() / 1000);
   const startSec = nowSec - 30 * 24 * 3600;
 
   const meters = await Promise.all(
-    meterDefs.map(async ({ meterName, displayName }): Promise<MeterSeries> => {
+    meterDefs.map(async ({ meterApiName, displayName }): Promise<MeterSeries> => {
       try {
-        const resp = await fetch(`${amberfloBaseUrl}/usage/sparse`, {
+        const resp = await fetch(`${amberfloBaseUrl}/usage`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
             'x-api-key': apiKey,
           },
           body: JSON.stringify({
-            meterApiName: meterName,
+            meterApiName,
+            aggregation: 'sum',
+            timeGroupingInterval: 'day',
             timeRange: { startTimeInSeconds: startSec, endTimeInSeconds: nowSec },
-            filter: { customerId: [customerId] },
+            filter: { customerId: customerIds },
             groupBy: ['customerId'],
           }),
         });
 
         if (!resp.ok) {
-          return { meterApiName: meterName, label: displayName, values: [] };
+          return { meterApiName, label: displayName, values: [] };
         }
 
         const json = (await resp.json()) as {
           clientMeters?: { values?: { secondsSinceEpochUtc: number; value: number }[] }[];
         };
-        const raw = json.clientMeters?.[0]?.values ?? [];
-        return {
-          meterApiName: meterName,
-          label: displayName,
-          values: raw.map((v) => ({
-            timestamp: v.secondsSinceEpochUtc * 1000,
-            value: v.value,
-          })),
-        };
+        // Sum across all clientMeters (one per customerId group) per bucket.
+        const buckets = new Map<number, number>();
+        for (const cm of json.clientMeters ?? []) {
+          for (const v of cm.values ?? []) {
+            buckets.set(
+              v.secondsSinceEpochUtc,
+              (buckets.get(v.secondsSinceEpochUtc) ?? 0) + v.value
+            );
+          }
+        }
+        const values = [...buckets.entries()]
+          .sort(([a], [b]) => a - b)
+          .map(([ts, value]) => ({ timestamp: ts * 1000, value }));
+        return { meterApiName, label: displayName, values };
       } catch {
-        return { meterApiName: meterName, label: displayName, values: [] };
+        return { meterApiName, label: displayName, values: [] };
       }
     })
   );
@@ -278,8 +249,8 @@ export default function UsagePage() {
         };
       case 'no-billing-account':
         return {
-          title: 'No billing account linked',
-          body: 'This project does not have a billing account binding. A BillingAccountBinding must be created in the organization namespace before usage data is available.',
+          title: 'No billing account',
+          body: 'This organization does not have a billing account. Usage data is keyed to a billing account, so there is nothing to display.',
         };
       case 'no-meters':
         return {
@@ -290,7 +261,7 @@ export default function UsagePage() {
         if (result.meters.length === 0 || result.meters.every((m) => m.values.length === 0)) {
           return {
             title: 'No usage to display',
-            body: 'Usage data will appear here once this project starts consuming metered resources.',
+            body: 'Usage data will appear here once this organization starts consuming metered resources.',
           };
         }
         return null;

--- a/app/routes/project/detail/layout.tsx
+++ b/app/routes/project/detail/layout.tsx
@@ -17,7 +17,6 @@ import {
   ComMiloapisResourcemanagerV1Alpha1Project,
 } from '@openapi/resourcemanager.miloapis.com/v1alpha1';
 import {
-  BarChart3,
   ChartSpline,
   CircleGauge,
   ExternalLink,
@@ -150,11 +149,6 @@ export default function Layout() {
       title: t`Activity`,
       href: projectRoutes.activity.root(projectName),
       icon: SquareActivity,
-    },
-    {
-      title: t`Usage`,
-      href: projectRoutes.usage(projectName),
-      icon: BarChart3,
     },
     {
       title: t`Quotas`,

--- a/app/utils/config/routes.config.ts
+++ b/app/utils/config/routes.config.ts
@@ -27,6 +27,7 @@ export const orgRoutes = {
     grant: (orgName: string) => `/customers/organizations/${orgName}/quotas/grants`,
     featureFlags: (orgName: string) => `/customers/organizations/${orgName}/quotas/feature-flags`,
   },
+  usage: (orgName: string) => `/customers/organizations/${orgName}/usage`,
 } as const;
 
 // Projects feature routes
@@ -67,7 +68,6 @@ export const projectRoutes = {
     detail: (projectName: string, secretName: string) =>
       `/customers/projects/${projectName}/secrets/${secretName}`,
   },
-  usage: (projectName: string) => `/customers/projects/${projectName}/usage`,
 } as const;
 
 // Groups feature routes


### PR DESCRIPTION
## Summary

- Move the Usage panel from `/customers/projects/:projectName/usage` to `/customers/organizations/:orgName/usage`. Amberflo events are keyed to a BillingAccount (customerId) and carry no project dimension today, so the project-level page was always showing the billing account's aggregate — misleading.
- Fix `meterApiName`: amberflo-provider registers meters with `APIName: string(md.UID)`, not `spec.meterName`. The old value never matched any registered meter.
- Fix the request: use `/usage` with the required `aggregation: "sum"` and `timeGroupingInterval: "day"` fields. The previous `/usage/sparse` call omitted both, so Amberflo silently returned empty `clientMeters`.

Org loader lists all BillingAccounts in `organization-<orgName>` and queries Amberflo with every customerId, summing per-bucket so orgs with multiple billing accounts roll up correctly.

<img width="1808" height="938" alt="Screenshot From 2026-05-12 15-50-43" src="https://github.com/user-attachments/assets/ecf3559b-0b31-4eb2-b337-4fc15db7d5ff" />


## Test plan

- [x] Navigate to `/customers/organizations/the-other-org-l5ux2o/usage` and confirm charts populate (CPU/Memory Allocated/Seconds, Uptime) matching Amberflo dashboard.
- [x] Verify the panel is no longer reachable under any project URL.
- [x] Verify empty/permission/no-billing-account states still render reasonably.