### PR TITLE
feat(domain): add org-scoped Domains tab on organization detail

### DIFF
--- a/app/features/domain/hooks/useOrgDomainList.ts
+++ b/app/features/domain/hooks/useOrgDomainList.ts
@@ -1,0 +1,64 @@
+import type { DomainRow } from '../components/domain-list';
+import {
+  projectDomainListQuery,
+  projectQueryKeys,
+  useOrgProjectListQuery,
+} from '@/resources/request/client';
+import { useQueries } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+/**
+ * Aggregate the domains under every project an organization owns.
+ *
+ * Per #476: the search index doesn't carry org tenancy yet (only project),
+ * so we resolve this client-side — list the org's projects, then fan out
+ * one domain query per project and merge the results. The trade-off is
+ * O(n) requests per org load; per Kev on #476 that's acceptable while orgs
+ * have few projects. Once milo-os/search supports tagging resources with
+ * their org at index time, this hook can collapse to a single search call.
+ */
+export function useOrgDomainList(orgName: string): {
+  rows: DomainRow[];
+  isLoading: boolean;
+} {
+  const projectsQuery = useOrgProjectListQuery(orgName);
+
+  const projectNames = useMemo(
+    () =>
+      (projectsQuery.data?.items ?? [])
+        .map((project) => project.metadata?.name ?? '')
+        .filter((name): name is string => !!name),
+    [projectsQuery.data]
+  );
+
+  // Fan out one list query per project. Sharing the same query keys as the
+  // project-scoped Domains tab means visiting that tab later reuses these
+  // cache entries (and vice versa).
+  const domainQueries = useQueries({
+    queries: projectNames.map((projectName) => ({
+      queryKey: projectQueryKeys.domains.list(projectName),
+      queryFn: () => projectDomainListQuery(projectName),
+      staleTime: 5 * 60 * 1000,
+    })),
+  });
+
+  const rows = useMemo<DomainRow[]>(() => {
+    const out: DomainRow[] = [];
+    domainQueries.forEach((query, index) => {
+      const projectName = projectNames[index];
+      for (const domain of query.data?.items ?? []) {
+        out.push({ domain, projectName });
+      }
+    });
+    return out;
+  }, [domainQueries, projectNames]);
+
+  // Loading while we either still don't know the project set or any of the
+  // fan-out queries is in flight. An empty org (no projects) settles
+  // immediately on the empty array.
+  const isLoading =
+    projectsQuery.isLoading ||
+    (projectNames.length > 0 && domainQueries.some((query) => query.isLoading));
+
+  return { rows, isLoading };
+}

--- a/app/features/domain/index.ts
+++ b/app/features/domain/index.ts
@@ -1,4 +1,5 @@
 export * from './hooks/useDomainStatus';
+export * from './hooks/useOrgDomainList';
 export * from './components/domain-status-probe';
 export * from './components/domain-expiration';
 export * from './components/domain-dns-provider';

--- a/app/modules/i18n/locales/en.po
+++ b/app/modules/i18n/locales/en.po
@@ -121,7 +121,7 @@ msgstr "Active Sessions"
 #: app/components/app-search/use-app-search.ts:48
 #: app/components/app-sidebar/index.tsx:171
 #: app/routes/organization/detail/activity/index.tsx:8
-#: app/routes/organization/detail/layout.tsx:73
+#: app/routes/organization/detail/layout.tsx:79
 #: app/routes/project/detail/activity/index.tsx:14
 #: app/routes/project/detail/layout.tsx:149
 #: app/routes/user/detail/activity/index.tsx:23
@@ -865,6 +865,8 @@ msgstr "Domain verification is in progress. This may take a few minutes."
 #: app/components/app-sidebar/index.tsx:137
 #: app/routes/domain/index.tsx:10
 #: app/routes/domain/layout.tsx:5
+#: app/routes/organization/detail/domain.tsx:9
+#: app/routes/organization/detail/layout.tsx:74
 #: app/routes/project/detail/domain/layout.tsx:5
 #: app/routes/project/detail/layout.tsx:134
 msgid "Domains"
