### PR TITLE
feat: enrich service catalog consumers via graphql gateway

### DIFF
--- a/app/features/service-catalog/hooks/useApprovalDialog.tsx
+++ b/app/features/service-catalog/hooks/useApprovalDialog.tsx
@@ -1,5 +1,5 @@
 import { DialogForm } from '@/components/dialog';
-import { useDecideServiceConsumerMutation, type ServiceConsumer } from '@/resources/request/client';
+import { useDecideServiceConsumerMutation } from '@/resources/request/client';
 import { Form } from '@datum-cloud/datum-ui/form';
 import { toast } from '@datum-cloud/datum-ui/toast';
 import { t } from '@lingui/core/macro';
@@ -14,12 +14,12 @@ const schema = z.object({
 
 export function useApprovalDialog(producerProject: string) {
   const decideMutation = useDecideServiceConsumerMutation(producerProject);
-  const [pending, setPending] = useState<{ consumer: ServiceConsumer; decision: Decision } | null>(
-    null
-  );
+  const [pending, setPending] = useState<{ consumerName: string; decision: Decision } | null>(null);
 
-  const openDialog = (consumer: ServiceConsumer, decision: Decision) =>
-    setPending({ consumer, decision });
+  // Takes the consumer's name (metadata.name) so callers can drive the dialog
+  // from either the raw k8s shape or the gateway-enriched flat shape.
+  const openDialog = (consumerName: string, decision: Decision) =>
+    setPending({ consumerName, decision });
 
   const isApproving = pending?.decision === 'Approved';
 
@@ -42,9 +42,8 @@ export function useApprovalDialog(producerProject: string) {
       requireDirty={false}
       onSubmit={async (formData) => {
         if (!pending) return;
-        const consumerName = pending.consumer.metadata?.name ?? '';
         await decideMutation.mutateAsync({
-          consumerName,
+          consumerName: pending.consumerName,
           decision: pending.decision,
           message: formData.message || undefined,
         });

--- a/app/modules/graphql/service-consumers.ts
+++ b/app/modules/graphql/service-consumers.ts
@@ -1,0 +1,69 @@
+import { gqlRequest } from './client';
+
+export interface EnrichedConsumerProject {
+  /** The project's machine name (metadata.name). */
+  name: string;
+  /**
+   * Human-readable name from the project's kubernetes.io/description
+   * annotation, falling back to the machine name when unset or inaccessible.
+   */
+  displayName: string;
+}
+
+/**
+ * A ServiceConsumer flattened and enriched by the graphql-gateway. The gateway
+ * resolves each consumer project's display name server-side, so the table no
+ * longer needs a per-row project lookup.
+ */
+export interface EnrichedServiceConsumer {
+  /** metadata.name */
+  name: string;
+  /** spec.serviceRef.name — used to filter consumers by service. */
+  serviceName: string | null;
+  /** status.phase — e.g. Active, PendingApproval. */
+  phase: string | null;
+  /** spec.approval.decision — e.g. Approved, Denied. */
+  approvalDecision: string | null;
+  /** spec.approval.message */
+  approvalMessage: string | null;
+  /** metadata.creationTimestamp */
+  requestedAt: string | null;
+  consumerProject: EnrichedConsumerProject;
+}
+
+const SERVICE_CONSUMERS_QUERY = /* GraphQL */ `
+  query ServiceConsumers($producerProject: ID!) {
+    serviceConsumers(producerProject: $producerProject) {
+      name
+      serviceName
+      phase
+      approvalDecision
+      approvalMessage
+      requestedAt
+      consumerProject {
+        name
+        displayName
+      }
+    }
+  }
+`;
+
+/**
+ * Lists the ServiceConsumers in a producer project, enriched with each
+ * consumer project's display name. Resolved server-side by the gateway in a
+ * single round trip (replacing the client-side consumer-list + per-project
+ * lookups).
+ *
+ * The gateway degrades gracefully: a list failure yields an empty array, and
+ * a per-project lookup failure falls back to the raw project name. Genuine
+ * transport/proxy failures still throw via {@link gqlRequest}.
+ */
+export async function listServiceConsumers(
+  producerProject: string
+): Promise<EnrichedServiceConsumer[]> {
+  const data = await gqlRequest<{ serviceConsumers: EnrichedServiceConsumer[] }>(
+    SERVICE_CONSUMERS_QUERY,
+    { producerProject }
+  );
+  return data.serviceConsumers;
+}

--- a/app/resources/request/client/apis/project.api.ts
+++ b/app/resources/request/client/apis/project.api.ts
@@ -14,7 +14,6 @@ import {
 import {
   deleteResourcemanagerMiloapisComV1Alpha1Project,
   listResourcemanagerMiloapisComV1Alpha1Project,
-  readResourcemanagerMiloapisComV1Alpha1Project,
 } from '@openapi/resourcemanager.miloapis.com/v1alpha1';
 import { listTelemetryMiloapisComV1Alpha1ExportPolicyForAllNamespaces } from '@openapi/telemetry.miloapis.com/v1alpha1';
 
@@ -27,14 +26,6 @@ export const projectListQuery = async (params?: ListQueryParams) => {
     },
   });
   return response.data.data;
-};
-
-export const projectQuery = async (projectName: string) => {
-  if (!projectName) return null;
-  const response = await readResourcemanagerMiloapisComV1Alpha1Project({
-    path: { name: projectName },
-  });
-  return response.data.data ?? null;
 };
 
 export const projectEdgeListQuery = async (projectName: string, params?: ListQueryParams) => {

--- a/app/resources/request/client/queries/project.queries.ts
+++ b/app/resources/request/client/queries/project.queries.ts
@@ -5,15 +5,13 @@ import {
   projectExportPolicyListQuery,
   projectEdgeListQuery,
   projectListQuery,
-  projectQuery,
 } from '../apis/project.api';
 import { ListQueryParams } from '@/resources/schemas';
-import { useQueries, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
 export const projectQueryKeys = {
   all: ['projects'] as const,
   list: (params?: ListQueryParams) => ['projects', 'list', params] as const,
-  detail: (projectName: string) => ['projects', 'detail', projectName] as const,
   domains: {
     all: (projectName: string) => ['projects', projectName, 'domains'] as const,
     list: (projectName: string, params?: ListQueryParams) =>
@@ -57,35 +55,6 @@ export const useProjectListQuery = (params?: ListQueryParams) => {
     queryFn: () => projectListQuery(params),
     staleTime: 5 * 60 * 1000,
   });
-};
-
-/**
- * Fetches the given projects by name and returns a map of project name to its
- * human-readable display name (the `kubernetes.io/description` annotation),
- * falling back to the project name when no annotation is present.
- */
-export const useProjectDisplayNamesQuery = (projectNames: string[]) => {
-  const uniqueNames = Array.from(new Set(projectNames.filter(Boolean)));
-
-  const queries = useQueries({
-    queries: uniqueNames.map((name) => ({
-      queryKey: projectQueryKeys.detail(name),
-      queryFn: () => projectQuery(name),
-      enabled: !!name,
-      staleTime: 5 * 60 * 1000,
-    })),
-  });
-
-  const displayNames: Record<string, string> = {};
-  uniqueNames.forEach((name, index) => {
-    const project = queries[index]?.data;
-    displayNames[name] = project?.metadata?.annotations?.['kubernetes.io/description'] || name;
-  });
-
-  return {
-    displayNames,
-    isLoading: queries.some((q) => q.isLoading),
-  };
 };
 
 export const useProjectDomainListQuery = (projectName: string, params?: ListQueryParams) => {

--- a/app/resources/request/client/queries/service-catalog.queries.ts
+++ b/app/resources/request/client/queries/service-catalog.queries.ts
@@ -7,6 +7,7 @@ import {
   listServices,
   type ApprovalDecision,
 } from '../apis/service-catalog.api';
+import { listServiceConsumers } from '@/modules/graphql/service-consumers';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 export const serviceCatalogQueryKeys = {
@@ -21,6 +22,10 @@ export const serviceCatalogQueryKeys = {
   },
   consumers: {
     inProject: (project: string) => ['service-catalog', 'consumers', 'project', project] as const,
+    // Gateway-enriched variant (adds consumer project display names), used by
+    // the Consumers table. Keyed separately from the raw REST list so both can
+    // coexist; mutations below invalidate both.
+    enriched: (project: string) => ['service-catalog', 'consumers', 'enriched', project] as const,
   },
 };
 
@@ -60,6 +65,18 @@ export const useServiceConsumersInProjectQuery = (projectName: string | undefine
   });
 };
 
+// Gateway-enriched consumer list (includes each consumer project's display
+// name). Used by the Consumers table; resolved server-side in one round trip.
+export const useServiceConsumersEnrichedQuery = (projectName: string | undefined) => {
+  const project = projectName ?? '';
+  return useQuery({
+    queryKey: serviceCatalogQueryKeys.consumers.enriched(project),
+    queryFn: () => listServiceConsumers(project),
+    enabled: !!project,
+    staleTime: 30 * 1000,
+  });
+};
+
 export const useRevokeServiceEntitlementMutation = (producerProject: string) => {
   const queryClient = useQueryClient();
   return useMutation({
@@ -71,9 +88,14 @@ export const useRevokeServiceEntitlementMutation = (producerProject: string) => 
       entitlementName: string;
     }) => deleteServiceEntitlement(consumerProject, entitlementName),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: serviceCatalogQueryKeys.consumers.inProject(producerProject),
-      });
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: serviceCatalogQueryKeys.consumers.inProject(producerProject),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: serviceCatalogQueryKeys.consumers.enriched(producerProject),
+        }),
+      ]);
     },
   });
 };
