### PR TITLE
feat(dns): add org-scoped DNS tab on organization detail

### DIFF
--- a/app/features/dns/hooks/useOrgDnsList.ts
+++ b/app/features/dns/hooks/useOrgDnsList.ts
@@ -1,0 +1,58 @@
+import type { DnsZoneRow } from '../components/dns-zone-list';
+import {
+  projectDnsListQuery,
+  projectQueryKeys,
+  useOrgProjectListQuery,
+} from '@/resources/request/client';
+import { useQueries } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+/**
+ * Aggregate the DNS zones under every project an organization owns.
+ *
+ * Per #489: the search index doesn't carry org tenancy yet (only project),
+ * so we resolve this client-side — list the org's projects, then fan out
+ * one DNS query per project and merge the results. Sharing the per-project
+ * query keys means the project-scoped DNS tab reuses these cache entries
+ * (and vice versa). Once milo-os/search supports tagging resources with
+ * their org at index time, this hook can collapse to a single search call.
+ */
+export function useOrgDnsList(orgName: string): {
+  rows: DnsZoneRow[];
+  isLoading: boolean;
+} {
+  const projectsQuery = useOrgProjectListQuery(orgName);
+
+  const projectNames = useMemo(
+    () =>
+      (projectsQuery.data?.items ?? [])
+        .map((project) => project.metadata?.name ?? '')
+        .filter((name): name is string => !!name),
+    [projectsQuery.data]
+  );
+
+  const dnsQueries = useQueries({
+    queries: projectNames.map((projectName) => ({
+      queryKey: projectQueryKeys.dns.list(projectName),
+      queryFn: () => projectDnsListQuery(projectName),
+      staleTime: 5 * 60 * 1000,
+    })),
+  });
+
+  const rows = useMemo<DnsZoneRow[]>(() => {
+    const out: DnsZoneRow[] = [];
+    dnsQueries.forEach((query, index) => {
+      const projectName = projectNames[index];
+      for (const dnsZone of query.data?.items ?? []) {
+        out.push({ dnsZone, projectName });
+      }
+    });
+    return out;
+  }, [dnsQueries, projectNames]);
+
+  const isLoading =
+    projectsQuery.isLoading ||
+    (projectNames.length > 0 && dnsQueries.some((query) => query.isLoading));
+
+  return { rows, isLoading };
+}

--- a/app/features/dns/index.ts
+++ b/app/features/dns/index.ts
@@ -2,3 +2,4 @@ export * from './components/dns-host-chips';
 export * from './components/dns-record-status-probe';
 export * from './components/dns-zone-list';
 export * from './hooks/useDnsRecordStatus';
+export * from './hooks/useOrgDnsList';

--- a/app/modules/i18n/locales/en.po
+++ b/app/modules/i18n/locales/en.po
@@ -121,7 +121,7 @@ msgstr "Active Sessions"
 #: app/components/app-search/use-app-search.ts:48
 #: app/components/app-sidebar/index.tsx:171
 #: app/routes/organization/detail/activity/index.tsx:8
-#: app/routes/organization/detail/layout.tsx:79
+#: app/routes/organization/detail/layout.tsx:85
 #: app/routes/project/detail/activity/index.tsx:14
 #: app/routes/project/detail/layout.tsx:149
 #: app/routes/user/detail/activity/index.tsx:23
@@ -800,6 +800,8 @@ msgstr "Display Name"
 msgid "Display name is required"
 msgstr "Display name is required"
 
+#: app/routes/organization/detail/dns.tsx:9
+#: app/routes/organization/detail/layout.tsx:80
 #: app/routes/project/detail/dns/layout.tsx:5
 #: app/routes/project/detail/layout.tsx:129
 msgid "DNS"
@@ -866,7 +868,7 @@ msgstr "Domain verification is in progress. This may take a few minutes."
 #: app/routes/domain/index.tsx:10
 #: app/routes/domain/layout.tsx:5
 #: app/routes/organization/detail/domain.tsx:9
-#: app/routes/organization/detail/layout.tsx:74
+#: app/routes/organization/detail/layout.tsx:75
 #: app/routes/project/detail/domain/layout.tsx:5
 #: app/routes/project/detail/layout.tsx:134
 msgid "Domains"