@@ -1098,7 +1100,7 @@ msgid "Feature flag enabled"
 msgstr "Feature flag enabled"
 
 #: app/routes/organization/detail/feature-flags.tsx:8
-#: app/routes/organization/detail/layout.tsx:103
+#: app/routes/organization/detail/layout.tsx:109
 msgid "Feature Flags"
 msgstr "Feature Flags"
 
@@ -1235,7 +1237,7 @@ msgstr "Go to dashboard"
 msgid "Grant deleted successfully"
 msgstr "Grant deleted successfully"
 
-#: app/routes/organization/detail/layout.tsx:97
+#: app/routes/organization/detail/layout.tsx:103
 #: app/routes/organization/detail/quota/grant.tsx:9
 #: app/routes/project/detail/layout.tsx:163
 #: app/routes/project/detail/quota/grant.tsx:12
@@ -1520,7 +1522,7 @@ msgstr "Member deleted successfully"
 
 #: app/routes/contact-group/detail/layout.tsx:39
 #: app/routes/contact-group/detail/member.tsx:34
-#: app/routes/organization/detail/layout.tsx:78
+#: app/routes/organization/detail/layout.tsx:84
 #: app/routes/organization/detail/member.tsx:25
 msgid "Members"
 msgstr "Members"
@@ -1815,7 +1817,7 @@ msgstr "Organization Type"
 msgid "Organizations"
 msgstr "Organizations"
 
-#: app/routes/organization/detail/layout.tsx:63
+#: app/routes/organization/detail/layout.tsx:64
 #: app/routes/project/detail/layout.tsx:119
 #: app/routes/user/detail/layout.tsx:32
 msgid "Overview"
@@ -1970,7 +1972,7 @@ msgstr "Project deleted successfully"
 #: app/components/app-search/use-app-search.ts:42
 #: app/components/app-sidebar/index.tsx:119
 #: app/routes/dashboard/index.tsx:75
-#: app/routes/organization/detail/layout.tsx:68
+#: app/routes/organization/detail/layout.tsx:69
 #: app/routes/organization/detail/project.tsx:17
 #: app/routes/project/detail/layout.tsx:57
 #: app/routes/project/index.tsx:16
@@ -2037,7 +2039,7 @@ msgstr "Quota updated successfully"
 msgid "Quota Utilization"
 msgstr "Quota Utilization"
 
-#: app/routes/organization/detail/layout.tsx:88
+#: app/routes/organization/detail/layout.tsx:94
 #: app/routes/organization/detail/quota/layout.tsx:5
 #: app/routes/project/detail/layout.tsx:154
 #: app/routes/project/detail/quota/layout.tsx:5
@@ -2597,8 +2599,8 @@ msgstr "Updating email addresses for GitHub identities"
 
 #: app/features/dashboard/components/quota-utilization-widget.tsx:161
 #: app/features/quota/components/quota-bucket-list.tsx:61
-#: app/routes/organization/detail/layout.tsx:83
-#: app/routes/organization/detail/layout.tsx:93
+#: app/routes/organization/detail/layout.tsx:89
+#: app/routes/organization/detail/layout.tsx:99
 #: app/routes/organization/detail/quota/usage.tsx:9
 #: app/routes/project/detail/layout.tsx:159
 #: app/routes/project/detail/quota/usage.tsx:12
@@ -2715,7 +2717,7 @@ msgstr "View contact groups"
 msgid "View Evaluation"
 msgstr "View Evaluation"
 
-#: app/routes/organization/detail/layout.tsx:122
+#: app/routes/organization/detail/layout.tsx:128
 #: app/routes/project/detail/layout.tsx:183
 msgid "View in Cloud Portal"
 msgstr "View in Cloud Portal"

--- a/app/modules/i18n/locales/fr.po
+++ b/app/modules/i18n/locales/fr.po
@@ -121,7 +121,7 @@ msgstr ""
 #: app/components/app-search/use-app-search.ts:48
 #: app/components/app-sidebar/index.tsx:171
 #: app/routes/organization/detail/activity/index.tsx:8
