### PR TITLE
fix(feature-flags): wrap long flag descriptions instead of overflowing

### DIFF
--- a/app/features/feature-flags/components/feature-flag-list.tsx
+++ b/app/features/feature-flags/components/feature-flag-list.tsx
@@ -109,10 +109,12 @@ export function FeatureFlagList({ orgName }: FeatureFlagListProps) {
         id: 'name',
         header: ({ column }) => <DataTable.ColumnHeader column={column} title={t`Flag`} />,
         cell: ({ row }) => (
-          <div className="flex flex-col">
+          <div className="flex max-w-5xl flex-col">
             <span className="text-sm font-medium">{displayName(row.original)}</span>
             {row.original.spec?.description && (
-              <span className="text-muted-foreground text-xs">{row.original.spec.description}</span>
+              <span className="text-muted-foreground text-xs break-words whitespace-normal">
+                {row.original.spec.description}
+              </span>
             )}
           </div>
         ),

--- a/app/modules/i18n/locales/en.po
+++ b/app/modules/i18n/locales/en.po
@@ -420,7 +420,7 @@ msgstr "by"
 #: app/features/contact-group/components/contact-group-form.tsx:97
 #: app/features/contact/components/contact-form.tsx:244
 #: app/features/contact/components/contact-list.tsx:117
-#: app/features/feature-flags/components/feature-flag-list.tsx:228
+#: app/features/feature-flags/components/feature-flag-list.tsx:230
 #: app/features/fraud/policy/policy-form.tsx:318
 #: app/features/quota/components/quota-bucket-list.tsx:128
 #: app/features/quota/components/quota-grant-list.tsx:138
@@ -891,24 +891,24 @@ msgstr "Description"
 msgid "Details"
 msgstr "Details"
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:227
+#: app/features/feature-flags/components/feature-flag-list.tsx:229
 msgid "Disable"
 msgstr "Disable"
 
 #. placeholder {0}: pendingGrants.length
-#: app/features/feature-flags/components/feature-flag-list.tsx:224
+#: app/features/feature-flags/components/feature-flag-list.tsx:226
 msgid "Disable \"{pendingFlag}\" for this organization? {0} resource grants will be deleted."
 msgstr "Disable \"{pendingFlag}\" for this organization? {0} resource grants will be deleted."
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:225
+#: app/features/feature-flags/components/feature-flag-list.tsx:227
 msgid "Disable \"{pendingFlag}\" for this organization? The associated resource grant will be deleted."
 msgstr "Disable \"{pendingFlag}\" for this organization? The associated resource grant will be deleted."
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:219
+#: app/features/feature-flags/components/feature-flag-list.tsx:221
 msgid "Disable feature flag"
 msgstr "Disable feature flag"
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:172
+#: app/features/feature-flags/components/feature-flag-list.tsx:174
 msgid "Disable flag"
 msgstr "Disable flag"
 
@@ -1057,23 +1057,23 @@ msgstr "Email HTML preview"
 msgid "Email is required"
 msgstr "Email is required"
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:227
+#: app/features/feature-flags/components/feature-flag-list.tsx:229
 msgid "Enable"
 msgstr "Enable"
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:222
+#: app/features/feature-flags/components/feature-flag-list.tsx:224
 msgid "Enable \"{pendingFlag}\" for this organization? A new resource grant will be created."
 msgstr "Enable \"{pendingFlag}\" for this organization? A new resource grant will be created."
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:219
+#: app/features/feature-flags/components/feature-flag-list.tsx:221
 msgid "Enable feature flag"
 msgstr "Enable feature flag"
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:172
+#: app/features/feature-flags/components/feature-flag-list.tsx:174
 msgid "Enable flag"
 msgstr "Enable flag"
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:122
+#: app/features/feature-flags/components/feature-flag-list.tsx:124
 msgid "Enabled by"
 msgstr "Enabled by"
 
@@ -1843,7 +1843,7 @@ msgstr "No email activity found."
 msgid "No export policies found."
 msgstr "No export policies found."
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:262
+#: app/features/feature-flags/components/feature-flag-list.tsx:264
 msgid "No feature flags registered."
 msgstr "No feature flags registered."
 
@@ -2123,7 +2123,7 @@ msgstr "Pipeline Stages"
 msgid "Plain Text"
 msgstr "Plain Text"
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:142
+#: app/features/feature-flags/components/feature-flag-list.tsx:144
 msgid "Platform"
 msgstr "Platform"
 
@@ -2505,7 +2505,7 @@ msgstr "Search AI Edge..."
 msgid "Search by email, name, or ID..."
 msgstr "Search by email, name, or ID..."
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:254
+#: app/features/feature-flags/components/feature-flag-list.tsx:256
 msgid "Search by flag key or description..."
 msgstr "Search by flag key or description..."
 
@@ -2844,7 +2844,7 @@ msgstr "These items are checked every few minutes. If you've already made change
 msgid "This email is already used by <0>{displayName}</0>."
 msgstr "This email is already used by <0>{displayName}</0>."
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:181
+#: app/features/feature-flags/components/feature-flag-list.tsx:183
 msgid "This flag is managed by the platform and can't be changed from here."
 msgstr "This flag is managed by the platform and can't be changed from here."
 
@@ -2868,7 +2868,7 @@ msgstr "Timezone"
 msgid "Timezone updated successfully"
 msgstr "Timezone updated successfully"
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:159
+#: app/features/feature-flags/components/feature-flag-list.tsx:161
 msgid "Toggle"
 msgstr "Toggle"
 

--- a/app/modules/i18n/locales/fr.po
+++ b/app/modules/i18n/locales/fr.po
@@ -420,7 +420,7 @@ msgstr ""
 #: app/features/contact-group/components/contact-group-form.tsx:97
 #: app/features/contact/components/contact-form.tsx:244
 #: app/features/contact/components/contact-list.tsx:117
-#: app/features/feature-flags/components/feature-flag-list.tsx:228
+#: app/features/feature-flags/components/feature-flag-list.tsx:230
 #: app/features/fraud/policy/policy-form.tsx:318
 #: app/features/quota/components/quota-bucket-list.tsx:128
 #: app/features/quota/components/quota-grant-list.tsx:138
@@ -891,24 +891,24 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:227
+#: app/features/feature-flags/components/feature-flag-list.tsx:229
 msgid "Disable"
 msgstr ""
 
 #. placeholder {0}: pendingGrants.length
-#: app/features/feature-flags/components/feature-flag-list.tsx:224
+#: app/features/feature-flags/components/feature-flag-list.tsx:226
 msgid "Disable \"{pendingFlag}\" for this organization? {0} resource grants will be deleted."
 msgstr ""
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:225
+#: app/features/feature-flags/components/feature-flag-list.tsx:227
 msgid "Disable \"{pendingFlag}\" for this organization? The associated resource grant will be deleted."
 msgstr ""
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:219
+#: app/features/feature-flags/components/feature-flag-list.tsx:221
 msgid "Disable feature flag"
 msgstr ""
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:172
+#: app/features/feature-flags/components/feature-flag-list.tsx:174
 msgid "Disable flag"
 msgstr ""
 
@@ -1057,23 +1057,23 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:227
+#: app/features/feature-flags/components/feature-flag-list.tsx:229
 msgid "Enable"
 msgstr ""
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:222
+#: app/features/feature-flags/components/feature-flag-list.tsx:224
 msgid "Enable \"{pendingFlag}\" for this organization? A new resource grant will be created."
 msgstr ""
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:219
+#: app/features/feature-flags/components/feature-flag-list.tsx:221
 msgid "Enable feature flag"
 msgstr ""
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:172
+#: app/features/feature-flags/components/feature-flag-list.tsx:174
 msgid "Enable flag"
 msgstr ""
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:122
+#: app/features/feature-flags/components/feature-flag-list.tsx:124
 msgid "Enabled by"
 msgstr ""
 
@@ -1843,7 +1843,7 @@ msgstr ""
 msgid "No export policies found."
 msgstr ""
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:262
+#: app/features/feature-flags/components/feature-flag-list.tsx:264
 msgid "No feature flags registered."
 msgstr ""
 
@@ -2123,7 +2123,7 @@ msgstr ""
 msgid "Plain Text"
 msgstr ""
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:142
+#: app/features/feature-flags/components/feature-flag-list.tsx:144
 msgid "Platform"
 msgstr ""
 
@@ -2505,7 +2505,7 @@ msgstr ""
 msgid "Search by email, name, or ID..."
 msgstr ""
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:254
+#: app/features/feature-flags/components/feature-flag-list.tsx:256
 msgid "Search by flag key or description..."
 msgstr ""
 
@@ -2844,7 +2844,7 @@ msgstr ""
 msgid "This email is already used by <0>{displayName}</0>."
 msgstr ""
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:181
+#: app/features/feature-flags/components/feature-flag-list.tsx:183
 msgid "This flag is managed by the platform and can't be changed from here."
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Timezone updated successfully"
 msgstr ""
 
-#: app/features/feature-flags/components/feature-flag-list.tsx:159
+#: app/features/feature-flags/components/feature-flag-list.tsx:161
 msgid "Toggle"
 msgstr ""
 


### PR DESCRIPTION
## Summary

The Feature Flags table rendered long flag descriptions on a single line, forcing the column wider than its container and producing a horizontal scrollbar. This just mildly annoyed me when I was looking at it so I thought id fix it real quick.

This constrains the "Flag" column cell to a max width and lets the description wrap across multiple lines (`break-words whitespace-normal`) — full text is preserved, no truncation, and the horizontal scroll is gone.

Before
<img width="1311" height="752" alt="image" src="https://github.com/user-attachments/assets/0f0ed755-dcef-4229-9ead-4c28e9e135f5" /> 

After
<img width="1311" height="752" alt="image" src="https://github.com/user-attachments/assets/96b6c3f4-1cd3-4ac2-a80a-bfe140361283" />


## Test plan

- [ ] Open an org's Feature Flags page with long descriptions (e.g. "Multi Billing Accounts", "Cloud Portal Billing")
- [ ] Confirm descriptions wrap and no horizontal scrollbar appears
- [ ] Confirm short flags still render normally