@@ -1100,7 +1102,7 @@ msgid "Feature flag enabled"
 msgstr "Feature flag enabled"
 
 #: app/routes/organization/detail/feature-flags.tsx:8
-#: app/routes/organization/detail/layout.tsx:109
+#: app/routes/organization/detail/layout.tsx:115
 msgid "Feature Flags"
 msgstr "Feature Flags"
 
@@ -1237,7 +1239,7 @@ msgstr "Go to dashboard"
 msgid "Grant deleted successfully"
 msgstr "Grant deleted successfully"
 
-#: app/routes/organization/detail/layout.tsx:103
+#: app/routes/organization/detail/layout.tsx:109
 #: app/routes/organization/detail/quota/grant.tsx:9
 #: app/routes/project/detail/layout.tsx:163
 #: app/routes/project/detail/quota/grant.tsx:12
@@ -1522,7 +1524,7 @@ msgstr "Member deleted successfully"
 
 #: app/routes/contact-group/detail/layout.tsx:39
 #: app/routes/contact-group/detail/member.tsx:34
-#: app/routes/organization/detail/layout.tsx:84
+#: app/routes/organization/detail/layout.tsx:90
 #: app/routes/organization/detail/member.tsx:25
 msgid "Members"
 msgstr "Members"
@@ -1817,7 +1819,7 @@ msgstr "Organization Type"
 msgid "Organizations"
 msgstr "Organizations"
 
-#: app/routes/organization/detail/layout.tsx:64
+#: app/routes/organization/detail/layout.tsx:65
 #: app/routes/project/detail/layout.tsx:119
 #: app/routes/user/detail/layout.tsx:32
 msgid "Overview"
@@ -1972,7 +1974,7 @@ msgstr "Project deleted successfully"
 #: app/components/app-search/use-app-search.ts:42
 #: app/components/app-sidebar/index.tsx:119
 #: app/routes/dashboard/index.tsx:75
-#: app/routes/organization/detail/layout.tsx:69
+#: app/routes/organization/detail/layout.tsx:70
 #: app/routes/organization/detail/project.tsx:17
 #: app/routes/project/detail/layout.tsx:57
 #: app/routes/project/index.tsx:16
@@ -2039,7 +2041,7 @@ msgstr "Quota updated successfully"
 msgid "Quota Utilization"
 msgstr "Quota Utilization"
 
-#: app/routes/organization/detail/layout.tsx:94
+#: app/routes/organization/detail/layout.tsx:100
 #: app/routes/organization/detail/quota/layout.tsx:5
 #: app/routes/project/detail/layout.tsx:154
 #: app/routes/project/detail/quota/layout.tsx:5
@@ -2599,8 +2601,8 @@ msgstr "Updating email addresses for GitHub identities"
 
 #: app/features/dashboard/components/quota-utilization-widget.tsx:161
 #: app/features/quota/components/quota-bucket-list.tsx:61
-#: app/routes/organization/detail/layout.tsx:89
-#: app/routes/organization/detail/layout.tsx:99
+#: app/routes/organization/detail/layout.tsx:95
+#: app/routes/organization/detail/layout.tsx:105
 #: app/routes/organization/detail/quota/usage.tsx:9
 #: app/routes/project/detail/layout.tsx:159
 #: app/routes/project/detail/quota/usage.tsx:12
@@ -2717,7 +2719,7 @@ msgstr "View contact groups"
 msgid "View Evaluation"
 msgstr "View Evaluation"
 
-#: app/routes/organization/detail/layout.tsx:128
+#: app/routes/organization/detail/layout.tsx:134
 #: app/routes/project/detail/layout.tsx:183
 msgid "View in Cloud Portal"
 msgstr "View in Cloud Portal"

--- a/app/modules/i18n/locales/fr.po
+++ b/app/modules/i18n/locales/fr.po
@@ -121,7 +121,7 @@ msgstr ""
 #: app/components/app-search/use-app-search.ts:48
 #: app/components/app-sidebar/index.tsx:171
 #: app/routes/organization/detail/activity/index.tsx:8