@@ -91,9 +113,14 @@ export const useDecideServiceConsumerMutation = (projectName: string) => {
       message?: string;
     }) => decideServiceConsumer(projectName, consumerName, decision, message),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: serviceCatalogQueryKeys.consumers.inProject(projectName),
-      });
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: serviceCatalogQueryKeys.consumers.inProject(projectName),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: serviceCatalogQueryKeys.consumers.enriched(projectName),
+        }),
+      ]);
     },
   });
 };

--- a/app/routes/service-catalog/detail/approvals.tsx
+++ b/app/routes/service-catalog/detail/approvals.tsx
@@ -50,13 +50,13 @@ export default function ApprovalsPage() {
     {
       label: t`Approve`,
       icon: <CheckCircle className="size-4" />,
-      onClick: (row) => openDialog(row, 'Approved'),
+      onClick: (row) => openDialog(row.metadata?.name ?? '', 'Approved'),
     },
     {
       label: t`Deny`,
       icon: <XCircle className="size-4" />,
       variant: 'destructive' as const,
-      onClick: (row) => openDialog(row, 'Denied'),
+      onClick: (row) => openDialog(row.metadata?.name ?? '', 'Denied'),
     },
   ];
 

--- a/app/routes/service-catalog/detail/consumers.tsx
+++ b/app/routes/service-catalog/detail/consumers.tsx
@@ -5,11 +5,11 @@ import { DataTableToolbar } from '@/components/data-table-toolbar';
 import { DateTime } from '@/components/date';
 import { DialogConfirm } from '@/components/dialog';
 import { MessageCard } from '@/components/message-card';