-#: app/routes/organization/detail/layout.tsx:73
+#: app/routes/organization/detail/layout.tsx:79
 #: app/routes/project/detail/activity/index.tsx:14
 #: app/routes/project/detail/layout.tsx:149
 #: app/routes/user/detail/activity/index.tsx:23
@@ -865,6 +865,8 @@ msgstr ""
 #: app/components/app-sidebar/index.tsx:137
 #: app/routes/domain/index.tsx:10
 #: app/routes/domain/layout.tsx:5
+#: app/routes/organization/detail/domain.tsx:9
+#: app/routes/organization/detail/layout.tsx:74
 #: app/routes/project/detail/domain/layout.tsx:5
 #: app/routes/project/detail/layout.tsx:134
 msgid "Domains"
@@ -1098,7 +1100,7 @@ msgid "Feature flag enabled"
 msgstr ""
 
 #: app/routes/organization/detail/feature-flags.tsx:8
-#: app/routes/organization/detail/layout.tsx:103
+#: app/routes/organization/detail/layout.tsx:109
 msgid "Feature Flags"
 msgstr ""
 
@@ -1235,7 +1237,7 @@ msgstr ""
 msgid "Grant deleted successfully"
 msgstr ""
 
-#: app/routes/organization/detail/layout.tsx:97
+#: app/routes/organization/detail/layout.tsx:103
 #: app/routes/organization/detail/quota/grant.tsx:9
 #: app/routes/project/detail/layout.tsx:163
 #: app/routes/project/detail/quota/grant.tsx:12
@@ -1520,7 +1522,7 @@ msgstr ""
 
 #: app/routes/contact-group/detail/layout.tsx:39
 #: app/routes/contact-group/detail/member.tsx:34
-#: app/routes/organization/detail/layout.tsx:78
+#: app/routes/organization/detail/layout.tsx:84
 #: app/routes/organization/detail/member.tsx:25
 msgid "Members"
 msgstr ""
@@ -1815,7 +1817,7 @@ msgstr ""
 msgid "Organizations"
 msgstr ""
 
-#: app/routes/organization/detail/layout.tsx:63
+#: app/routes/organization/detail/layout.tsx:64
 #: app/routes/project/detail/layout.tsx:119
 #: app/routes/user/detail/layout.tsx:32
 msgid "Overview"
@@ -1970,7 +1972,7 @@ msgstr ""
 #: app/components/app-search/use-app-search.ts:42
 #: app/components/app-sidebar/index.tsx:119
 #: app/routes/dashboard/index.tsx:75
-#: app/routes/organization/detail/layout.tsx:68
+#: app/routes/organization/detail/layout.tsx:69
 #: app/routes/organization/detail/project.tsx:17
 #: app/routes/project/detail/layout.tsx:57
 #: app/routes/project/index.tsx:16
@@ -2037,7 +2039,7 @@ msgstr ""
 msgid "Quota Utilization"
 msgstr ""
 
-#: app/routes/organization/detail/layout.tsx:88
+#: app/routes/organization/detail/layout.tsx:94
 #: app/routes/organization/detail/quota/layout.tsx:5
 #: app/routes/project/detail/layout.tsx:154
 #: app/routes/project/detail/quota/layout.tsx:5
@@ -2597,8 +2599,8 @@ msgstr ""
 
 #: app/features/dashboard/components/quota-utilization-widget.tsx:161
 #: app/features/quota/components/quota-bucket-list.tsx:61
-#: app/routes/organization/detail/layout.tsx:83
-#: app/routes/organization/detail/layout.tsx:93
+#: app/routes/organization/detail/layout.tsx:89
+#: app/routes/organization/detail/layout.tsx:99
 #: app/routes/organization/detail/quota/usage.tsx:9
 #: app/routes/project/detail/layout.tsx:159
 #: app/routes/project/detail/quota/usage.tsx:12
@@ -2715,7 +2717,7 @@ msgstr ""
 msgid "View Evaluation"
 msgstr ""
 