-#: app/routes/organization/detail/layout.tsx:79
+#: app/routes/organization/detail/layout.tsx:85
 #: app/routes/project/detail/activity/index.tsx:14
 #: app/routes/project/detail/layout.tsx:149
 #: app/routes/user/detail/activity/index.tsx:23
@@ -800,6 +800,8 @@ msgstr ""
 msgid "Display name is required"
 msgstr ""
 
+#: app/routes/organization/detail/dns.tsx:9
+#: app/routes/organization/detail/layout.tsx:80
 #: app/routes/project/detail/dns/layout.tsx:5
 #: app/routes/project/detail/layout.tsx:129
 msgid "DNS"
@@ -866,7 +868,7 @@ msgstr ""
 #: app/routes/domain/index.tsx:10
 #: app/routes/domain/layout.tsx:5
 #: app/routes/organization/detail/domain.tsx:9
-#: app/routes/organization/detail/layout.tsx:74
+#: app/routes/organization/detail/layout.tsx:75
 #: app/routes/project/detail/domain/layout.tsx:5
 #: app/routes/project/detail/layout.tsx:134
 msgid "Domains"
@@ -1100,7 +1102,7 @@ msgid "Feature flag enabled"
 msgstr ""
 
 #: app/routes/organization/detail/feature-flags.tsx:8
-#: app/routes/organization/detail/layout.tsx:109
+#: app/routes/organization/detail/layout.tsx:115
 msgid "Feature Flags"
 msgstr ""
 
@@ -1237,7 +1239,7 @@ msgstr ""
 msgid "Grant deleted successfully"
 msgstr ""
 
-#: app/routes/organization/detail/layout.tsx:103
+#: app/routes/organization/detail/layout.tsx:109
 #: app/routes/organization/detail/quota/grant.tsx:9
 #: app/routes/project/detail/layout.tsx:163
 #: app/routes/project/detail/quota/grant.tsx:12
@@ -1522,7 +1524,7 @@ msgstr ""
 
 #: app/routes/contact-group/detail/layout.tsx:39
 #: app/routes/contact-group/detail/member.tsx:34
-#: app/routes/organization/detail/layout.tsx:84
+#: app/routes/organization/detail/layout.tsx:90
 #: app/routes/organization/detail/member.tsx:25
 msgid "Members"
 msgstr ""
@@ -1817,7 +1819,7 @@ msgstr ""
 msgid "Organizations"
 msgstr ""
 
-#: app/routes/organization/detail/layout.tsx:64
+#: app/routes/organization/detail/layout.tsx:65
 #: app/routes/project/detail/layout.tsx:119
 #: app/routes/user/detail/layout.tsx:32
 msgid "Overview"
@@ -1972,7 +1974,7 @@ msgstr ""
 #: app/components/app-search/use-app-search.ts:42
 #: app/components/app-sidebar/index.tsx:119
 #: app/routes/dashboard/index.tsx:75
-#: app/routes/organization/detail/layout.tsx:69
+#: app/routes/organization/detail/layout.tsx:70
 #: app/routes/organization/detail/project.tsx:17
 #: app/routes/project/detail/layout.tsx:57
 #: app/routes/project/index.tsx:16
@@ -2039,7 +2041,7 @@ msgstr ""
 msgid "Quota Utilization"
 msgstr ""
 
-#: app/routes/organization/detail/layout.tsx:94
+#: app/routes/organization/detail/layout.tsx:100
 #: app/routes/organization/detail/quota/layout.tsx:5
 #: app/routes/project/detail/layout.tsx:154
 #: app/routes/project/detail/quota/layout.tsx:5
@@ -2599,8 +2601,8 @@ msgstr ""
 
 #: app/features/dashboard/components/quota-utilization-widget.tsx:161
 #: app/features/quota/components/quota-bucket-list.tsx:61
-#: app/routes/organization/detail/layout.tsx:89
-#: app/routes/organization/detail/layout.tsx:99
+#: app/routes/organization/detail/layout.tsx:95
+#: app/routes/organization/detail/layout.tsx:105
 #: app/routes/organization/detail/quota/usage.tsx:9
 #: app/routes/project/detail/layout.tsx:159
 #: app/routes/project/detail/quota/usage.tsx:12
