### PR TITLE
fix(row-actions): render ActionItem icons as JSX to handle forwardRef

### DIFF
--- a/app/features/contact/components/contact-list.tsx
+++ b/app/features/contact/components/contact-list.tsx
@@ -49,14 +49,14 @@ export function ContactList({
   const actions: ActionItem<ComMiloapisNotificationV1Alpha1Contact>[] = [
     {
       label: t`Edit`,
-      icon: EditIcon,
+      icon: <EditIcon className="size-4" />,
       onClick: (row) => {
         navigate(contactRoutes.detail(row.metadata?.namespace ?? '', row.metadata?.name ?? ''));
       },
     },
     {
       label: t`Delete`,
-      icon: Trash2Icon,
+      icon: <Trash2Icon className="size-4" />,
       variant: 'destructive' as const,
       onClick: (row) => setSelectedContact(row),
     },

--- a/app/features/quota/components/quota-bucket-list.tsx
+++ b/app/features/quota/components/quota-bucket-list.tsx
@@ -45,7 +45,7 @@ export function QuotaBucketList({ queryKeyPrefix, fetchFn, createGrantFn }: Quot
   const actions: ActionItem<ComMiloapisQuotaV1Alpha1AllowanceBucket>[] = [
     {
       label: t`Edit Quota`,
-      icon: PencilIcon,
+      icon: <PencilIcon className="size-4" />,
       onClick: (row) => setSelected(row),
     },
   ];

--- a/app/features/quota/components/quota-grant-list.tsx
+++ b/app/features/quota/components/quota-grant-list.tsx
@@ -54,7 +54,7 @@ export function QuotaGrantList({ queryKeyPrefix, fetchFn, deleteGrantFn }: Quota
     () => [
       {
         label: tMacro`Delete`,
-        icon: Trash2Icon,
+        icon: <Trash2Icon className="size-4" />,
         variant: 'destructive' as const,
         onClick: (row) => setSelectedGrant(row),
         disabled: (row) => {

--- a/app/routes/contact-group/detail/member.tsx
+++ b/app/routes/contact-group/detail/member.tsx
@@ -161,7 +161,7 @@ export default function Page() {
   const actions: ActionItem<ContactGroupMembershipWithContact>[] = [
     {
       label: t`Delete`,
-      icon: Trash2Icon,
+      icon: <Trash2Icon className="size-4" />,
       variant: 'destructive' as const,
       onClick: (row) => setSelectedMembership(row),
     },

--- a/app/routes/contact-group/index.tsx
+++ b/app/routes/contact-group/index.tsx
@@ -49,12 +49,12 @@ export default function Page() {
   const actions: ActionItem<ComMiloapisNotificationV1Alpha1ContactGroup>[] = [
     {
       label: t`Edit`,
-      icon: EditIcon,
+      icon: <EditIcon className="size-4" />,
       onClick: (row) => navigate(contactGroupRoutes.detail(row.metadata?.name ?? '')),
     },
     {
       label: t`Delete`,
-      icon: Trash2Icon,
+      icon: <Trash2Icon className="size-4" />,
       variant: 'destructive' as const,
       onClick: (row) => setSelectedContactGroup(row),
     },

--- a/app/routes/contact/detail/group.tsx
+++ b/app/routes/contact/detail/group.tsx
@@ -70,7 +70,7 @@ export default function Page() {
   const actions: ActionItem<ContactMembershipWithContactGroup>[] = [
     {
       label: t`Delete`,
-      icon: Trash2Icon,
+      icon: <Trash2Icon className="size-4" />,
       variant: 'destructive' as const,
       onClick: (row) => setSelectedGroup(row),
     },

--- a/app/routes/fraud/index.tsx
+++ b/app/routes/fraud/index.tsx
@@ -96,7 +96,7 @@ export default function Page() {
   const actions: ActionItem<FraudEvaluation>[] = [
     {
       label: t`Delete`,
-      icon: Trash2Icon,
+      icon: <Trash2Icon className="size-4" />,
       variant: 'destructive' as const,
       onClick: (row) => setSelectedEval(row),
     },

--- a/app/routes/fraud/providers/index.tsx
+++ b/app/routes/fraud/providers/index.tsx
@@ -39,12 +39,12 @@ export default function Page() {
   const actions: ActionItem<FraudProvider>[] = [
     {
       label: t`Edit`,
-      icon: EditIcon,
+      icon: <EditIcon className="size-4" />,
       onClick: (row) => navigate(fraudRoutes.providers.detail(row.metadata?.name ?? '')),
     },
     {
       label: t`Delete`,
-      icon: Trash2Icon,
+      icon: <Trash2Icon className="size-4" />,
       variant: 'destructive' as const,
       onClick: (row) => setSelectedProvider(row),
     },

--- a/app/routes/group/member.tsx
+++ b/app/routes/group/member.tsx
@@ -93,7 +93,7 @@ export default function Page() {
   const actions: ActionItem<ComMiloapisIamV1Alpha1GroupMembership>[] = [
     {
       label: t`Delete`,
-      icon: Trash2Icon,
+      icon: <Trash2Icon className="size-4" />,
       variant: 'destructive' as const,
       onClick: (row) => setSelectedGroupMembership(row),
     },

--- a/app/routes/organization/detail/member.tsx
+++ b/app/routes/organization/detail/member.tsx
@@ -45,7 +45,7 @@ export default function Page() {
   const actions: ActionItem<TeamMember>[] = [
     {
       label: t`Resend`,
-      icon: MailIcon,
+      icon: <MailIcon className="size-4" />,
       hidden: (row) => row.invitationState !== 'Pending',
       onClick: async (row) => {
         if (row.createdAt) {
@@ -83,7 +83,7 @@ export default function Page() {
     },
     {
       label: t`Cancel`,
-      icon: CircleXIcon,
+      icon: <CircleXIcon className="size-4" />,
       variant: 'destructive' as const,
       hidden: (row) => row.invitationState !== 'Pending',
       onClick: async (row) => {

--- a/app/routes/profile/session.tsx
+++ b/app/routes/profile/session.tsx
@@ -39,7 +39,7 @@ export default function Page() {
   const actions: ActionItem<ComMiloapisGoMiloPkgApisIdentityV1Alpha1Session>[] = [
     {
       label: tMacro`Delete`,
-      icon: Trash2Icon,
+      icon: <Trash2Icon className="size-4" />,
       variant: 'destructive' as const,
       onClick: (row) => setSelectedSession(row),
     },

--- a/app/routes/user/index.tsx
+++ b/app/routes/user/index.tsx
@@ -46,12 +46,12 @@ export default function Page() {
   const actions: ActionItem<ComMiloapisIamV1Alpha1User>[] = [
     {
       label: t`Manage`,
-      icon: EditIcon,
+      icon: <EditIcon className="size-4" />,
       onClick: (row) => navigate(userRoutes.detail(row.metadata?.name ?? '')),
     },
     {
       label: t`Approve`,
-      icon: CheckIcon,
+      icon: <CheckIcon className="size-4" />,
       hidden: (row) => row.status?.registrationApproval !== 'Pending',
       onClick: async (row) => {
         setLoadingStates((prev) => ({ ...prev, [row.metadata?.name ?? '']: true }));
@@ -66,14 +66,14 @@ export default function Page() {
     },
     {
       label: t`Reject`,
-      icon: XIcon,
+      icon: <XIcon className="size-4" />,
       variant: 'destructive' as const,
       hidden: (row) => row.status?.registrationApproval !== 'Pending',
       onClick: (row) => setSelectedUser(row),
     },
     {
       label: t`Move to Pending`,
-      icon: RotateCcwIcon,
+      icon: <RotateCcwIcon className="size-4" />,
       hidden: (row) => row.status?.registrationApproval === 'Pending',
       onClick: async (row) => {
         setLoadingStates((prev) => ({ ...prev, [row.metadata?.name ?? '']: true }));


### PR DESCRIPTION
Closes #502.

## Problem
Clicking the 3-dot row actions menu on the users list crashed with:

> Objects are not valid as a React child (found: object with keys {\$\$typeof, render})

## Cause
datum-ui's action-row decides how to render the icon with `typeof action.icon === "function"`. Lucide-react icons are `forwardRef` objects (`typeof === "object"`), so the check fails, the code falls through, and React tries to render a raw forwardRef object as a child.

## Fix
Pass icons as JSX elements in every `ActionItem` instead of component refs.

```tsx
// Before
icon: EditIcon

// After
icon: <EditIcon className="size-4" />
```

Files touched (12): user list, fraud + providers, contact list, contact-group + members, contact group detail, org members, fraud evals, quota bucket + grant, sessions, group members. All matched the same `icon: SomeIcon,` pattern inside `ActionItem[]`.

Nav/menu sidebars (`MenuItem` shape) were left as-is. They take icons as components and render them correctly — only `more-actions` has this quirk.