### PR TITLE
feat(edge): add org-scoped AI Edge tab on organization detail

### DIFF
--- a/app/features/edge/hooks/useOrgEdgeList.ts
+++ b/app/features/edge/hooks/useOrgEdgeList.ts
@@ -1,0 +1,58 @@
+import type { EdgeRow } from '../components/edge-list';
+import {
+  projectEdgeListQuery,
+  projectQueryKeys,
+  useOrgProjectListQuery,
+} from '@/resources/request/client';
+import { useQueries } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+/**
+ * Aggregate the AI Edges under every project an organization owns.
+ *
+ * Per #490: the search index doesn't carry org tenancy yet (only project),
+ * so we resolve this client-side — list the org's projects, then fan out
+ * one edge query per project and merge the results. Sharing the per-project
+ * query keys means the project-scoped Edges tab reuses these cache entries
+ * (and vice versa). Once milo-os/search supports tagging resources with
+ * their org at index time, this hook can collapse to a single search call.
+ */
+export function useOrgEdgeList(orgName: string): {
+  rows: EdgeRow[];
+  isLoading: boolean;
+} {
+  const projectsQuery = useOrgProjectListQuery(orgName);
+
+  const projectNames = useMemo(
+    () =>
+      (projectsQuery.data?.items ?? [])
+        .map((project) => project.metadata?.name ?? '')
+        .filter((name): name is string => !!name),
+    [projectsQuery.data]
+  );
+
+  const edgeQueries = useQueries({
+    queries: projectNames.map((projectName) => ({
+      queryKey: projectQueryKeys.edges.list(projectName),
+      queryFn: () => projectEdgeListQuery(projectName),
+      staleTime: 5 * 60 * 1000,
+    })),
+  });
+
+  const rows = useMemo<EdgeRow[]>(() => {
+    const out: EdgeRow[] = [];
+    edgeQueries.forEach((query, index) => {
+      const projectName = projectNames[index];
+      for (const edge of query.data?.items ?? []) {
+        out.push({ edge, projectName });
+      }
+    });
+    return out;
+  }, [edgeQueries, projectNames]);
+
+  const isLoading =
+    projectsQuery.isLoading ||
+    (projectNames.length > 0 && edgeQueries.some((query) => query.isLoading));
+
+  return { rows, isLoading };
+}

--- a/app/features/edge/index.ts
+++ b/app/features/edge/index.ts
@@ -1,1 +1,2 @@
 export * from './components/edge-list';
+export * from './hooks/useOrgEdgeList';

--- a/app/modules/i18n/locales/en.po
+++ b/app/modules/i18n/locales/en.po
@@ -121,7 +121,7 @@ msgstr "Active Sessions"
 #: app/components/app-search/use-app-search.ts:48
 #: app/components/app-sidebar/index.tsx:171
 #: app/routes/organization/detail/activity/index.tsx:8
-#: app/routes/organization/detail/layout.tsx:85
+#: app/routes/organization/detail/layout.tsx:91
 #: app/routes/project/detail/activity/index.tsx:14
 #: app/routes/project/detail/layout.tsx:149
 #: app/routes/user/detail/activity/index.tsx:23
@@ -194,6 +194,8 @@ msgstr "Age"
 #: app/features/activity/components/activity-list.tsx:488
 #: app/routes/edge/index.tsx:10
 #: app/routes/edge/layout.tsx:5
+#: app/routes/organization/detail/edge.tsx:9
+#: app/routes/organization/detail/layout.tsx:76
 #: app/routes/project/detail/edge/layout.tsx:5
 #: app/routes/project/detail/layout.tsx:124
 msgid "AI Edge"
@@ -801,7 +803,7 @@ msgid "Display name is required"
 msgstr "Display name is required"
 
 #: app/routes/organization/detail/dns.tsx:9
-#: app/routes/organization/detail/layout.tsx:80
+#: app/routes/organization/detail/layout.tsx:81
 #: app/routes/project/detail/dns/layout.tsx:5
 #: app/routes/project/detail/layout.tsx:129
 msgid "DNS"
@@ -868,7 +870,7 @@ msgstr "Domain verification is in progress. This may take a few minutes."
 #: app/routes/domain/index.tsx:10
 #: app/routes/domain/layout.tsx:5
 #: app/routes/organization/detail/domain.tsx:9
-#: app/routes/organization/detail/layout.tsx:75
+#: app/routes/organization/detail/layout.tsx:86
 #: app/routes/project/detail/domain/layout.tsx:5
 #: app/routes/project/detail/layout.tsx:134
 msgid "Domains"