@@ -2717,7 +2719,7 @@ msgstr ""
 msgid "View Evaluation"
 msgstr ""
 
-#: app/routes/organization/detail/layout.tsx:128
+#: app/routes/organization/detail/layout.tsx:134
 #: app/routes/project/detail/layout.tsx:183
 msgid "View in Cloud Portal"
 msgstr ""

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -34,6 +34,7 @@ export default [
           route('members', 'routes/organization/detail/member.tsx'),
           route('projects', 'routes/organization/detail/project.tsx'),
           route('domains', 'routes/organization/detail/domain.tsx'),
+          route('dns', 'routes/organization/detail/dns.tsx'),
           route('activity', 'routes/organization/detail/activity/layout.tsx', [
             index('routes/organization/detail/activity/index.tsx'),
             route('events', 'routes/organization/detail/activity/events.tsx'),

--- a/app/routes/organization/detail/dns.tsx
+++ b/app/routes/organization/detail/dns.tsx
@@ -1,0 +1,36 @@
+import { getOrganizationDetailMetadata, useOrganizationDetailData } from '../shared';
+import type { Route } from './+types/dns';
+import { DnsZoneList, useOrgDnsList } from '@/features/dns';
+import { projectRoutes } from '@/utils/config/routes.config';
+import { metaObject } from '@/utils/helpers';
+import { Trans } from '@lingui/react/macro';
+
+export const handle = {
+  breadcrumb: () => <Trans>DNS</Trans>,
+};
+
+export const meta: Route.MetaFunction = ({ matches }) => {
+  const { organizationName } = getOrganizationDetailMetadata(matches);
+  return metaObject(`DNS - ${organizationName}`);
+};
+
+export default function Page() {
+  const data = useOrganizationDetailData();
+  const orgName = data?.metadata?.name ?? '';
+  const { rows, isLoading } = useOrgDnsList(orgName);
+
+  return (
+    <DnsZoneList
+      data={rows}
+      loading={isLoading}
+      showProjectColumn
+      linkBuilder={(row) =>
+        projectRoutes.dns.detail(
+          row.projectName,
+          row.dnsZone.metadata?.namespace ?? '',
+          row.dnsZone.metadata?.name ?? ''
+        )
+      }
+    />
+  );
+}

--- a/app/routes/organization/detail/layout.tsx
+++ b/app/routes/organization/detail/layout.tsx
@@ -16,6 +16,7 @@ import {
   Flag,
   Folders,
   Layers,
+  Signpost,
   SquareActivity,
   Users,
 } from 'lucide-react';
@@ -74,6 +75,11 @@ export default function Layout() {
       title: t`Domains`,
       href: orgRoutes.domain(orgName),
       icon: Layers,
+    },
+    {
+      title: t`DNS`,
+      href: orgRoutes.dns(orgName),
+      icon: Signpost,
     },
     {
       title: t`Activity`,

--- a/app/utils/config/routes.config.ts
+++ b/app/utils/config/routes.config.ts
@@ -18,6 +18,7 @@ export const orgRoutes = {
   project: (orgName: string) => `/customers/organizations/${orgName}/projects`,
   member: (orgName: string) => `/customers/organizations/${orgName}/members`,
   domain: (orgName: string) => `/customers/organizations/${orgName}/domains`,
+  dns: (orgName: string) => `/customers/organizations/${orgName}/dns`,
   activity: {
     root: (orgName: string) => `/customers/organizations/${orgName}/activity`,
     events: (orgName: string) => `/customers/organizations/${orgName}/activity/events`,


### PR DESCRIPTION
Closes #489. Mirrors the Domains tab from #487.

## What's new
- New tab on the org detail page: lists DNS zones across every project in the org.
- New hook `useOrgDnsList(orgName)` — fans out per-project DNS queries via `useQueries` and merges them into rows.
- Reuses the existing `DnsZoneList` component with `showProjectColumn` on.

## Notes
- Shares the `projectQueryKeys.dns.list` keys with the project-scoped DNS tab, so cache is reused both ways.
- Nav order matches the main sidebar and project detail (DNS before Domains).
- Search-index org tenancy is still not wired, so this is client-side fan-out for now — same trade-off as #487. Collapses to a single search call when milo-os/search supports it.