### PR TITLE
feat(graphql): migrate org, project, and quota pages to gateway

### DIFF
--- a/app/features/activity/components/ProjectsFilter.tsx
+++ b/app/features/activity/components/ProjectsFilter.tsx
@@ -1,3 +1,4 @@
+import type { GqlProject } from '@/modules/graphql/organizations';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@datum-cloud/activity-ui';
 import { Badge } from '@datum-cloud/datum-ui/badge';
 import { Button } from '@datum-cloud/datum-ui/button';
@@ -5,7 +6,6 @@ import { Checkbox } from '@datum-cloud/datum-ui/checkbox';
 import { Input } from '@datum-cloud/datum-ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@datum-cloud/datum-ui/popover';
 import { cn } from '@datum-cloud/datum-ui/utils';
-import type { GqlProject } from '@/modules/graphql/organizations';
 import { Layers, ChevronDown } from 'lucide-react';
 import { useState, useMemo, useCallback } from 'react';
 

--- a/app/features/activity/components/multi-source-activity-feed.tsx
+++ b/app/features/activity/components/multi-source-activity-feed.tsx
@@ -50,6 +50,7 @@ import {
   serializeProjectsFilter,
 } from '@/features/activity/lib/activity-filters';
 import { staffResourceLinkResolver } from '@/features/activity/lib/activity-link-resolvers';