@@ -1102,7 +1104,7 @@ msgid "Feature flag enabled"
 msgstr "Feature flag enabled"
 
 #: app/routes/organization/detail/feature-flags.tsx:8
-#: app/routes/organization/detail/layout.tsx:115
+#: app/routes/organization/detail/layout.tsx:121
 msgid "Feature Flags"
 msgstr "Feature Flags"
 
@@ -1239,7 +1241,7 @@ msgstr "Go to dashboard"
 msgid "Grant deleted successfully"
 msgstr "Grant deleted successfully"
 
-#: app/routes/organization/detail/layout.tsx:109
+#: app/routes/organization/detail/layout.tsx:115
 #: app/routes/organization/detail/quota/grant.tsx:9
 #: app/routes/project/detail/layout.tsx:163
 #: app/routes/project/detail/quota/grant.tsx:12
@@ -1524,7 +1526,7 @@ msgstr "Member deleted successfully"
 
 #: app/routes/contact-group/detail/layout.tsx:39
 #: app/routes/contact-group/detail/member.tsx:34
-#: app/routes/organization/detail/layout.tsx:90
+#: app/routes/organization/detail/layout.tsx:96
 #: app/routes/organization/detail/member.tsx:25
 msgid "Members"
 msgstr "Members"
@@ -1819,7 +1821,7 @@ msgstr "Organization Type"
 msgid "Organizations"
 msgstr "Organizations"
 
-#: app/routes/organization/detail/layout.tsx:65
+#: app/routes/organization/detail/layout.tsx:66
 #: app/routes/project/detail/layout.tsx:119
 #: app/routes/user/detail/layout.tsx:32
 msgid "Overview"
@@ -1974,7 +1976,7 @@ msgstr "Project deleted successfully"
 #: app/components/app-search/use-app-search.ts:42
 #: app/components/app-sidebar/index.tsx:119
 #: app/routes/dashboard/index.tsx:75
-#: app/routes/organization/detail/layout.tsx:70
+#: app/routes/organization/detail/layout.tsx:71
 #: app/routes/organization/detail/project.tsx:17
 #: app/routes/project/detail/layout.tsx:57
 #: app/routes/project/index.tsx:16
@@ -2041,7 +2043,7 @@ msgstr "Quota updated successfully"
 msgid "Quota Utilization"
 msgstr "Quota Utilization"
 
-#: app/routes/organization/detail/layout.tsx:100
+#: app/routes/organization/detail/layout.tsx:106
 #: app/routes/organization/detail/quota/layout.tsx:5
 #: app/routes/project/detail/layout.tsx:154
 #: app/routes/project/detail/quota/layout.tsx:5
@@ -2601,8 +2603,8 @@ msgstr "Updating email addresses for GitHub identities"
 
 #: app/features/dashboard/components/quota-utilization-widget.tsx:161
 #: app/features/quota/components/quota-bucket-list.tsx:61
-#: app/routes/organization/detail/layout.tsx:95
-#: app/routes/organization/detail/layout.tsx:105
+#: app/routes/organization/detail/layout.tsx:101
+#: app/routes/organization/detail/layout.tsx:111
 #: app/routes/organization/detail/quota/usage.tsx:9
 #: app/routes/project/detail/layout.tsx:159
 #: app/routes/project/detail/quota/usage.tsx:12
@@ -2719,7 +2721,7 @@ msgstr "View contact groups"
 msgid "View Evaluation"
 msgstr "View Evaluation"
 
-#: app/routes/organization/detail/layout.tsx:134
+#: app/routes/organization/detail/layout.tsx:140
 #: app/routes/project/detail/layout.tsx:183
 msgid "View in Cloud Portal"
 msgstr "View in Cloud Portal"

--- a/app/modules/i18n/locales/fr.po
+++ b/app/modules/i18n/locales/fr.po
@@ -121,7 +121,7 @@ msgstr ""
 #: app/components/app-search/use-app-search.ts:48
 #: app/components/app-sidebar/index.tsx:171
 #: app/routes/organization/detail/activity/index.tsx:8
-#: app/routes/organization/detail/layout.tsx:85
+#: app/routes/organization/detail/layout.tsx:91
 #: app/routes/project/detail/activity/index.tsx:14
 #: app/routes/project/detail/layout.tsx:149
 #: app/routes/user/detail/activity/index.tsx:23
