### PR TITLE
feat(errors): humanize K8s API error messages before they reach toasts

### DIFF
--- a/app/modules/axios/axios.client.ts
+++ b/app/modules/axios/axios.client.ts
@@ -1,3 +1,4 @@
+import { parseK8sMessage } from '@/utils/errors';
 import { logger } from '@/utils/logger';
 import { captureApiError } from '@/utils/logger';
 import { toast } from '@datum-cloud/datum-ui/toast';
@@ -42,38 +43,46 @@ const onResponse = (response: AxiosResponse): AxiosResponse => {
 
 // Extract error message from response
 const getErrorMessage = (error: AxiosError): { message: string; requestId?: string } => {
+  let raw: { message: string; requestId?: string } | undefined;
+
   // Try to get error message from response data
   if (error.response?.data) {
     const data = error.response.data as any;
 
     // Handle different response data structures
     if (typeof data === 'string') {
-      return { message: data };
-    }
-
-    if (typeof data === 'object') {
+      raw = { message: data };
+    } else if (typeof data === 'object') {
       const requestId = data.requestId;
 
       // Common error response formats - prioritize 'error' field for your API format
-      if (data.error) return { message: data.error, requestId };
-      if (data.message) return { message: data.message, requestId };
-      if (data.detail) return { message: data.detail, requestId };
-      if (data.description) return { message: data.description, requestId };
-
-      // If it's an object with error details, try to extract meaningful message
-      const errorKeys = Object.keys(data).filter((key) =>
-        ['message', 'error', 'detail', 'description', 'reason', 'cause'].includes(key)
-      );
-      if (errorKeys.length > 0) {
-        return { message: data[errorKeys[0]], requestId };
+      if (data.error) raw = { message: data.error, requestId };
+      else if (data.message) raw = { message: data.message, requestId };
+      else if (data.detail) raw = { message: data.detail, requestId };
+      else if (data.description) raw = { message: data.description, requestId };
+      else {
+        // If it's an object with error details, try to extract meaningful message
+        const errorKeys = Object.keys(data).filter((key) =>
+          ['message', 'error', 'detail', 'description', 'reason', 'cause'].includes(key)
+        );
+        if (errorKeys.length > 0) {
+          raw = { message: data[errorKeys[0]], requestId };
+        }
       }
     }
   }
 
   // Fallback to status text or generic message
-  return {
-    message: error.response?.statusText || error.message || 'An unexpected error occurred',
-  };
+  if (!raw) {
+    raw = {
+      message: error.response?.statusText || error.message || 'An unexpected error occurred',
+    };
+  }
+
+  // Run K8s messages through the humanizer (strips admission-webhook
+  // prefixes, swaps internal plurals for display labels). Non-K8s messages
+  // pass through unchanged.
+  return { ...raw, message: parseK8sMessage(raw.message) };
 };
 
 const onResponseError = (error: AxiosError): Promise<AxiosError> => {

--- a/app/utils/errors/error-parser.test.ts
+++ b/app/utils/errors/error-parser.test.ts
@@ -1,0 +1,47 @@
+import { parseK8sMessage } from './error-parser';
+import { describe, expect, it } from 'vitest';
+
+describe('parseK8sMessage', () => {
+  it('returns empty for empty input', () => {
+    expect(parseK8sMessage('')).toBe('');
+  });
+
+  it('passes through a plain message unchanged', () => {
+    expect(parseK8sMessage('something went wrong')).toBe('something went wrong');
+  });
+
+  it('humanizes a standalone "not found" K8s path', () => {
+    expect(parseK8sMessage('dnszones.dns.networking.miloapis.com "example" not found')).toBe(
+      'DNS Zone "example" not found'
+    );
+  });
+
+  it('falls back to raw kind when label is unknown', () => {
+    expect(parseK8sMessage('widgets.example.com "x" not found')).toBe('widgets "x" not found');
+  });
+
+  it('strips admission webhook prefix and surfaces the deepest segment', () => {
+    const raw =
+      'admission webhook "vdomain-v1alpha.kb.io" denied the request: ' +
+      'domains.networking.miloapis.com "example" is invalid: ' +
+      'must be unique within the project';
+    expect(parseK8sMessage(raw)).toBe('Must be unique within the project');
+  });
+
+  it('humanizes nested "not found"', () => {
+    const raw =
+      'admission webhook "x" denied the request: ' +
+      'dnszones.dns.networking.miloapis.com "missing" not found';
+    expect(parseK8sMessage(raw)).toBe('DNS Zone "missing" not found');
+  });
+
+  it('handles plain conflict-style messages', () => {
+    expect(parseK8sMessage('contact already exists')).toBe('contact already exists');
+  });
+
+  it('uses AI Edge label for httpproxies', () => {
+    expect(parseK8sMessage('httpproxies.networking.miloapis.com "edge-1" not found')).toBe(
+      'AI Edge "edge-1" not found'
+    );
+  });
+});

--- a/app/utils/errors/error-parser.ts
+++ b/app/utils/errors/error-parser.ts
@@ -1,0 +1,71 @@
+import { getResourceLabel } from '@/utils/helpers/resource-labels';
+
+/**
+ * K8s resource path pattern: `group.api.com "name" is reason`
+ * Examples:
+ *   - projects.resourcemanager.miloapis.com "x" is forbidden
+ *   - domains.networking.miloapis.com "x" is invalid
+ */
+const K8S_RESOURCE_PATH_PATTERN = /^[\w.-]+\.[\w.-]+\.\w+ "[^"]+" (?:is \w+|not found)$/;
+
+/**
+ * Admission webhook prefix pattern.
+ * Example: admission webhook "vdomain-v1alpha.kb.io" denied the request
+ */
+const ADMISSION_WEBHOOK_PATTERN = /^admission webhook "[^"]+" denied the request$/;
+
+/**
+ * K8s "not found" single-segment pattern: `kind.group.api.com "name" not found`.
+ * Captures the resource kind (first segment) and the quoted resource name.
+ */
+const K8S_NOT_FOUND_PATTERN = /^(\w+)\.[\w.-]+ "([^"]+)" not found$/;
+
+function capitalize(str: string): string {
+  if (!str) return str;
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+/**
+ * Parse a raw K8s Status message into something a user can read.
+ *
+ * K8s messages are often nested with colon separators:
+ *   admission webhook "x" denied the request: kind.group.com "name" is reason: actual message
+ *
+ * This walks backwards through the colon-separated segments, skipping
+ * admission-webhook prefixes and K8s resource path segments, and returns
+ * the deepest meaningful segment. "not found" messages are humanized via
+ * the shared resource label map.
+ *
+ * Falls through unchanged for non-K8s messages.
+ */
+export function parseK8sMessage(raw: string): string {
+  if (!raw) return raw;
+
+  const segments = raw.split(': ');
+
+  if (segments.length === 1) {
+    const notFoundMatch = raw.match(K8S_NOT_FOUND_PATTERN);
+    if (notFoundMatch) {
+      const label = getResourceLabel(notFoundMatch[1]);
+      return `${label} "${notFoundMatch[2]}" not found`;
+    }
+    return raw;
+  }
+
+  for (let i = segments.length - 1; i >= 0; i--) {
+    const segment = segments[i].trim();
+
+    const notFoundMatch = segment.match(K8S_NOT_FOUND_PATTERN);
+    if (notFoundMatch) {
+      const label = getResourceLabel(notFoundMatch[1]);
+      return `${label} "${notFoundMatch[2]}" not found`;
+    }
+
+    if (K8S_RESOURCE_PATH_PATTERN.test(segment)) continue;
+    if (ADMISSION_WEBHOOK_PATTERN.test(segment)) continue;
+
+    return capitalize(segment);
+  }
+
+  return capitalize(segments[segments.length - 1].trim());
+}

--- a/app/utils/errors/index.ts
+++ b/app/utils/errors/index.ts
@@ -1,3 +1,4 @@
 export * from './base';
 export * from './auth';
 export * from './http';
+export * from './error-parser';

--- a/app/utils/helpers/resource-labels.ts
+++ b/app/utils/helpers/resource-labels.ts
@@ -1,0 +1,53 @@
+/**
+ * K8s resource kind (plural) → human-readable label.
+ *
+ * Used by the error message parser to humanize raw K8s Status messages
+ * like `dnszones.dns.networking.miloapis.com "x" not found` into
+ * `DNS Zone "x" not found`.
+ *
+ * Keep keys in lowercase plural form (matching the kind in K8s API paths).
+ */
+const RESOURCE_LABELS: Readonly<Record<string, string>> = Object.freeze({
+  // Organization-level
+  organizations: 'Organization',
+  users: 'User',
+  groups: 'Group',
+  roles: 'Role',
+  projects: 'Project',
+  invitations: 'Invitation',
+  members: 'Member',
+  policybindings: 'Role',
+
+  // Project-level
+  domains: 'Domain',
+  dnszones: 'DNS Zone',
+  dnsrecords: 'DNS Record',
+  dnsrecordsets: 'DNS Record Set',
+  dnszonediscoveries: 'DNS Zone Discovery',
+  httpproxies: 'AI Edge',
+  secrets: 'Secret',
+  exportpolicies: 'Export Policy',
+
+  // Contacts
+  contacts: 'Contact',
+  contactgroups: 'Contact Group',
+
+  // Quota & feature flags
+  resourceregistrations: 'Resource Registration',
+  resourcegrants: 'Resource Grant',
+  allowancebuckets: 'Allowance Bucket',
+
+  // Service catalog
+  services: 'Service',
+  serviceconfigurations: 'Service Configuration',
+  serviceconsumers: 'Service Consumer',
+  serviceentitlements: 'Service Entitlement',
+
+  // Fraud
+  fraudevaluations: 'Fraud Evaluation',
+  fraudpolicies: 'Fraud Policy',
+});
+
+export function getResourceLabel(resource: string): string {
+  return RESOURCE_LABELS[resource.toLowerCase()] ?? resource;
+}


### PR DESCRIPTION
First half of #494. The "validate before submit" half is intentionally out of scope here — leaving that for a separate decision (lookup vs dryRun, per the Slack thread).

## What changed
- New `parseK8sMessage()` (`app/utils/errors/error-parser.ts`) — strips admission-webhook prefixes and rewrites raw K8s resource paths into readable labels.
- New `getResourceLabel()` (`app/utils/helpers/resource-labels.ts`) — central registry of K8s plural → human label (e.g. `dnszones` → `DNS Zone`, `httpproxies` → `AI Edge`).
- Wired into the existing axios interceptor at `axios.client.ts:getErrorMessage()`. Single insertion point — every existing `toast.error(...)` call gets the cleaner message for free, no call-site changes.

## Before / after

| Raw K8s message | Toast now shows |
|---|---|
| `dnszones.dns.networking.miloapis.com "example" not found` | `DNS Zone "example" not found` |
| `admission webhook "x" denied the request: domains.networking.miloapis.com "y" is invalid: must be unique within the project` | `Must be unique within the project` |
| `httpproxies.networking.miloapis.com "edge-1" not found` | `AI Edge "edge-1" not found` |
| `contact already exists` *(plain message)* | `contact already exists` *(unchanged)* |

## Notes
- Ported from cloud-portal's `app/utils/errors/` layer. Same regex shape, trimmed to the pieces that matter for this repo.
- Resource label map is staff-portal-flavored: includes service catalog, fraud, quota/feature-flags kinds in addition to the cloud-portal set.
- Non-K8s messages pass through unchanged, so existing third-party / Zitadel / generic errors are unaffected.
- 8 unit tests covering the main shapes (empty, plain, not-found, webhook-wrapped, nested not-found, unknown kind fallback, conflict-style, AI Edge label).