### PR TITLE
fix(activity): refresh project sources when filter selection changes

### DIFF
--- a/app/features/activity/components/MultiSourceActivityFeed.tsx
+++ b/app/features/activity/components/MultiSourceActivityFeed.tsx
@@ -390,17 +390,28 @@ function MultiSourceView({
 
   const projectSlots = [slot0, slot1, slot2, slot3, slot4, slot5, slot6, slot7, slot8, slot9];
 
-  // Auto-load on mount
+  // Auto-load on mount + whenever a project slot's client changes (user added
+  // a project via the Projects filter, or swapped one for another in the same
+  // slot). We track the previous client per slot so a no-op rerender doesn't
+  // re-fetch, but a null→client / clientA→clientB transition does.
   const hasMountedRef = useRef(false);
+  const prevProjectClientsRef = useRef<Array<ActivityApiClient | null>>(
+    Array.from({ length: MAX_PROJECTS }, () => null)
+  );
   useEffect(() => {
-    if (hasMountedRef.current) return;
-    hasMountedRef.current = true;
-    orgFeed.refresh();
-    projectSlots.forEach((slot, i) => {
-      if (projectClients[i] !== null) slot.refresh();
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      orgFeed.refresh();
+    }
+    projectClients.forEach((client, i) => {
+      const prev = prevProjectClientsRef.current[i];
+      if (client !== null && client !== prev) {
+        projectSlots[i].refresh();
+      }
     });
+    prevProjectClientsRef.current = projectClients;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [projectClients]);
 
   // Wrap setFilters/setTimeRange so a user-initiated change in the filter bar
   // (a) updates the org source, (b) fans the same value out to all active


### PR DESCRIPTION
## Summary

- Org Activity Feed only auto-loaded project sources captured at mount, so projects added via the Projects filter after page load were wired up but never fetched.
- Replace the mount-only effect with one that runs on `projectClients` changes and tracks the previous client per slot — so `refresh()` fires on any `null→client` or `clientA→clientB` transition.
- Reloading the page with `?projects=…` in the URL already worked (mount path); this fix makes the dynamic add/swap path behave the same.

## Test plan

- [x] Land on `/customers/organizations/<org>/activity` with no `?projects=` — auto-selected first project loads and its activities appear in the merged feed.
- [x] Add a second project via the Projects pill dropdown — URL updates to `?projects=first,second` AND the new project's activities appear without a page reload.
- [x] Swap a project: deselect one and select another in the same operation — the new project's activities replace the old one's.
- [x] Remove a project (deselect) — no spurious refetches; remaining sources keep their data.
- [x] Hard reload with `?projects=first,second&start=now-30d&changeSource=all` — both projects' activities still appear (existing behavior preserved).