@@ -194,6 +194,8 @@ msgstr ""
 #: app/features/activity/components/activity-list.tsx:488
 #: app/routes/edge/index.tsx:10
 #: app/routes/edge/layout.tsx:5
+#: app/routes/organization/detail/edge.tsx:9
+#: app/routes/organization/detail/layout.tsx:76
 #: app/routes/project/detail/edge/layout.tsx:5
 #: app/routes/project/detail/layout.tsx:124
 msgid "AI Edge"
@@ -801,7 +803,7 @@ msgid "Display name is required"
 msgstr ""
 
 #: app/routes/organization/detail/dns.tsx:9
-#: app/routes/organization/detail/layout.tsx:80
+#: app/routes/organization/detail/layout.tsx:81
 #: app/routes/project/detail/dns/layout.tsx:5
 #: app/routes/project/detail/layout.tsx:129
 msgid "DNS"
@@ -868,7 +870,7 @@ msgstr ""
 #: app/routes/domain/index.tsx:10
 #: app/routes/domain/layout.tsx:5
 #: app/routes/organization/detail/domain.tsx:9
-#: app/routes/organization/detail/layout.tsx:75
+#: app/routes/organization/detail/layout.tsx:86
 #: app/routes/project/detail/domain/layout.tsx:5
 #: app/routes/project/detail/layout.tsx:134
 msgid "Domains"
@@ -1102,7 +1104,7 @@ msgid "Feature flag enabled"
 msgstr ""
 
 #: app/routes/organization/detail/feature-flags.tsx:8
-#: app/routes/organization/detail/layout.tsx:115
+#: app/routes/organization/detail/layout.tsx:121
 msgid "Feature Flags"
 msgstr ""
 
@@ -1239,7 +1241,7 @@ msgstr ""
 msgid "Grant deleted successfully"
 msgstr ""
 
-#: app/routes/organization/detail/layout.tsx:109
+#: app/routes/organization/detail/layout.tsx:115
 #: app/routes/organization/detail/quota/grant.tsx:9
 #: app/routes/project/detail/layout.tsx:163
 #: app/routes/project/detail/quota/grant.tsx:12
@@ -1524,7 +1526,7 @@ msgstr ""
 
 #: app/routes/contact-group/detail/layout.tsx:39
 #: app/routes/contact-group/detail/member.tsx:34
-#: app/routes/organization/detail/layout.tsx:90
+#: app/routes/organization/detail/layout.tsx:96
 #: app/routes/organization/detail/member.tsx:25
 msgid "Members"
 msgstr ""
@@ -1819,7 +1821,7 @@ msgstr ""
 msgid "Organizations"
 msgstr ""
 
-#: app/routes/organization/detail/layout.tsx:65
+#: app/routes/organization/detail/layout.tsx:66
 #: app/routes/project/detail/layout.tsx:119
 #: app/routes/user/detail/layout.tsx:32
 msgid "Overview"
@@ -1974,7 +1976,7 @@ msgstr ""
 #: app/components/app-search/use-app-search.ts:42
 #: app/components/app-sidebar/index.tsx:119
 #: app/routes/dashboard/index.tsx:75
-#: app/routes/organization/detail/layout.tsx:70
+#: app/routes/organization/detail/layout.tsx:71
 #: app/routes/organization/detail/project.tsx:17
 #: app/routes/project/detail/layout.tsx:57
 #: app/routes/project/index.tsx:16
@@ -2041,7 +2043,7 @@ msgstr ""
 msgid "Quota Utilization"
 msgstr ""
 
-#: app/routes/organization/detail/layout.tsx:100
+#: app/routes/organization/detail/layout.tsx:106
 #: app/routes/organization/detail/quota/layout.tsx:5
 #: app/routes/project/detail/layout.tsx:154
 #: app/routes/project/detail/quota/layout.tsx:5
@@ -2601,8 +2603,8 @@ msgstr ""
 
 #: app/features/dashboard/components/quota-utilization-widget.tsx:161
 #: app/features/quota/components/quota-bucket-list.tsx:61
-#: app/routes/organization/detail/layout.tsx:95
-#: app/routes/organization/detail/layout.tsx:105
+#: app/routes/organization/detail/layout.tsx:101
+#: app/routes/organization/detail/layout.tsx:111
 #: app/routes/organization/detail/quota/usage.tsx:9
 #: app/routes/project/detail/layout.tsx:159
 #: app/routes/project/detail/quota/usage.tsx:12
