### PR TITLE
chore(lefthook): unhang pre-commit, scope i18n, cache eslint

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,7 +4,7 @@ pre-commit:
     eslint:
       glob: '*.{js,jsx,ts,tsx}'
       exclude: '**/locales/**'
-      run: bunx eslint {staged_files} --fix
+      run: bunx eslint --cache --cache-location node_modules/.cache/eslint/ {staged_files} --fix
       auto_add: true
     prettier:
       glob: '*.{js,jsx,ts,tsx,json}'
@@ -12,5 +12,11 @@ pre-commit:
       run: bunx prettier --write {staged_files}
       auto_add: true
     i18n:
+      glob: 'app/**/*.{ts,tsx}'
+      env:
+        # Lingui's CLI emits a TTY spinner that, under lefthook's piped capture,
+        # spams cursor-control escapes until the buffer fills and the process
+        # appears to hang at 100% CPU. CI=1 disables the spinner.
+        CI: '1'
       run: bunx lingui extract --clean && bunx lingui compile --typescript && git add app/modules/i18n/locales/
       auto_add: true


### PR DESCRIPTION
## Summary

Pre-commit was hanging indefinitely at 100% CPU. Root cause: lingui's CLI emits a TTY spinner that, under lefthook's piped stdout capture, fails to detect non-TTY and spams cursor-control escapes until the buffer fills, backpressuring the process. (Captured 1.8 GB of escape codes from one stuck run.) Setting \`CI=1\` disables the spinner.

While here:
- Scope the i18n task to \`app/**/*.{ts,tsx}\` so it skips when no source files are staged (previously ran on every commit, even docs-only changes).
- Cache eslint results under \`node_modules/.cache/eslint\` to avoid cold-loading the TS program graph between consecutive invocations.

End-to-end pre-commit time: hangs forever → ~6.4 s.

## Test plan

- [x] Stage a TS file and commit — pre-commit completes in seconds.
- [x] Verify i18n still extracts/compiles when an \`app/\` source file changes.
- [ ] Verify i18n is skipped when only non-\`app/\` files are staged.