### PR TITLE
feat: show human-readable consumer project name in service catalog

### DIFF
--- a/app/resources/request/client/apis/project.api.ts
+++ b/app/resources/request/client/apis/project.api.ts
@@ -14,6 +14,7 @@ import {
 import {
   deleteResourcemanagerMiloapisComV1Alpha1Project,
   listResourcemanagerMiloapisComV1Alpha1Project,
+  readResourcemanagerMiloapisComV1Alpha1Project,
 } from '@openapi/resourcemanager.miloapis.com/v1alpha1';
 import { listTelemetryMiloapisComV1Alpha1ExportPolicyForAllNamespaces } from '@openapi/telemetry.miloapis.com/v1alpha1';
 
@@ -26,6 +27,14 @@ export const projectListQuery = async (params?: ListQueryParams) => {
     },
   });
   return response.data.data;
+};
+
+export const projectQuery = async (projectName: string) => {
+  if (!projectName) return null;
+  const response = await readResourcemanagerMiloapisComV1Alpha1Project({
+    path: { name: projectName },
+  });
+  return response.data.data ?? null;
 };
 
 export const projectEdgeListQuery = async (projectName: string, params?: ListQueryParams) => {

--- a/app/resources/request/client/queries/project.queries.ts
+++ b/app/resources/request/client/queries/project.queries.ts
@@ -5,13 +5,15 @@ import {
   projectExportPolicyListQuery,
   projectEdgeListQuery,
   projectListQuery,
+  projectQuery,
 } from '../apis/project.api';
 import { ListQueryParams } from '@/resources/schemas';
-import { useQuery } from '@tanstack/react-query';
+import { useQueries, useQuery } from '@tanstack/react-query';
 
 export const projectQueryKeys = {
   all: ['projects'] as const,
   list: (params?: ListQueryParams) => ['projects', 'list', params] as const,
+  detail: (projectName: string) => ['projects', 'detail', projectName] as const,
   domains: {
     all: (projectName: string) => ['projects', projectName, 'domains'] as const,
     list: (projectName: string, params?: ListQueryParams) =>
@@ -55,6 +57,35 @@ export const useProjectListQuery = (params?: ListQueryParams) => {
     queryFn: () => projectListQuery(params),
     staleTime: 5 * 60 * 1000,
   });
+};
+
+/**
+ * Fetches the given projects by name and returns a map of project name to its
+ * human-readable display name (the `kubernetes.io/description` annotation),
+ * falling back to the project name when no annotation is present.
+ */
+export const useProjectDisplayNamesQuery = (projectNames: string[]) => {
+  const uniqueNames = Array.from(new Set(projectNames.filter(Boolean)));
+
+  const queries = useQueries({
+    queries: uniqueNames.map((name) => ({
+      queryKey: projectQueryKeys.detail(name),
+      queryFn: () => projectQuery(name),
+      enabled: !!name,
+      staleTime: 5 * 60 * 1000,
+    })),
+  });
+
+  const displayNames: Record<string, string> = {};
+  uniqueNames.forEach((name, index) => {
+    const project = queries[index]?.data;
+    displayNames[name] = project?.metadata?.annotations?.['kubernetes.io/description'] || name;
+  });
+
+  return {
+    displayNames,
+    isLoading: queries.some((q) => q.isLoading),
+  };
 };
 
 export const useProjectDomainListQuery = (projectName: string, params?: ListQueryParams) => {

--- a/app/routes/service-catalog/detail/consumers.tsx
+++ b/app/routes/service-catalog/detail/consumers.tsx
@@ -7,6 +7,7 @@ import { DialogConfirm } from '@/components/dialog';
 import { MessageCard } from '@/components/message-card';
 import { consumerMatchesService, useApprovalDialog } from '@/features/service-catalog';
 import {
+  useProjectDisplayNamesQuery,
   useRevokeServiceEntitlementMutation,
   useServiceConsumersInProjectQuery,
 } from '@/resources/request/client';
@@ -49,6 +50,14 @@ export default function ConsumersPage() {
 
   const { data, isLoading, error } = useServiceConsumersInProjectQuery(producerProject);
 
+  const items = (data?.items ?? []).filter((c) =>
+    consumerMatchesService(c, serviceName, canonicalName)
+  );
+
+  const { displayNames } = useProjectDisplayNamesQuery(
+    items.map((c) => c.spec?.consumerProjectRef?.name ?? '')
+  );
+
   const actions: ActionItem<ServiceConsumer>[] = [
     {
       label: t`Approve`,
@@ -80,16 +89,27 @@ export default function ConsumersPage() {
       ),
       cell: ({ getValue }) => {
         const project = getValue();
-        return project ? (
-          <Link
-            to={projectRoutes.detail(project)}
-            className="text-primary font-mono text-sm hover:underline">
-            {project}
-          </Link>
-        ) : (
-          <Text size="sm" textColor="muted">
-            —
-          </Text>
+        if (!project) {
+          return (
+            <Text size="sm" textColor="muted">
+              —
+            </Text>
+          );
+        }
+        const displayName = displayNames[project] ?? project;
+        return (
+          <div className="flex flex-col">
+            <Link
+              to={projectRoutes.detail(project)}
+              className="text-primary text-sm hover:underline">
+              {displayName}
+            </Link>
+            {displayName !== project && (
+              <Text size="xs" textColor="muted" className="font-mono">
+                {project}
+              </Text>
+            )}
+          </div>
         );
       },
     }),
@@ -155,10 +175,6 @@ export default function ConsumersPage() {
     }),
   ];
 
-  const items = (data?.items ?? []).filter((c) =>
-    consumerMatchesService(c, serviceName, canonicalName)
-  );
-
   if (!producerProject) {
     return (
       <MessageCard
@@ -222,8 +238,10 @@ export default function ConsumersPage() {
         searchFn={(row, search) => {
           const q = search.trim().toLowerCase();
           if (!q) return true;
+          const consumerProject = row.spec?.consumerProjectRef?.name ?? '';
           return [
-            row.spec?.consumerProjectRef?.name,
+            consumerProject,
+            displayNames[consumerProject],
             row.metadata?.name,
             row.spec?.approval?.message,
           ]


### PR DESCRIPTION
## Summary

The Service Catalog **Consumers** table showed only the consumer project's machine name (e.g. `personal-project-44245c5a`), taken from `spec.consumerProjectRef.name`. This surfaces the human-readable project name instead — the `kubernetes.io/description` annotation, which is the established project display-name convention in this repo (same as the org Projects table, `organization/detail/project.tsx`).

The "Consumer Project" cell now links the friendly name with the raw project ID as muted monospace subtext (only when they differ), falling back to the raw name while loading or when no annotation is set. Search matches both the display name and the raw ID.

<img width="1438" height="810" alt="image" src="https://github.com/user-attachments/assets/3d5e8b01-fcc2-4c38-a528-43d7d426a73c" />


## How it works

`ServiceConsumer` only carries the project *name*, not its annotations, so the display name is resolved in a second step:

- **`project.api.ts`** — `projectQuery(name)` reads a single Project by name.
- **`project.queries.ts`** — `useProjectDisplayNamesQuery(names)` fetches the consumer projects in parallel (`useQueries`, deduped, 5-min stale) and returns a `name → description` map, falling back to the name.
- **`consumers.tsx`** — wires the map into the column cell and search.

## Notes

- This adds one project read per unique consumer project (an N+1). Fine at current scale (single-digit consumers, cached/deduped). If a producer ever has hundreds of consumers we'd want a bulk lookup or a gateway-side join — left out deliberately as out of scope.
- i18n catalogs intentionally not regenerated here; no new translatable strings were added.

## Test plan

- [ ] Consumers table shows friendly project names with the ID as subtext
- [ ] Projects without a `kubernetes.io/description` annotation fall back to the raw name
- [ ] Search matches both the display name and the raw project ID
- [ ] Project link still navigates correctly