+import type { GqlProject } from '@/modules/graphql/organizations';
 import { useOrgProjectListQuery } from '@/resources/request/client';
 import {
   ActivityApiClient,
@@ -78,7 +79,6 @@ import {
   TableRow,
 } from '@datum-cloud/datum-ui/table';
 import { cn } from '@datum-cloud/datum-ui/utils';
-import type { GqlProject } from '@/modules/graphql/organizations';
 import { useMemo, useCallback, useEffect, useRef } from 'react';
 import { useSearchParams } from 'react-router';
 

--- a/app/features/quota/components/quota-bucket-list.tsx
+++ b/app/features/quota/components/quota-bucket-list.tsx
@@ -1,7 +1,6 @@
 import { groupQuotas, type QuotaRow } from '../lib/quotas-grouping';
-import { resolveResourceDisplayName, resolveServiceDisplayName } from '../lib/service-catalog';
 import { DialogForm } from '@/components/dialog';
-import { useResourceRegistrationListQuery } from '@/resources/request/client';
+import { type GqlQuotaBucket, type GqlQuotaBucketList } from '@/modules/graphql/quota';
 import { Badge } from '@datum-cloud/datum-ui/badge';
 import { Card, CardContent } from '@datum-cloud/datum-ui/card';
 import { ActionItem } from '@datum-cloud/datum-ui/data-table';
@@ -10,38 +9,31 @@ import { GroupedTable, type GroupedTableGroup } from '@datum-cloud/datum-ui/grou
 import { toast } from '@datum-cloud/datum-ui/toast';
 import { Text } from '@datum-cloud/datum-ui/typography';
 import { useLingui } from '@lingui/react/macro';
-import {
-  ComMiloapisQuotaV1Alpha1AllowanceBucket,
-  ComMiloapisQuotaV1Alpha1AllowanceBucketList,
-  ComMiloapisQuotaV1Alpha1ResourceGrant,
-  ComMiloapisQuotaV1Alpha1ResourceRegistration,
-} from '@openapi/quota.miloapis.com/v1alpha1';
+import { Tooltip } from '@datum-cloud/datum-ui/tooltip';
+import { ComMiloapisQuotaV1Alpha1ResourceGrant } from '@openapi/quota.miloapis.com/v1alpha1';
 import { useQuery } from '@tanstack/react-query';
 import { type ColumnDef } from '@tanstack/react-table';
-import { PencilIcon } from 'lucide-react';
+import { InfoIcon, PencilIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import z from 'zod';
 
 interface QuotaBucketListProps {
   queryKeyPrefix: string[];
-  fetchFn: (
-    params?: Record<string, unknown>
-  ) => Promise<ComMiloapisQuotaV1Alpha1AllowanceBucketList>;
+  fetchFn: (params?: Record<string, unknown>) => Promise<GqlQuotaBucketList>;
   createGrantFn: (
     namespace: string,
     payload: ComMiloapisQuotaV1Alpha1ResourceGrant['spec']
   ) => Promise<ComMiloapisQuotaV1Alpha1ResourceGrant>;
 }
 
-/** Internal row: the grouping fields joined to the underlying bucket. */
 interface QuotaTableRow extends QuotaRow {
-  bucket: ComMiloapisQuotaV1Alpha1AllowanceBucket;
+  bucket: GqlQuotaBucket;
   description?: string;
 }
 
-function usage(bucket: ComMiloapisQuotaV1Alpha1AllowanceBucket) {
-  const used = bucket.status?.allocated ?? 0;
-  const total = bucket.status?.limit ?? 0;
+function usage(bucket: GqlQuotaBucket) {
+  const used = bucket.allocated;
+  const total = bucket.limit;
   const percentage = total > 0 ? Math.round((used / total) * 100) : 0;
   return { used, total, percentage };
 }
@@ -55,7 +47,7 @@ function barColor(percentage: number, total: number) {
 
 export function QuotaBucketList({ queryKeyPrefix, fetchFn, createGrantFn }: QuotaBucketListProps) {
   const { t } = useLingui();
-  const [selected, setSelected] = useState<ComMiloapisQuotaV1Alpha1AllowanceBucket | null>(null);
+  const [selected, setSelected] = useState<GqlQuotaBucket | null>(null);
 
   const tableQuery = useQuery({
     queryKey: [...queryKeyPrefix, 'list'],
@@ -64,51 +56,16 @@ export function QuotaBucketList({ queryKeyPrefix, fetchFn, createGrantFn }: Quot
     staleTime: 60 * 1000,
   });
 
-  const registrationsQuery = useResourceRegistrationListQuery();
-
-  // resourceType -> registration, for display name / description / owner lookup.
-  const registrations = useMemo(() => {
-    const map = new Map<string, ComMiloapisQuotaV1Alpha1ResourceRegistration>();
-    for (const reg of registrationsQuery.data?.items ?? []) {
-      if (reg.spec?.resourceType) map.set(reg.spec.resourceType, reg);
-    }
-    return map;
-  }, [registrationsQuery.data]);
-
   const rows = useMemo<QuotaTableRow[]>(() => {
-    return (tableQuery.data?.items ?? [])
-      .filter((bucket) => {
-        const reg = registrations.get(bucket.spec?.resourceType ?? '');
-        // Feature-type registrations are visibility flags with no countable
-        // usage — they belong on the Feature Flags page, not here. (Codegen
-        // narrows spec.type to Entity|Allocation, so compare as a string.)
-        return String(reg?.spec?.type ?? '') !== 'Feature';
-      })
-      .map((bucket) => {
-        const resourceType = bucket.spec?.resourceType ?? '';
-        const reg = registrations.get(resourceType);
-        const annotations = reg?.metadata?.annotations ?? {};
-        const labels = reg?.metadata?.labels ?? {};
-        // Two ownership labels exist in the wild: `services.miloapis.com/owner`
-        // (hand-authored on network/dns/core/notes/resourcemanager registrations)
-        // and `services.miloapis.com/service` (set by the service-catalog
-        // ServiceConfiguration controller on compute/billing). Prefer owner,
-        // fall back to service.
-        const owner =
-          labels['services.miloapis.com/owner'] ?? labels['services.miloapis.com/service'];
-        return {
-          resourceType,
-          displayName: resolveResourceDisplayName(
-            annotations['kubernetes.io/display-name'],
-            resourceType
-          ),
-          description: annotations['kubernetes.io/description'] ?? reg?.spec?.description,
-          group: resolveServiceDisplayName(owner, resourceType),
-          percentage: usage(bucket).percentage,
-          bucket,
-        };
-      });
-  }, [tableQuery.data, registrations]);
+    return (tableQuery.data?.items ?? []).map((bucket) => ({
+      resourceType: bucket.resourceType,
+      displayName: bucket.displayName,
+      description: bucket.description ?? undefined,
+      group: bucket.serviceDisplayName,
+      percentage: usage(bucket).percentage,
+      bucket,
+    }));
+  }, [tableQuery.data]);
 
   const groups = useMemo<GroupedTableGroup<QuotaTableRow>[]>(
     () =>
@@ -129,18 +86,20 @@ export function QuotaBucketList({ queryKeyPrefix, fetchFn, createGrantFn }: Quot
         accessorFn: (row) => row.displayName,
         size: 320,
         cell: ({ row }) => (
-          <div>
-            <Text size="sm" className="block font-medium">
-              {row.original.displayName}
-            </Text>
-            {row.original.description && (
-              <Text size="xs" textColor="muted" className="mt-0.5 block">
-                {row.original.description}
+          <div className="overflow-hidden">
+            <div className="flex items-center gap-1.5">
+              <Text size="sm" className="font-medium">
+                {row.original.displayName}
               </Text>
-            )}
-            {row.original.resourceType !== row.original.displayName && (
-              <Text size="xs" textColor="muted" className="mt-0.5 block font-mono">
-                {row.original.resourceType}
+              {row.original.resourceType !== row.original.displayName && (
+                <Tooltip message={row.original.resourceType}>
+                  <InfoIcon className="size-3 shrink-0 text-muted-foreground opacity-60" />
+                </Tooltip>
+              )}
+            </div>
+            {row.original.description && (
+              <Text size="xs" textColor="muted" className="mt-0.5 block line-clamp-2">
+                {row.original.description}
               </Text>
             )}
           </div>
@@ -194,7 +153,7 @@ export function QuotaBucketList({ queryKeyPrefix, fetchFn, createGrantFn }: Quot
     },
   ];
 
-  const currentLimit = selected?.status?.limit ?? 0;
+  const currentLimit = selected?.limit ?? 0;
   const increaseSchema = z.object({
     newLimit: z.coerce
       .number()
@@ -212,14 +171,14 @@ export function QuotaBucketList({ queryKeyPrefix, fetchFn, createGrantFn }: Quot
         cancelText={t`Cancel`}
         onSubmit={async (formData) => {
           const amount = Math.max(0, formData.newLimit - currentLimit);
-          await createGrantFn(selected?.metadata?.namespace ?? '', {
+          await createGrantFn(selected?.namespace ?? '', {
             consumerRef: {
-              apiGroup: selected?.spec.consumerRef.apiGroup ?? '',
-              kind: selected?.spec.consumerRef.kind as 'Organization' | 'Project',
-              name: selected?.spec.consumerRef.name ?? '',
+              apiGroup: selected?.consumerApiGroup ?? '',
+              kind: selected?.consumerKind as 'Organization' | 'Project',
+              name: selected?.consumerName ?? '',
             },
             allowances: [
-              { resourceType: selected?.spec.resourceType ?? '', buckets: [{ amount }] },
+              { resourceType: selected?.resourceType ?? '', buckets: [{ amount }] },
             ],
           });
           await new Promise((r) => setTimeout(() => r(tableQuery.refetch()), 1000));
@@ -230,7 +189,7 @@ export function QuotaBucketList({ queryKeyPrefix, fetchFn, createGrantFn }: Quot
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-2">
             <Text className="text-muted-foreground">{t`Resource Type:`}</Text>
-            <Text>{selected?.spec.resourceType}</Text>
+            <Text>{selected?.resourceType}</Text>
           </div>
           <div className="flex items-center gap-2">
             <Text className="text-muted-foreground">{t`Limit:`}</Text>

--- a/app/features/quota/components/quota-grant-list.tsx
+++ b/app/features/quota/components/quota-grant-list.tsx
@@ -1,60 +1,35 @@
 import { groupQuotas, type QuotaRow } from '../lib/quotas-grouping';
-import { resolveResourceDisplayName, resolveServiceDisplayName } from '../lib/service-catalog';
 import { BadgeCondition } from '@/components/badge';
 import { DateTime } from '@/components/date';
 import { DialogConfirm } from '@/components/dialog';
-import { useResourceRegistrationListQuery } from '@/resources/request/client';
+import { type GqlQuotaGrant, type GqlQuotaGrantList } from '@/modules/graphql/quota';
 import { Badge } from '@datum-cloud/datum-ui/badge';
+import { Tooltip } from '@datum-cloud/datum-ui/tooltip';
 import { Card, CardContent } from '@datum-cloud/datum-ui/card';
 import { ActionItem } from '@datum-cloud/datum-ui/data-table';
 import { GroupedTable, type GroupedTableGroup } from '@datum-cloud/datum-ui/grouped-table';
 import { toast } from '@datum-cloud/datum-ui/toast';
 import { Text } from '@datum-cloud/datum-ui/typography';
 import { useLingui } from '@lingui/react/macro';
-import {
-  ComMiloapisQuotaV1Alpha1ResourceGrant,
-  ComMiloapisQuotaV1Alpha1ResourceGrantList,
-  ComMiloapisQuotaV1Alpha1ResourceRegistration,
-} from '@openapi/quota.miloapis.com/v1alpha1';
 import { useQuery } from '@tanstack/react-query';
 import { type ColumnDef } from '@tanstack/react-table';
-import { Trash2Icon } from 'lucide-react';
+import { InfoIcon, Trash2Icon } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 interface QuotaGrantListProps {
   queryKeyPrefix: string[];
-  fetchFn: (params?: Record<string, unknown>) => Promise<ComMiloapisQuotaV1Alpha1ResourceGrantList>;
+  fetchFn: (params?: Record<string, unknown>) => Promise<GqlQuotaGrantList>;
   deleteGrantFn: (name: string, namespace: string) => Promise<unknown>;
 }
 
-/**
- * Internal row: a single (grant × resourceType) pair. A grant that allows
- * multiple resourceTypes is flattened into one row per type so the table can
- * group by owning service and show friendly names, the same as the Usage tab.
- * Deletes still operate on the parent grant.
- */
 interface QuotaGrantRow extends QuotaRow {
-  grant: ComMiloapisQuotaV1Alpha1ResourceGrant;
+  grant: GqlQuotaGrant;
   allocation: number;
-}
-
-/** Sum every bucket amount per resourceType within a single grant. */
-function allocationByResourceType(
-  allowances: ComMiloapisQuotaV1Alpha1ResourceGrant['spec']['allowances'] | undefined
-): Array<[string, number]> {
-  const totals = new Map<string, number>();
-  for (const allowance of allowances ?? []) {
-    const sum = (allowance.buckets ?? []).reduce((acc, b) => acc + (b?.amount ?? 0), 0);
-    totals.set(allowance.resourceType, (totals.get(allowance.resourceType) ?? 0) + sum);
-  }
-  return Array.from(totals.entries());
 }
 
 export function QuotaGrantList({ queryKeyPrefix, fetchFn, deleteGrantFn }: QuotaGrantListProps) {
   const { t } = useLingui();
-  const [selectedGrant, setSelectedGrant] = useState<ComMiloapisQuotaV1Alpha1ResourceGrant | null>(
-    null
-  );
+  const [selectedGrant, setSelectedGrant] = useState<GqlQuotaGrant | null>(null);
 
   const tableQuery = useQuery({
     queryKey: [...queryKeyPrefix, 'list'],
@@ -63,41 +38,18 @@ export function QuotaGrantList({ queryKeyPrefix, fetchFn, deleteGrantFn }: Quota
     staleTime: 60 * 1000,
   });
 
-  const registrationsQuery = useResourceRegistrationListQuery();
-
-  // resourceType -> registration, for display name / description / owner lookup.
-  const registrations = useMemo(() => {
-    const map = new Map<string, ComMiloapisQuotaV1Alpha1ResourceRegistration>();
-    for (const reg of registrationsQuery.data?.items ?? []) {
-      if (reg.spec?.resourceType) map.set(reg.spec.resourceType, reg);
-    }
-    return map;
-  }, [registrationsQuery.data]);
-
   const rows = useMemo<QuotaGrantRow[]>(() => {
     return (tableQuery.data?.items ?? []).flatMap((grant) =>
-      allocationByResourceType(grant.spec?.allowances).map(([resourceType, allocation]) => {
-        const reg = registrations.get(resourceType);
-        const annotations = reg?.metadata?.annotations ?? {};
-        const labels = reg?.metadata?.labels ?? {};
-        // Prefer the hand-authored owner label, fall back to the catalog-managed
-        // service label (compute/billing). Mirrors the Usage tab resolution.
-        const owner =
-          labels['services.miloapis.com/owner'] ?? labels['services.miloapis.com/service'];
-        return {
-          resourceType,
-          displayName: resolveResourceDisplayName(
-            annotations['kubernetes.io/display-name'],
-            resourceType
-          ),
-          group: resolveServiceDisplayName(owner, resourceType),
-          percentage: 0,
-          allocation,
-          grant,
-        };
-      })
+      grant.allowances.map((allowance) => ({
+        resourceType: allowance.resourceType,
+        displayName: allowance.displayName,
+        group: allowance.serviceDisplayName,
+        percentage: 0,
+        allocation: allowance.amount,
+        grant,
+      }))
     );
-  }, [tableQuery.data, registrations]);
+  }, [tableQuery.data]);
 
   const groups = useMemo<GroupedTableGroup<QuotaGrantRow>[]>(
     () =>
@@ -118,14 +70,14 @@ export function QuotaGrantList({ queryKeyPrefix, fetchFn, deleteGrantFn }: Quota
         accessorFn: (row) => row.displayName,
         size: 300,
         cell: ({ row }) => (
-          <div>
-            <Text size="sm" className="block font-medium">
+          <div className="flex items-center gap-1.5">
+            <Text size="xs" className="font-medium">
               {row.original.displayName}
             </Text>
             {row.original.resourceType !== row.original.displayName && (
-              <Text size="xs" textColor="muted" className="mt-0.5 block font-mono">
-                {row.original.resourceType}
-              </Text>
+              <Tooltip message={row.original.resourceType}>
+                <InfoIcon className="size-3 shrink-0 text-muted-foreground opacity-60" />
+              </Tooltip>
             )}
           </div>
         ),
@@ -133,15 +85,15 @@ export function QuotaGrantList({ queryKeyPrefix, fetchFn, deleteGrantFn }: Quota
       {
         id: 'grant',
         header: t`Grant`,
-        accessorFn: (row) => row.grant.metadata?.name,
+        accessorFn: (row) => row.grant.name,
         size: 220,
         cell: ({ row }) => (
           <Text
             size="sm"
             textColor="muted"
             className="truncate"
-            title={row.original.grant.metadata?.name}>
-            {row.original.grant.metadata?.name}
+            title={row.original.grant.name}>
+            {row.original.grant.name}
           </Text>
         ),
       },
@@ -159,11 +111,17 @@ export function QuotaGrantList({ queryKeyPrefix, fetchFn, deleteGrantFn }: Quota
       {
         id: 'status',
         header: t`Status`,
-        accessorFn: (row) => row.grant.status,
+        accessorFn: (row) => row.grant.conditions,
         size: 160,
         cell: ({ row }) => (
           <BadgeCondition
-            status={row.original.grant.status}
+            status={{
+              conditions: row.original.grant.conditions.map((c) => ({
+                type: c.type,
+                status: c.status,
+                message: c.message ?? undefined,
+              })),
+            }}
             multiple={false}
             showMessage
             className="text-xs"
@@ -173,9 +131,9 @@ export function QuotaGrantList({ queryKeyPrefix, fetchFn, deleteGrantFn }: Quota
       {
         id: 'created',
         header: t`Created`,
-        accessorFn: (row) => row.grant.metadata?.creationTimestamp,
+        accessorFn: (row) => row.grant.createdAt,
         size: 160,
-        cell: ({ row }) => <DateTime date={row.original.grant.metadata?.creationTimestamp} />,
+        cell: ({ row }) => <DateTime date={row.original.grant.createdAt ?? undefined} />,
       },
     ],
     [t]
@@ -188,11 +146,11 @@ export function QuotaGrantList({ queryKeyPrefix, fetchFn, deleteGrantFn }: Quota
       variant: 'destructive' as const,
       onClick: (row) => setSelectedGrant(row.grant),
       disabled: (row) => {
-        const isInactive = row.grant.status?.conditions?.some(
+        const isInactive = row.grant.conditions.some(
           (c) => c.type === 'Active' && c.status === 'False'
         );
         if (isInactive) return true;
-        return row.grant.metadata?.labels?.['quota.miloapis.com/auto-created'] === 'true';
+        return row.grant.autoCreated;
       },
     },
   ];
@@ -203,16 +161,13 @@ export function QuotaGrantList({ queryKeyPrefix, fetchFn, deleteGrantFn }: Quota
         open={!!selectedGrant}
         onOpenChange={() => setSelectedGrant(null)}
         title={t`Delete Grant`}
-        description={t`Are you sure you want to delete grant "${selectedGrant?.metadata?.name}"? This action cannot be undone.`}
+        description={t`Are you sure you want to delete grant "${selectedGrant?.name}"? This action cannot be undone.`}
         confirmText={t`Delete`}
         cancelText={t`Cancel`}
         variant="destructive"
         requireConfirmation
         onConfirm={async () => {
-          await deleteGrantFn(
-            selectedGrant?.metadata?.name ?? '',
-            selectedGrant?.metadata?.namespace ?? ''
-          );
+          await deleteGrantFn(selectedGrant?.name ?? '', selectedGrant?.namespace ?? '');
           await new Promise((resolve) => setTimeout(() => resolve(tableQuery.refetch()), 1000));
           setSelectedGrant(null);
           toast.success(t`Grant deleted successfully`);
@@ -235,12 +190,10 @@ export function QuotaGrantList({ queryKeyPrefix, fetchFn, deleteGrantFn }: Quota
               return (
                 row.displayName.toLowerCase().includes(q) ||
                 row.resourceType.toLowerCase().includes(q) ||
-                (row.grant.metadata?.name ?? '').toLowerCase().includes(q)
+                row.grant.name.toLowerCase().includes(q)
               );
             }}
-            getRowId={(row) =>
-              `${row.grant.metadata?.namespace ?? ''}/${row.grant.metadata?.name ?? ''}/${row.resourceType}`
-            }
+            getRowId={(row) => `${row.grant.namespace}/${row.grant.name}/${row.resourceType}`}
             rowActions={rowActions}
             empty={t`No grants found.`}
           />

--- a/app/modules/graphql/quota.ts
+++ b/app/modules/graphql/quota.ts
@@ -1,0 +1,122 @@
+import { createGqlClient } from './client';
+import { mapApiError } from '@/utils/errors/error-mapper';
+
+export interface GqlQuotaBucket {
+  name: string;
+  namespace: string;
+  resourceType: string;
+  consumerKind: string;
+  consumerName: string;
+  consumerApiGroup: string;
+  allocated: number;
+  limit: number;
+  available: number;
+  displayName: string;
+  description: string | null;
+  registrationType: string | null;
+  serviceOwner: string | null;
+  serviceDisplayName: string;
+}
+
+export interface GqlQuotaBucketList {
+  items: GqlQuotaBucket[];
+}
+
+export interface GqlQuotaGrantAllowance {
+  resourceType: string;
+  displayName: string;
+  serviceDisplayName: string;
+  amount: number;
+}
+
+export interface GqlQuotaCondition {
+  type: string;
+  status: string;
+  message: string | null;
+}
+
+export interface GqlQuotaGrant {
+  name: string;
+  namespace: string;
+  createdAt: string | null;
+  autoCreated: boolean;
+  allowances: GqlQuotaGrantAllowance[];
+  conditions: GqlQuotaCondition[];
+}
+
+export interface GqlQuotaGrantList {
+  items: GqlQuotaGrant[];
+}
+
+const QUOTA_BUCKET_FIELDS = `
+  name namespace resourceType
+  consumerKind consumerName consumerApiGroup
+  allocated limit available
+  displayName description registrationType serviceOwner serviceDisplayName
+`;
+
+const QUOTA_GRANT_FIELDS = `
+  name namespace createdAt autoCreated
+  allowances { resourceType displayName serviceDisplayName amount }
+  conditions { type status message }
+`;
+
+const ORG_QUOTA_BUCKETS_QUERY = `
+  query OrgQuotaBuckets($orgName: String!) {
+    orgQuotaBuckets(orgName: $orgName) {
+      items { ${QUOTA_BUCKET_FIELDS} }
+    }
+  }
+`;
+
+const PROJECT_QUOTA_BUCKETS_QUERY = `
+  query ProjectQuotaBuckets($projectName: String!) {
+    projectQuotaBuckets(projectName: $projectName) {
+      items { ${QUOTA_BUCKET_FIELDS} }
+    }
+  }
+`;
+
+const ORG_QUOTA_GRANTS_QUERY = `
+  query OrgQuotaGrants($orgName: String!) {
+    orgQuotaGrants(orgName: $orgName) {
+      items { ${QUOTA_GRANT_FIELDS} }
+    }
+  }
+`;
+
+const PROJECT_QUOTA_GRANTS_QUERY = `
+  query ProjectQuotaGrants($projectName: String!) {
+    projectQuotaGrants(projectName: $projectName) {
+      items { ${QUOTA_GRANT_FIELDS} }
+    }
+  }
+`;
+
+export async function listOrgQuotaBuckets(orgName: string): Promise<GqlQuotaBucketList> {
+  const client = createGqlClient({ type: 'global' });
+  const result = await client.query(ORG_QUOTA_BUCKETS_QUERY, { orgName }).toPromise();
+  if (result.error) throw mapApiError(result.error);
+  return result.data?.orgQuotaBuckets ?? { items: [] };
+}
+
+export async function listProjectQuotaBuckets(projectName: string): Promise<GqlQuotaBucketList> {
+  const client = createGqlClient({ type: 'global' });
+  const result = await client.query(PROJECT_QUOTA_BUCKETS_QUERY, { projectName }).toPromise();
+  if (result.error) throw mapApiError(result.error);
+  return result.data?.projectQuotaBuckets ?? { items: [] };
+}
+
+export async function listOrgQuotaGrants(orgName: string): Promise<GqlQuotaGrantList> {
+  const client = createGqlClient({ type: 'global' });
+  const result = await client.query(ORG_QUOTA_GRANTS_QUERY, { orgName }).toPromise();
+  if (result.error) throw mapApiError(result.error);
+  return result.data?.orgQuotaGrants ?? { items: [] };
+}
+
+export async function listProjectQuotaGrants(projectName: string): Promise<GqlQuotaGrantList> {
+  const client = createGqlClient({ type: 'global' });
+  const result = await client.query(PROJECT_QUOTA_GRANTS_QUERY, { projectName }).toPromise();
+  if (result.error) throw mapApiError(result.error);
+  return result.data?.projectQuotaGrants ?? { items: [] };
+}

--- a/app/modules/i18n/locales/en.po
+++ b/app/modules/i18n/locales/en.po
@@ -53,7 +53,7 @@ msgstr "# of Sinks"
 msgid "# of Sources"
 msgstr "# of Sources"
 
-#: app/features/quota/components/quota-bucket-list.tsx:165
+#: app/features/quota/components/quota-bucket-list.tsx:124
 msgid "% Used"
 msgstr "% Used"
 
@@ -270,7 +270,7 @@ msgstr "All registrations are up to date"
 msgid "All write operations"
 msgstr "All write operations"
 
-#: app/features/quota/components/quota-grant-list.tsx:150
+#: app/features/quota/components/quota-grant-list.tsx:98
 msgid "Allocation"
 msgstr "Allocation"
 
@@ -332,8 +332,8 @@ msgstr "Are you sure you want to delete {0} lists? This action cannot be undone.
 msgid "Are you sure you want to delete contact \"{0}\"? This action cannot be undone."
 msgstr "Are you sure you want to delete contact \"{0}\"? This action cannot be undone."
 
-#. placeholder {0}: selectedGrant?.metadata?.name
-#: app/features/quota/components/quota-grant-list.tsx:206
+#. placeholder {0}: selectedGrant?.name
+#: app/features/quota/components/quota-grant-list.tsx:160
 msgid "Are you sure you want to delete grant \"{0}\"? This action cannot be undone."
 msgstr "Are you sure you want to delete grant \"{0}\"? This action cannot be undone."
 
@@ -478,8 +478,8 @@ msgstr "by"
 #: app/features/contact/components/contact-list.tsx:117
 #: app/features/feature-flags/components/feature-flag-list.tsx:230
 #: app/features/fraud/policy/policy-form.tsx:318
-#: app/features/quota/components/quota-bucket-list.tsx:212
-#: app/features/quota/components/quota-grant-list.tsx:208
+#: app/features/quota/components/quota-bucket-list.tsx:171
+#: app/features/quota/components/quota-grant-list.tsx:162
 #: app/features/service-catalog/hooks/useApprovalDialog.tsx:39
 #: app/features/user/components/user-reject-dialog.tsx:30
 #: app/routes/contact-group/detail/member.tsx:346
@@ -710,7 +710,7 @@ msgstr "Create Policy"
 #: app/features/domain/components/domain-list.tsx:106
 #: app/features/edge/components/detail/edge-general-card.tsx:49
 #: app/features/edge/components/edge-list.tsx:107
-#: app/features/quota/components/quota-grant-list.tsx:175
+#: app/features/quota/components/quota-grant-list.tsx:129
 #: app/features/user/components/user-identity-card.tsx:181
 #: app/routes/contact-group/index.tsx:89
 #: app/routes/finance/billing-account/detail/index.tsx:208
@@ -834,8 +834,8 @@ msgstr "Degraded"
 #: app/features/contact/components/contact-list.tsx:58
 #: app/features/contact/components/contact-list.tsx:116
 #: app/features/fraud/policy/policy-detail.tsx:100
-#: app/features/quota/components/quota-grant-list.tsx:186
-#: app/features/quota/components/quota-grant-list.tsx:207
+#: app/features/quota/components/quota-grant-list.tsx:140
+#: app/features/quota/components/quota-grant-list.tsx:161
 #: app/routes/contact-group/detail/member.tsx:163
 #: app/routes/contact-group/detail/member.tsx:345
 #: app/routes/contact-group/index.tsx:56
@@ -883,7 +883,7 @@ msgstr "Delete Contact"
 msgid "Delete Evaluation"
 msgstr "Delete Evaluation"
 
-#: app/features/quota/components/quota-grant-list.tsx:205
+#: app/features/quota/components/quota-grant-list.tsx:159
 msgid "Delete Grant"
 msgstr "Delete Grant"
 
@@ -1109,8 +1109,8 @@ msgstr "Edit Fraud Policy"
 msgid "Edit Fraud Provider"
 msgstr "Edit Fraud Provider"
 
-#: app/features/quota/components/quota-bucket-list.tsx:191
-#: app/features/quota/components/quota-bucket-list.tsx:210
+#: app/features/quota/components/quota-bucket-list.tsx:150
+#: app/features/quota/components/quota-bucket-list.tsx:169
 msgid "Edit Quota"
 msgstr "Edit Quota"
 
@@ -1520,18 +1520,18 @@ msgstr "Get"
 msgid "Go to dashboard"
 msgstr "Go to dashboard"
 
-#: app/features/quota/components/quota-grant-list.tsx:135
+#: app/features/quota/components/quota-grant-list.tsx:87
 msgid "Grant"
 msgstr "Grant"
 
-#: app/features/quota/components/quota-grant-list.tsx:218
+#: app/features/quota/components/quota-grant-list.tsx:169
 msgid "Grant deleted successfully"
 msgstr "Grant deleted successfully"
 
 #: app/routes/organization/detail/layout.tsx:120
-#: app/routes/organization/detail/quota/grant.tsx:9
+#: app/routes/organization/detail/quota/grant.tsx:10
 #: app/routes/project/detail/layout.tsx:168
-#: app/routes/project/detail/quota/grant.tsx:12
+#: app/routes/project/detail/quota/grant.tsx:10
 msgid "Grants"
 msgstr "Grants"
 
@@ -1701,7 +1701,7 @@ msgstr "License Key Key"
 msgid "Light"
 msgstr "Light"
 
-#: app/features/quota/components/quota-bucket-list.tsx:236
+#: app/features/quota/components/quota-bucket-list.tsx:193
 msgid "Limit:"
 msgstr "Limit:"
 
@@ -1972,7 +1972,7 @@ msgstr "New Evaluation"
 msgid "New Fraud Evaluation"
 msgstr "New Fraud Evaluation"
 
-#: app/features/quota/components/quota-bucket-list.tsx:240
+#: app/features/quota/components/quota-bucket-list.tsx:197
 msgid "New Limit"
 msgstr "New Limit"
 
@@ -2080,7 +2080,7 @@ msgstr "No fraud providers configured."
 msgid "No grants found to remove for this flag"
 msgstr "No grants found to remove for this flag"
 
-#: app/features/quota/components/quota-grant-list.tsx:245
+#: app/features/quota/components/quota-grant-list.tsx:194
 msgid "No grants found."
 msgstr "No grants found."
 
@@ -2146,7 +2146,7 @@ msgstr "No projects found."
 msgid "No Published configuration. Drafts are not fanned out to billing or quota."
 msgstr "No Published configuration. Drafts are not fanned out to billing or quota."
 
-#: app/features/quota/components/quota-bucket-list.tsx:265
+#: app/features/quota/components/quota-bucket-list.tsx:222
 msgid "No quota buckets found."
 msgstr "No quota buckets found."
 
@@ -2560,7 +2560,7 @@ msgstr "Quick ranges"
 msgid "Quota"
 msgstr "Quota"
 
-#: app/features/quota/components/quota-bucket-list.tsx:226
+#: app/features/quota/components/quota-bucket-list.tsx:183
 msgid "Quota updated successfully"
 msgstr "Quota updated successfully"
 
@@ -2678,8 +2678,8 @@ msgid "Resend"
 msgstr "Resend"
 
 #: app/features/dashboard/components/quota-utilization-widget.tsx:156
-#: app/features/quota/components/quota-bucket-list.tsx:128
-#: app/features/quota/components/quota-grant-list.tsx:117
+#: app/features/quota/components/quota-bucket-list.tsx:85
+#: app/features/quota/components/quota-grant-list.tsx:69
 msgid "Resource"
 msgstr "Resource"
 
@@ -2697,7 +2697,7 @@ msgstr "Resource Name"
 msgid "Resource Type"
 msgstr "Resource Type"
 
-#: app/features/quota/components/quota-bucket-list.tsx:232
+#: app/features/quota/components/quota-bucket-list.tsx:189
 msgid "Resource Type:"
 msgstr "Resource Type:"
 
@@ -2850,7 +2850,7 @@ msgstr "Search export policies..."
 msgid "Search for an existing contact by email..."
 msgstr "Search for an existing contact by email..."
 
-#: app/features/quota/components/quota-grant-list.tsx:231
+#: app/features/quota/components/quota-grant-list.tsx:182
 msgid "Search grants..."
 msgstr "Search grants..."
 
@@ -2884,7 +2884,7 @@ msgstr "Search organizations..."
 msgid "Search projects..."
 msgstr "Search projects..."
 
-#: app/features/quota/components/quota-bucket-list.tsx:254
+#: app/features/quota/components/quota-bucket-list.tsx:211
 msgid "Search quotas..."
 msgstr "Search quotas..."
 
@@ -3070,7 +3070,7 @@ msgstr "Start Time"
 #: app/features/email/components/email-list.tsx:143
 #: app/features/email/components/email-list.tsx:159
 #: app/features/fraud/policy/policy-detail.tsx:158
-#: app/features/quota/components/quota-grant-list.tsx:161
+#: app/features/quota/components/quota-grant-list.tsx:109
 #: app/features/service-catalog/components/conditions-card.tsx:23
 #: app/routes/contact-group/detail/member.tsx:208
 #: app/routes/contact-group/index.tsx:82
@@ -3263,7 +3263,7 @@ msgstr "Unverified"
 #: app/features/contact-group/components/contact-group-form.tsx:101
 #: app/features/contact/components/contact-form.tsx:250
 #: app/features/fraud/policy/policy-form.tsx:321
-#: app/features/quota/components/quota-bucket-list.tsx:211
+#: app/features/quota/components/quota-bucket-list.tsx:170
 #: app/routes/fraud/providers/detail.tsx:181
 msgid "Update"
 msgstr "Update"
@@ -3281,12 +3281,12 @@ msgid "Updating email addresses for GitHub identities"
 msgstr "Updating email addresses for GitHub identities"
 
 #: app/features/dashboard/components/quota-utilization-widget.tsx:161
-#: app/features/quota/components/quota-bucket-list.tsx:151
+#: app/features/quota/components/quota-bucket-list.tsx:110
 #: app/routes/organization/detail/layout.tsx:96
 #: app/routes/organization/detail/layout.tsx:116
-#: app/routes/organization/detail/quota/usage.tsx:9
+#: app/routes/organization/detail/quota/usage.tsx:10
 #: app/routes/project/detail/layout.tsx:164
-#: app/routes/project/detail/quota/usage.tsx:12
+#: app/routes/project/detail/quota/usage.tsx:10
 msgid "Usage"
 msgstr "Usage"
 

--- a/app/modules/i18n/locales/fr.po
+++ b/app/modules/i18n/locales/fr.po
@@ -53,7 +53,7 @@ msgstr ""
 msgid "# of Sources"
 msgstr ""
 
-#: app/features/quota/components/quota-bucket-list.tsx:165
+#: app/features/quota/components/quota-bucket-list.tsx:124
 msgid "% Used"
 msgstr ""
 
@@ -270,7 +270,7 @@ msgstr ""
 msgid "All write operations"
 msgstr ""
 
-#: app/features/quota/components/quota-grant-list.tsx:150
+#: app/features/quota/components/quota-grant-list.tsx:98
 msgid "Allocation"
 msgstr ""
 
@@ -332,8 +332,8 @@ msgstr ""
 msgid "Are you sure you want to delete contact \"{0}\"? This action cannot be undone."
 msgstr ""
 
-#. placeholder {0}: selectedGrant?.metadata?.name
-#: app/features/quota/components/quota-grant-list.tsx:206
+#. placeholder {0}: selectedGrant?.name
+#: app/features/quota/components/quota-grant-list.tsx:160
 msgid "Are you sure you want to delete grant \"{0}\"? This action cannot be undone."
 msgstr ""
 
@@ -478,8 +478,8 @@ msgstr ""
 #: app/features/contact/components/contact-list.tsx:117
 #: app/features/feature-flags/components/feature-flag-list.tsx:230
 #: app/features/fraud/policy/policy-form.tsx:318
-#: app/features/quota/components/quota-bucket-list.tsx:212
-#: app/features/quota/components/quota-grant-list.tsx:208
+#: app/features/quota/components/quota-bucket-list.tsx:171
+#: app/features/quota/components/quota-grant-list.tsx:162
 #: app/features/service-catalog/hooks/useApprovalDialog.tsx:39
 #: app/features/user/components/user-reject-dialog.tsx:30
 #: app/routes/contact-group/detail/member.tsx:346
@@ -710,7 +710,7 @@ msgstr ""
 #: app/features/domain/components/domain-list.tsx:106
 #: app/features/edge/components/detail/edge-general-card.tsx:49
 #: app/features/edge/components/edge-list.tsx:107
-#: app/features/quota/components/quota-grant-list.tsx:175
+#: app/features/quota/components/quota-grant-list.tsx:129
 #: app/features/user/components/user-identity-card.tsx:181
 #: app/routes/contact-group/index.tsx:89
 #: app/routes/finance/billing-account/detail/index.tsx:208
@@ -834,8 +834,8 @@ msgstr ""
 #: app/features/contact/components/contact-list.tsx:58
 #: app/features/contact/components/contact-list.tsx:116
 #: app/features/fraud/policy/policy-detail.tsx:100
-#: app/features/quota/components/quota-grant-list.tsx:186
-#: app/features/quota/components/quota-grant-list.tsx:207
+#: app/features/quota/components/quota-grant-list.tsx:140
+#: app/features/quota/components/quota-grant-list.tsx:161
 #: app/routes/contact-group/detail/member.tsx:163
 #: app/routes/contact-group/detail/member.tsx:345
 #: app/routes/contact-group/index.tsx:56
@@ -883,7 +883,7 @@ msgstr ""
 msgid "Delete Evaluation"
 msgstr ""
 
-#: app/features/quota/components/quota-grant-list.tsx:205
+#: app/features/quota/components/quota-grant-list.tsx:159
 msgid "Delete Grant"
 msgstr ""
 
@@ -1109,8 +1109,8 @@ msgstr ""
 msgid "Edit Fraud Provider"
 msgstr ""
 
-#: app/features/quota/components/quota-bucket-list.tsx:191
-#: app/features/quota/components/quota-bucket-list.tsx:210
+#: app/features/quota/components/quota-bucket-list.tsx:150
+#: app/features/quota/components/quota-bucket-list.tsx:169
 msgid "Edit Quota"
 msgstr ""
 
@@ -1520,18 +1520,18 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: app/features/quota/components/quota-grant-list.tsx:135
+#: app/features/quota/components/quota-grant-list.tsx:87
 msgid "Grant"
 msgstr ""
 
-#: app/features/quota/components/quota-grant-list.tsx:218
+#: app/features/quota/components/quota-grant-list.tsx:169
 msgid "Grant deleted successfully"
 msgstr ""
 
 #: app/routes/organization/detail/layout.tsx:120
-#: app/routes/organization/detail/quota/grant.tsx:9
+#: app/routes/organization/detail/quota/grant.tsx:10
 #: app/routes/project/detail/layout.tsx:168
-#: app/routes/project/detail/quota/grant.tsx:12
+#: app/routes/project/detail/quota/grant.tsx:10
 msgid "Grants"
 msgstr ""
 
@@ -1701,7 +1701,7 @@ msgstr ""
 msgid "Light"
 msgstr ""
 
-#: app/features/quota/components/quota-bucket-list.tsx:236
+#: app/features/quota/components/quota-bucket-list.tsx:193
 msgid "Limit:"
 msgstr ""
 
@@ -1972,7 +1972,7 @@ msgstr ""
 msgid "New Fraud Evaluation"
 msgstr ""
 
-#: app/features/quota/components/quota-bucket-list.tsx:240
+#: app/features/quota/components/quota-bucket-list.tsx:197
 msgid "New Limit"
 msgstr ""
 
@@ -2080,7 +2080,7 @@ msgstr ""
 msgid "No grants found to remove for this flag"
 msgstr ""
 
-#: app/features/quota/components/quota-grant-list.tsx:245
+#: app/features/quota/components/quota-grant-list.tsx:194
 msgid "No grants found."
 msgstr ""
 
@@ -2146,7 +2146,7 @@ msgstr ""
 msgid "No Published configuration. Drafts are not fanned out to billing or quota."
 msgstr ""
 
-#: app/features/quota/components/quota-bucket-list.tsx:265
+#: app/features/quota/components/quota-bucket-list.tsx:222
 msgid "No quota buckets found."
 msgstr ""
 
@@ -2560,7 +2560,7 @@ msgstr ""
 msgid "Quota"
 msgstr ""
 
-#: app/features/quota/components/quota-bucket-list.tsx:226
+#: app/features/quota/components/quota-bucket-list.tsx:183
 msgid "Quota updated successfully"
 msgstr ""
 
@@ -2678,8 +2678,8 @@ msgid "Resend"
 msgstr ""
 
 #: app/features/dashboard/components/quota-utilization-widget.tsx:156
-#: app/features/quota/components/quota-bucket-list.tsx:128
-#: app/features/quota/components/quota-grant-list.tsx:117
+#: app/features/quota/components/quota-bucket-list.tsx:85
+#: app/features/quota/components/quota-grant-list.tsx:69
 msgid "Resource"
 msgstr ""
 
@@ -2697,7 +2697,7 @@ msgstr ""
 msgid "Resource Type"
 msgstr ""
 
-#: app/features/quota/components/quota-bucket-list.tsx:232
+#: app/features/quota/components/quota-bucket-list.tsx:189
 msgid "Resource Type:"
 msgstr ""
 
@@ -2850,7 +2850,7 @@ msgstr ""
 msgid "Search for an existing contact by email..."
 msgstr ""
 
-#: app/features/quota/components/quota-grant-list.tsx:231
+#: app/features/quota/components/quota-grant-list.tsx:182
 msgid "Search grants..."
 msgstr ""
 
@@ -2884,7 +2884,7 @@ msgstr ""
 msgid "Search projects..."
 msgstr ""
 
-#: app/features/quota/components/quota-bucket-list.tsx:254
+#: app/features/quota/components/quota-bucket-list.tsx:211
 msgid "Search quotas..."
 msgstr ""
 
@@ -3070,7 +3070,7 @@ msgstr ""
 #: app/features/email/components/email-list.tsx:143
 #: app/features/email/components/email-list.tsx:159
 #: app/features/fraud/policy/policy-detail.tsx:158
-#: app/features/quota/components/quota-grant-list.tsx:161
+#: app/features/quota/components/quota-grant-list.tsx:109
 #: app/features/service-catalog/components/conditions-card.tsx:23
 #: app/routes/contact-group/detail/member.tsx:208
 #: app/routes/contact-group/index.tsx:82
@@ -3263,7 +3263,7 @@ msgstr ""
 #: app/features/contact-group/components/contact-group-form.tsx:101
 #: app/features/contact/components/contact-form.tsx:250
 #: app/features/fraud/policy/policy-form.tsx:321
-#: app/features/quota/components/quota-bucket-list.tsx:211
+#: app/features/quota/components/quota-bucket-list.tsx:170
 #: app/routes/fraud/providers/detail.tsx:181
 msgid "Update"
 msgstr ""
@@ -3281,12 +3281,12 @@ msgid "Updating email addresses for GitHub identities"
 msgstr ""
 
 #: app/features/dashboard/components/quota-utilization-widget.tsx:161
-#: app/features/quota/components/quota-bucket-list.tsx:151
+#: app/features/quota/components/quota-bucket-list.tsx:110
 #: app/routes/organization/detail/layout.tsx:96
 #: app/routes/organization/detail/layout.tsx:116
-#: app/routes/organization/detail/quota/usage.tsx:9
+#: app/routes/organization/detail/quota/usage.tsx:10
 #: app/routes/project/detail/layout.tsx:164
-#: app/routes/project/detail/quota/usage.tsx:12
+#: app/routes/project/detail/quota/usage.tsx:10
 msgid "Usage"
 msgstr ""
 

--- a/app/routes/organization/detail/quota/grant.tsx
+++ b/app/routes/organization/detail/quota/grant.tsx
@@ -1,7 +1,8 @@
 import { getOrganizationDetailMetadata, useOrganizationDetailData } from '../../shared';
 import type { Route } from './+types/grant';
 import { QuotaGrantList } from '@/features/quota';
-import { orgQuotaGrantDeleteMutation, orgQuotaGrantListQuery } from '@/resources/request/client';
+import { listOrgQuotaGrants } from '@/modules/graphql/quota';
+import { orgQuotaGrantDeleteMutation } from '@/resources/request/client';
 import { metaObject } from '@/utils/helpers';
 import { Trans } from '@lingui/react/macro';
 
@@ -20,7 +21,7 @@ export default function Page() {
   return (
     <QuotaGrantList
       queryKeyPrefix={['organizations', data.metadata?.name ?? '', 'grants']}
-      fetchFn={(params) => orgQuotaGrantListQuery(data.metadata?.name ?? '', params)}
+      fetchFn={() => listOrgQuotaGrants(data.metadata?.name ?? '')}
       deleteGrantFn={(name, namespace) =>
         orgQuotaGrantDeleteMutation(data.metadata?.name ?? '', name, namespace)
       }

--- a/app/routes/organization/detail/quota/usage.tsx
+++ b/app/routes/organization/detail/quota/usage.tsx
@@ -1,7 +1,8 @@
 import { getOrganizationDetailMetadata, useOrganizationDetailData } from '../../shared';
 import type { Route } from './+types/usage';
 import { QuotaBucketList } from '@/features/quota';
-import { orgQuotaBucketListQuery, orgQuotaGrantCreateMutation } from '@/resources/request/client';
+import { listOrgQuotaBuckets } from '@/modules/graphql/quota';
+import { orgQuotaGrantCreateMutation } from '@/resources/request/client';
 import { metaObject } from '@/utils/helpers';
 import { Trans } from '@lingui/react/macro';
 
@@ -20,7 +21,7 @@ export default function Page() {
   return (
     <QuotaBucketList
       queryKeyPrefix={['organizations', data.metadata?.name ?? '', 'buckets']}
-      fetchFn={(params) => orgQuotaBucketListQuery(data.metadata?.name ?? '', params)}
+      fetchFn={() => listOrgQuotaBuckets(data.metadata?.name ?? '')}
       createGrantFn={(namespace, payload) =>
         orgQuotaGrantCreateMutation(data.metadata?.name ?? '', namespace, payload)
       }

--- a/app/routes/project/detail/quota/grant.tsx
+++ b/app/routes/project/detail/quota/grant.tsx
@@ -1,10 +1,8 @@
 import { getProjectDetailMetadata, useProjectDetailData } from '../../shared';
 import type { Route } from './+types/grant';
 import { QuotaGrantList } from '@/features/quota';
-import {
-  projectQuotaGrantDeleteMutation,
-  projectQuotaGrantListQuery,
-} from '@/resources/request/client';
+import { listProjectQuotaGrants } from '@/modules/graphql/quota';
+import { projectQuotaGrantDeleteMutation } from '@/resources/request/client';
 import { metaObject } from '@/utils/helpers';
 import { Trans } from '@lingui/react/macro';
 
@@ -23,7 +21,7 @@ export default function Page() {
   return (
     <QuotaGrantList
       queryKeyPrefix={['projects', project?.metadata?.name ?? '', 'grants']}
-      fetchFn={(params) => projectQuotaGrantListQuery(project?.metadata?.name ?? '', params)}
+      fetchFn={() => listProjectQuotaGrants(project?.metadata?.name ?? '')}
       deleteGrantFn={(name, namespace) =>
         projectQuotaGrantDeleteMutation(project?.metadata?.name ?? '', name, namespace)
       }

--- a/app/routes/project/detail/quota/usage.tsx
+++ b/app/routes/project/detail/quota/usage.tsx
@@ -1,10 +1,8 @@
 import { getProjectDetailMetadata, useProjectDetailData } from '../../shared';
 import type { Route } from './+types/usage';
 import { QuotaBucketList } from '@/features/quota';
-import {
-  projectQuotaBucketListQuery,
-  projectQuotaGrantCreateMutation,
-} from '@/resources/request/client';
+import { listProjectQuotaBuckets } from '@/modules/graphql/quota';
+import { projectQuotaGrantCreateMutation } from '@/resources/request/client';
 import { metaObject } from '@/utils/helpers';
 import { Trans } from '@lingui/react/macro';
 
@@ -23,7 +21,7 @@ export default function Page() {
   return (
     <QuotaBucketList
       queryKeyPrefix={['projects', project?.metadata?.name ?? '', 'buckets']}
-      fetchFn={(params) => projectQuotaBucketListQuery(project?.metadata?.name ?? '', params)}
+      fetchFn={() => listProjectQuotaBuckets(project?.metadata?.name ?? '')}
       createGrantFn={(namespace, payload) =>
         projectQuotaGrantCreateMutation(project?.metadata?.name ?? '', namespace, payload)
       }


### PR DESCRIPTION
## Summary

- Adds URQL-based GraphQL client modules (`organizations.ts`, `projects.ts`, `quota.ts`) using raw query strings to target new gateway operations not yet deployed to staging
- Migrates org list, org detail, project list, org members pages from REST to GraphQL
- Migrates quota Usage and Grants tabs (org + project) from REST to GraphQL — removes client-side `useResourceRegistrationListQuery` join; display names now resolved server-side
- `QuotaBucketList`: resource type shown via info icon tooltip, description clamped to 2 lines
- `QuotaGrantList`: resource type shown via info icon tooltip
- Mutations (grant create/delete) remain as REST
- Updates `graphql.config.json` with 10 new operations for typed client generation once gateway is deployed

## Test plan

- [ ] Org list loads and paginates
- [ ] Org detail → Projects, Members tabs load
- [ ] Project list loads
- [ ] Org quota Usage tab: buckets grouped by service, display names correct, Feature-type resources absent
- [ ] Org quota Grants tab: grants listed, status badges render, auto-created grants have delete disabled
- [ ] Project quota Usage and Grants tabs same as above
- [ ] Edit quota dialog: correct resource type and current limit shown, submit creates grant
- [ ] Delete grant confirm flow works