@@ -2719,7 +2721,7 @@ msgstr ""
 msgid "View Evaluation"
 msgstr ""
 
-#: app/routes/organization/detail/layout.tsx:134
+#: app/routes/organization/detail/layout.tsx:140
 #: app/routes/project/detail/layout.tsx:183
 msgid "View in Cloud Portal"
 msgstr ""

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -34,6 +34,7 @@ export default [
           route('members', 'routes/organization/detail/member.tsx'),
           route('projects', 'routes/organization/detail/project.tsx'),
           route('domains', 'routes/organization/detail/domain.tsx'),
+          route('edges', 'routes/organization/detail/edge.tsx'),
           route('dns', 'routes/organization/detail/dns.tsx'),
           route('activity', 'routes/organization/detail/activity/layout.tsx', [
             index('routes/organization/detail/activity/index.tsx'),

--- a/app/routes/organization/detail/edge.tsx
+++ b/app/routes/organization/detail/edge.tsx
@@ -1,0 +1,32 @@
+import { getOrganizationDetailMetadata, useOrganizationDetailData } from '../shared';
+import type { Route } from './+types/edge';
+import { EdgeList, useOrgEdgeList } from '@/features/edge';
+import { projectRoutes } from '@/utils/config/routes.config';
+import { metaObject } from '@/utils/helpers';
+import { Trans } from '@lingui/react/macro';
+
+export const handle = {
+  breadcrumb: () => <Trans>AI Edge</Trans>,
+};
+
+export const meta: Route.MetaFunction = ({ matches }) => {
+  const { organizationName } = getOrganizationDetailMetadata(matches);
+  return metaObject(`AI Edge - ${organizationName}`);
+};
+
+export default function Page() {
+  const data = useOrganizationDetailData();
+  const orgName = data?.metadata?.name ?? '';
+  const { rows, isLoading } = useOrgEdgeList(orgName);
+
+  return (
+    <EdgeList
+      data={rows}
+      loading={isLoading}
+      showProjectColumn
+      linkBuilder={(row) =>
+        projectRoutes.edge.detail(row.projectName, row.edge.metadata?.name ?? '')
+      }
+    />
+  );
+}

--- a/app/routes/organization/detail/layout.tsx
+++ b/app/routes/organization/detail/layout.tsx
@@ -15,6 +15,7 @@ import {
   FileText,
   Flag,
   Folders,
+  Gauge,
   Layers,
   Signpost,
   SquareActivity,
@@ -72,14 +73,19 @@ export default function Layout() {
       icon: Folders,
     },
     {
-      title: t`Domains`,
-      href: orgRoutes.domain(orgName),
-      icon: Layers,
+      title: t`AI Edge`,
+      href: orgRoutes.edge(orgName),
+      icon: Gauge,
     },
     {
       title: t`DNS`,
       href: orgRoutes.dns(orgName),
       icon: Signpost,
+    },
+    {
+      title: t`Domains`,
+      href: orgRoutes.domain(orgName),
+      icon: Layers,
     },
     {
       title: t`Activity`,

--- a/app/utils/config/routes.config.ts
+++ b/app/utils/config/routes.config.ts
@@ -18,6 +18,7 @@ export const orgRoutes = {
   project: (orgName: string) => `/customers/organizations/${orgName}/projects`,
   member: (orgName: string) => `/customers/organizations/${orgName}/members`,
   domain: (orgName: string) => `/customers/organizations/${orgName}/domains`,
+  edge: (orgName: string) => `/customers/organizations/${orgName}/edges`,
   dns: (orgName: string) => `/customers/organizations/${orgName}/dns`,
   activity: {
     root: (orgName: string) => `/customers/organizations/${orgName}/activity`,


### PR DESCRIPTION
Closes #490. Mirrors the Domains tab from #487 and the DNS tab from #491.

## What's new
- New tab on the org detail page: lists AI Edges across every project in the org.
- New hook `useOrgEdgeList(orgName)` — fans out per-project edge queries via `useQueries` and merges them into rows.
- Reuses the existing `EdgeList` component with `showProjectColumn` on.

## Notes
- Shares the `projectQueryKeys.edges.list` keys with the project-scoped Edges tab, so cache is reused both ways.
- Nav reordered to AI Edge → DNS → Domains to match the main sidebar / project detail order.
- Search-index org tenancy is still not wired, so this is client-side fan-out for now — same trade-off as #487 / #491. Collapses to a single search call when milo-os/search supports it.