-import { consumerMatchesService, useApprovalDialog } from '@/features/service-catalog';
+import { useApprovalDialog } from '@/features/service-catalog';
+import type { EnrichedServiceConsumer } from '@/modules/graphql/service-consumers';
 import {
-  useProjectDisplayNamesQuery,
   useRevokeServiceEntitlementMutation,
-  useServiceConsumersInProjectQuery,
+  useServiceConsumersEnrichedQuery,
 } from '@/resources/request/client';
 import { projectRoutes } from '@/utils/config/routes.config';
 import { metaObject } from '@/utils/helpers';
@@ -18,13 +18,12 @@ import { ActionItem, DataTable } from '@datum-cloud/datum-ui/data-table';
 import { toast } from '@datum-cloud/datum-ui/toast';
 import { Text } from '@datum-cloud/datum-ui/typography';
 import { Trans, useLingui } from '@lingui/react/macro';
-import type { ComMiloapisServicesV1Alpha1ServiceConsumer } from '@openapi/services.miloapis.com/v1alpha1';
 import { createColumnHelper } from '@tanstack/react-table';
 import { CheckCircle, Trash2, XCircle } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router';
 
-type ServiceConsumer = ComMiloapisServicesV1Alpha1ServiceConsumer;
+type ServiceConsumer = EnrichedServiceConsumer;
 
 export const handle = {
   breadcrumb: () => <Trans>Consumers</Trans>,
@@ -48,72 +47,61 @@ export default function ConsumersPage() {
   const revokeMutation = useRevokeServiceEntitlementMutation(producerProject ?? '');
   const [revokeTarget, setRevokeTarget] = useState<ServiceConsumer | null>(null);
 
-  const { data, isLoading, error } = useServiceConsumersInProjectQuery(producerProject);
-
-  const items = (data?.items ?? []).filter((c) =>
-    consumerMatchesService(c, serviceName, canonicalName)
-  );
-
-  const { displayNames } = useProjectDisplayNamesQuery(
-    items.map((c) => c.spec?.consumerProjectRef?.name ?? '')
-  );
+  const { data, isLoading, error } = useServiceConsumersEnrichedQuery(producerProject);
 
   const actions: ActionItem<ServiceConsumer>[] = [
     {
       label: t`Approve`,
       icon: <CheckCircle className="size-4" />,
-      hidden: (row) => !(row.status?.phase === 'PendingApproval' && !row.spec?.approval),
-      onClick: (row) => openDialog(row, 'Approved'),
+      hidden: (row) => !(row.phase === 'PendingApproval' && !row.approvalDecision),
+      onClick: (row) => openDialog(row.name, 'Approved'),
     },
     {
       label: t`Deny`,
       icon: <XCircle className="size-4" />,
       variant: 'destructive' as const,
-      hidden: (row) => !(row.status?.phase === 'PendingApproval' && !row.spec?.approval),
-      onClick: (row) => openDialog(row, 'Denied'),
+      hidden: (row) => !(row.phase === 'PendingApproval' && !row.approvalDecision),
+      onClick: (row) => openDialog(row.name, 'Denied'),
     },
     {
       label: t`Revoke`,
       icon: <Trash2 className="size-4" />,
       variant: 'destructive' as const,
-      hidden: (row) => row.status?.phase !== 'Active',
+      hidden: (row) => row.phase !== 'Active',
       onClick: (row) => setRevokeTarget(row),
     },
   ];
 
   const columns = [
-    columnHelper.accessor((row) => row.spec?.consumerProjectRef?.name ?? '', {
+    columnHelper.accessor((row) => row.consumerProject.displayName, {
       id: 'project',
       header: ({ column }) => (
         <DataTable.ColumnHeader column={column} title={t`Consumer Project`} />
       ),
-      cell: ({ getValue }) => {
-        const project = getValue();
-        if (!project) {
+      cell: ({ row }) => {
+        const { name, displayName } = row.original.consumerProject;
+        if (!name) {
           return (
             <Text size="sm" textColor="muted">
               —
             </Text>
           );
         }
-        const displayName = displayNames[project] ?? project;
         return (
           <div className="flex flex-col">
-            <Link
-              to={projectRoutes.detail(project)}
-              className="text-primary text-sm hover:underline">
+            <Link to={projectRoutes.detail(name)} className="text-primary text-sm hover:underline">
               {displayName}
             </Link>
-            {displayName !== project && (
+            {displayName !== name && (
               <Text size="xs" textColor="muted" className="font-mono">
-                {project}
+                {name}
               </Text>
             )}
           </div>
         );
       },
     }),
-    columnHelper.accessor((row) => row.status?.phase ?? '', {
+    columnHelper.accessor((row) => row.phase ?? '', {
       id: 'phase',
       header: ({ column }) => <DataTable.ColumnHeader column={column} title={t`Phase`} />,
       cell: ({ getValue }) => {
@@ -125,12 +113,12 @@ export default function ConsumersPage() {
         );
       },
     }),
-    columnHelper.accessor((row) => row.spec?.approval?.decision ?? '', {
+    columnHelper.accessor((row) => row.approvalDecision ?? '', {
       id: 'approval',
       header: ({ column }) => <DataTable.ColumnHeader column={column} title={t`Approval`} />,
       cell: ({ getValue, row }) => {
         const decision = getValue();
-        const message = row.original.spec?.approval?.message;
+        const message = row.original.approvalMessage;
         if (!decision) {
           return (
             <Text size="sm" textColor="muted">
@@ -150,12 +138,12 @@ export default function ConsumersPage() {
         );
       },
     }),
-    columnHelper.accessor((row) => row.metadata?.creationTimestamp ?? '', {
+    columnHelper.accessor((row) => row.requestedAt ?? '', {
       id: 'createdAt',
       header: ({ column }) => <DataTable.ColumnHeader column={column} title={t`Requested at`} />,
       cell: ({ getValue }) => <DateTime date={getValue()} variant="relative" addSuffix />,
     }),
-    columnHelper.accessor((row) => row.metadata?.name ?? '', {
+    columnHelper.accessor((row) => row.name, {
       id: 'name',
       header: ({ column }) => <DataTable.ColumnHeader column={column} title={t`Consumer ID`} />,
       cell: ({ getValue }) => (
@@ -174,6 +162,10 @@ export default function ConsumersPage() {
       ),
     }),
   ];
+
+  const items = (data ?? []).filter(
+    (c) => c.serviceName === serviceName || (!!canonicalName && c.serviceName === canonicalName)
+  );
 
   if (!producerProject) {
     return (
@@ -196,10 +188,10 @@ export default function ConsumersPage() {
     );
   }
 
-  const revokeConsumerProject = revokeTarget?.spec?.consumerProjectRef?.name ?? '';
+  const revokeConsumerProject = revokeTarget?.consumerProject.name ?? '';
   // The ServiceEntitlement in the consumer project is conventionally named
-  // after the Service's metadata.name; the consumer's spec.serviceRef.name
-  // may be either form, so prefer this page's URL param.
+  // after the Service's metadata.name; the consumer's serviceName may be
+  // either form, so prefer this page's URL param.
   const revokeEntitlementName = serviceName;
 
   return (
@@ -229,7 +221,7 @@ export default function ConsumersPage() {
         loading={isLoading}
         data={items}
         columns={columns}
-        getRowId={(row) => row.metadata?.name ?? ''}
+        getRowId={(row) => row.name}
         defaultSort={[{ id: 'createdAt', desc: true }]}
         filterFns={{
           phase: (cellValue, filterValue) =>
@@ -238,12 +230,11 @@ export default function ConsumersPage() {
         searchFn={(row, search) => {
           const q = search.trim().toLowerCase();
           if (!q) return true;
-          const consumerProject = row.spec?.consumerProjectRef?.name ?? '';
           return [
-            consumerProject,
-            displayNames[consumerProject],
-            row.metadata?.name,
-            row.spec?.approval?.message,
+            row.consumerProject.name,
+            row.consumerProject.displayName,
+            row.name,
+            row.approvalMessage,
           ]
             .map((s) => (s ?? '').toLowerCase())
             .some((s) => s.includes(q));


### PR DESCRIPTION
## Summary

Shows the **human-readable consumer project name** in the Service Catalog Consumers table by resolving it server-side through the graphql-gateway, in a single round trip.

**This supersedes #516** (the client-side / per-consumer-project-read approach), which already merged to `main`. This PR is rebased on that merge: it takes over the Consumers table with the gateway query **and removes #516's now-dead `projectQuery` / `useProjectDisplayNamesQuery` helpers**.

## What changed

- **`app/modules/graphql/service-consumers.ts`** — new `listServiceConsumers(producerProject)` calling the gateway's `serviceConsumers` query; returns a flat, enriched consumer shape including `consumerProject { name, displayName }`.
- **`service-catalog.queries.ts`** — new `useServiceConsumersEnrichedQuery`, keyed separately (`consumers.enriched`) from the raw REST list. The revoke + decide mutations now invalidate **both** keys so the table refreshes after approve/deny/revoke.
- **`consumers.tsx`** — uses the enriched query; the Consumer Project cell links the display name with the raw project id as muted subtext (when they differ). Search matches both.
- **`useApprovalDialog`** — decoupled from the k8s `ServiceConsumer` type: now takes a consumer **name** string, so both the REST approvals page and the enriched consumers table can drive it. `approvals.tsx` caller updated.
- **Cleanup of #516** — removed `projectQuery` (`project.api.ts`) and `useProjectDisplayNamesQuery` + the `detail` query key (`project.queries.ts`), which the gateway query makes unnecessary.

## Scope boundary (deliberate)

Only the **Consumers table** moves to GraphQL. The **Approvals page and the nav badge stay on the REST list**, because they rely on the upstream **403 surfacing** to render the "IAM role pending" message — and the gateway resolver intentionally degrades errors to an empty list. Migrating those would lose that signal. This means when both are on screen the consumer list is fetched twice (REST + gql); acceptable at current scale, and called out for reviewers.

## Dependency / rollout

Requires the gateway resolver: **milo-os/graphql-gateway#35** (merge + deploy that first). Until deployed, `serviceConsumers` is unknown to the gateway and the table will error/empty.

## Test plan

- [ ] With gateway #35 deployed: table shows friendly project names + id subtext
- [ ] Projects without `kubernetes.io/description` fall back to the raw name
- [ ] Approve / Deny / Revoke from the table still work and refresh the table
- [ ] Approvals page + nav badge unchanged (still REST, still show IAM-pending message on 403)
- [ ] Search matches display name and raw id

`tsc --noEmit` clean, `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)