-#: app/routes/organization/detail/layout.tsx:122
+#: app/routes/organization/detail/layout.tsx:128
 #: app/routes/project/detail/layout.tsx:183
 msgid "View in Cloud Portal"
 msgstr ""

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -33,6 +33,7 @@ export default [
           index('routes/organization/detail/index.tsx'),
           route('members', 'routes/organization/detail/member.tsx'),
           route('projects', 'routes/organization/detail/project.tsx'),
+          route('domains', 'routes/organization/detail/domain.tsx'),
           route('activity', 'routes/organization/detail/activity/layout.tsx', [
             index('routes/organization/detail/activity/index.tsx'),
             route('events', 'routes/organization/detail/activity/events.tsx'),

--- a/app/routes/organization/detail/domain.tsx
+++ b/app/routes/organization/detail/domain.tsx
@@ -1,0 +1,36 @@
+import { getOrganizationDetailMetadata, useOrganizationDetailData } from '../shared';
+import type { Route } from './+types/domain';
+import { DomainList, useOrgDomainList } from '@/features/domain';
+import { projectRoutes } from '@/utils/config/routes.config';
+import { metaObject } from '@/utils/helpers';
+import { Trans } from '@lingui/react/macro';
+
+export const handle = {
+  breadcrumb: () => <Trans>Domains</Trans>,
+};
+
+export const meta: Route.MetaFunction = ({ matches }) => {
+  const { organizationName } = getOrganizationDetailMetadata(matches);
+  return metaObject(`Domains - ${organizationName}`);
+};
+
+export default function Page() {
+  const data = useOrganizationDetailData();
+  const orgName = data?.metadata?.name ?? '';
+  const { rows, isLoading } = useOrgDomainList(orgName);
+
+  return (
+    <DomainList
+      data={rows}
+      loading={isLoading}
+      showProjectColumn
+      linkBuilder={(row) =>
+        projectRoutes.domain.detail(
+          row.projectName,
+          row.domain.metadata?.namespace ?? '',
+          row.domain.metadata?.name ?? ''
+        )
+      }
+    />
+  );
+}

--- a/app/routes/organization/detail/layout.tsx
+++ b/app/routes/organization/detail/layout.tsx
@@ -15,6 +15,7 @@ import {
   FileText,
   Flag,
   Folders,
+  Layers,
   SquareActivity,
   Users,
 } from 'lucide-react';
@@ -68,6 +69,11 @@ export default function Layout() {
       title: t`Projects`,
       href: orgRoutes.project(orgName),
       icon: Folders,
+    },
+    {
+      title: t`Domains`,
+      href: orgRoutes.domain(orgName),
+      icon: Layers,
     },
     {
       title: t`Activity`,

--- a/app/utils/config/routes.config.ts
+++ b/app/utils/config/routes.config.ts
@@ -17,6 +17,7 @@ export const orgRoutes = {
   detail: (orgName: string) => `/customers/organizations/${orgName}`,
   project: (orgName: string) => `/customers/organizations/${orgName}/projects`,
   member: (orgName: string) => `/customers/organizations/${orgName}/members`,
+  domain: (orgName: string) => `/customers/organizations/${orgName}/domains`,
   activity: {
     root: (orgName: string) => `/customers/organizations/${orgName}/activity`,
     events: (orgName: string) => `/customers/organizations/${orgName}/activity/events`,


### PR DESCRIPTION
Adds a **Domains** tab to the org detail page listing every domain across every project the org owns. Reuses the shared `DomainList` (with `showProjectColumn`) so rows link back to each domain's project detail page.

Closes #476.

Per [Kev's call on #476](https://github.com/datum-cloud/staff-portal/issues/476#issuecomment-4549756731): the search index doesn't tag domains with their owning org yet, so this does the two-step lookup client-side — list the org's projects, then `useQueries` fans out one domain query per project and we merge results. O(n) requests per load, acceptable while orgs have few projects. New `useOrgDomainList` hook encapsulates the composition. Long-term fix (tag domains with org at index time) tracked on milo-os/search side; this hook collapses to a single search call once that lands.