### PR TITLE
feat(milo): show user avatars from status.avatarUrl

### DIFF
--- a/app/components/user-avatar/index.tsx
+++ b/app/components/user-avatar/index.tsx
@@ -1,0 +1,38 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@datum-cloud/datum-ui/avatar';
+
+/** First letters of the first two words, uppercased (e.g. "Ada Lovelace" → "AL"). */
+function initialsOf(name?: string): string {
+  return (
+    (name ?? '')
+      .split(' ')
+      .map((part) => part[0])
+      .filter(Boolean)
+      .join('')
+      .slice(0, 2)
+      .toUpperCase() || '?'
+  );
+}
+
+interface UserAvatarProps {
+  /** Display name — used for the alt text and to derive the initials fallback. */
+  name?: string;
+  /** Avatar image URL (User `status.avatarUrl`); falls back to initials if absent. */
+  avatarUrl?: string;
+  /** Classes for the Avatar root (size + shape). */
+  className?: string;
+  /** Classes for the initials fallback (shape + text size). */
+  fallbackClassName?: string;
+}
+
+/**
+ * A user's avatar: shows `avatarUrl` when present (auth-provider populated),
+ * otherwise the initials. One place so every user avatar renders the same way.
+ */
+export function UserAvatar({ name, avatarUrl, className, fallbackClassName }: UserAvatarProps) {
+  return (
+    <Avatar className={className}>
+      {avatarUrl && <AvatarImage src={avatarUrl} alt={name || 'User'} />}
+      <AvatarFallback className={fallbackClassName}>{initialsOf(name)}</AvatarFallback>
+    </Avatar>
+  );
+}

--- a/app/features/dashboard/components/recent-users-widget.tsx
+++ b/app/features/dashboard/components/recent-users-widget.tsx
@@ -1,8 +1,8 @@
 import { DateTime } from '@/components/date';
 import { DisplayName } from '@/components/display';
+import { UserAvatar } from '@/components/user-avatar';
 import { activityListQuery } from '@/resources/request/client';
 import { userRoutes } from '@/utils/config/routes.config';
-import { Avatar, AvatarFallback } from '@datum-cloud/datum-ui/avatar';
 import { Button } from '@datum-cloud/datum-ui/button';
 import { Card, CardContent, CardDescription, CardHeader } from '@datum-cloud/datum-ui/card';
 import { Text, Title } from '@datum-cloud/datum-ui/typography';
@@ -19,14 +19,16 @@ function UserItem({ log }: { log: IoK8sApiserverPkgApisAuditV1Event }) {
   if (!userData?.spec) return null;
 
   const { givenName, familyName } = userData?.spec ?? {};
-  const initials = `${givenName?.charAt(0) || ''}${familyName?.charAt(0) || ''}`;
   const fullName = `${givenName || ''} ${familyName || ''}`.trim();
 
   return (
     <div key={log.user?.username} className="flex items-center gap-3 rounded-md border p-2">
-      <Avatar className="h-8 w-8">
-        <AvatarFallback className="text-xs font-medium">{initials || '?'}</AvatarFallback>
-      </Avatar>
+      <UserAvatar
+        name={fullName}
+        avatarUrl={userData?.status?.avatarUrl}
+        className="h-8 w-8"
+        fallbackClassName="text-xs font-medium"
+      />
       <div className="min-w-0 flex-1">
         <div className="flex items-start justify-between">
           <div className="min-w-0 flex-1">

--- a/app/features/milo/components/navbar/milo-user-menu.tsx
+++ b/app/features/milo/components/navbar/milo-user-menu.tsx
@@ -1,9 +1,9 @@
 'use client';
 
+import { UserAvatar } from '@/components/user-avatar';
 import { useApp } from '@/providers/app.provider';
 import { ACTION_ICONS } from '@/utils/config/icons.config';
 import { routes } from '@/utils/config/routes.config';
-import { Avatar, AvatarFallback } from '@datum-cloud/datum-ui/avatar';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -33,33 +33,30 @@ export function MiloUserMenu() {
     [user]
   );
 
-  const initials = useMemo(
-    () =>
-      fullName
-        .split(' ')
-        .map((n) => n[0])
-        .join('')
-        .substring(0, 2)
-        .toUpperCase(),
-    [fullName]
-  );
+  const avatarUrl = user?.status?.avatarUrl;
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
         aria-label={t`Account menu`}
         className="bg-card border-border focus-visible:ring-ring hover:bg-foreground/5 flex items-center gap-1 rounded-full border p-0.5 pr-1.5 transition-colors outline-none focus-visible:ring-2">
-        <Avatar className="size-7 rounded-full">
-          <AvatarFallback className="rounded-full text-xs">{initials}</AvatarFallback>
-        </Avatar>
+        <UserAvatar
+          name={fullName}
+          avatarUrl={avatarUrl}
+          className="size-7 rounded-full"
+          fallbackClassName="rounded-full text-xs"
+        />
         <Icon icon={ChevronDown} className="text-foreground" />
       </DropdownMenuTrigger>
       <DropdownMenuContent className="min-w-56 rounded-md" side="bottom" align="end" sideOffset={8}>
         <DropdownMenuLabel className="p-0 font-normal">
           <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
-            <Avatar className="size-8 rounded-md">
-              <AvatarFallback className="rounded-md">{initials}</AvatarFallback>
-            </Avatar>
+            <UserAvatar
+              name={fullName}
+              avatarUrl={avatarUrl}
+              className="size-8 rounded-md"
+              fallbackClassName="rounded-md"
+            />
             <div className="grid flex-1 text-left text-sm leading-tight">
               <span className="truncate font-medium">{fullName}</span>
               <span className="truncate text-xs">{user?.spec?.email ?? ''}</span>

--- a/app/modules/i18n/locales/en.po
+++ b/app/modules/i18n/locales/en.po
@@ -131,7 +131,7 @@ msgstr "Account Identities"
 msgid "Account Management"
 msgstr "Account Management"
 
-#: app/features/milo/components/navbar/milo-user-menu.tsx:50
+#: app/features/milo/components/navbar/milo-user-menu.tsx:41
 msgid "Account menu"
 msgstr "Account menu"
 
@@ -170,7 +170,7 @@ msgstr "Active Sessions"
 #: app/routes/customer/project/detail/activity/layout.tsx:5
 #: app/routes/customer/project/detail/layout.tsx:142
 #: app/routes/customer/user/detail/activity/layout.tsx:5
-#: app/routes/customer/user/detail/layout.tsx:60
+#: app/routes/customer/user/detail/layout.tsx:53
 #: app/routes/operation/activity/layout.tsx:13
 msgid "Activity"
 msgstr "Activity"
@@ -303,7 +303,7 @@ msgstr "Approvals"
 #: app/routes/admin/service-catalog/detail/approvals.tsx:50
 #: app/routes/admin/service-catalog/detail/consumers.tsx:53
 #: app/routes/customer/user/detail/index.tsx:199
-#: app/routes/customer/user/index.tsx:51
+#: app/routes/customer/user/index.tsx:52
 msgid "Approve"
 msgstr "Approve"
 
@@ -414,7 +414,7 @@ msgstr "Associated with User: "
 #: app/routes/customer/project/detail/layout.tsx:148
 #: app/routes/customer/user/detail/activity/audit-logs.tsx:14
 #: app/routes/customer/user/detail/activity/audit-logs.tsx:17
-#: app/routes/customer/user/detail/layout.tsx:65
+#: app/routes/customer/user/detail/layout.tsx:58
 #: app/routes/operation/activity/audit-logs.tsx:11
 #: app/routes/operation/activity/audit-logs.tsx:14
 #: app/routes/operation/activity/layout.tsx:35
@@ -485,7 +485,7 @@ msgstr "by"
 #: app/routes/admin/service-catalog/detail/consumers.tsx:207
 #: app/routes/customer/organization/detail/member.tsx:85
 #: app/routes/customer/user/detail/index.tsx:149
-#: app/routes/customer/user/index.tsx:165
+#: app/routes/customer/user/index.tsx:177
 #: app/routes/marketing/contact-group/detail/member.tsx:345
 #: app/routes/marketing/contact-group/detail/member.tsx:362
 #: app/routes/marketing/contact-group/index.tsx:109
@@ -687,7 +687,7 @@ msgstr "Contact updated successfully"
 #: app/components/app-sidebar/index.tsx:147
 #: app/components/app-sidebar/index.tsx:153
 #: app/routes/customer/user/detail/contacts.tsx:9
-#: app/routes/customer/user/detail/layout.tsx:53
+#: app/routes/customer/user/detail/layout.tsx:46
 #: app/routes/marketing/contact/index.tsx:14
 #: app/routes/marketing/contact/layout.tsx:5
 msgid "Contacts"
@@ -777,7 +777,7 @@ msgstr "Create Policy"
 #: app/routes/customer/project/detail/index.tsx:99
 #: app/routes/customer/project/index.tsx:42
 #: app/routes/customer/user/detail/index.tsx:273
-#: app/routes/customer/user/index.tsx:119
+#: app/routes/customer/user/index.tsx:131
 #: app/routes/finance/billing-account/detail/index.tsx:208
 #: app/routes/marketing/contact-group/index.tsx:87
 #: app/routes/operation/fraud/providers/index.tsx:102
@@ -1172,7 +1172,7 @@ msgstr "Edit Quota"
 #: app/features/contact/components/contact-list.tsx:86
 #: app/features/dashboard/components/pending-approvals-widget.tsx:132
 #: app/routes/customer/user/detail/index.tsx:261
-#: app/routes/customer/user/index.tsx:203
+#: app/routes/customer/user/index.tsx:215
 #: app/routes/marketing/contact-group/detail/member.tsx:202
 #: app/routes/operation/fraud/index.tsx:122
 msgid "Email"
@@ -1180,7 +1180,7 @@ msgstr "Email"
 
 #: app/components/app-sidebar/index.tsx:169
 #: app/routes/customer/user/detail/email-activity.tsx:9
-#: app/routes/customer/user/detail/layout.tsx:55
+#: app/routes/customer/user/detail/layout.tsx:48
 #: app/routes/operation/email-activity/layout.tsx:5
 msgid "Email Activity"
 msgstr "Email Activity"
@@ -1201,7 +1201,7 @@ msgstr "Email First Seen"
 msgid "Email HTML preview"
 msgstr "Email HTML preview"
 
-#: app/routes/customer/user/index.tsx:141
+#: app/routes/customer/user/index.tsx:153
 msgid "Email is required"
 msgstr "Email is required"
 
@@ -1256,7 +1256,7 @@ msgstr "Enforcement"
 msgid "Enforcement Mode"
 msgstr "Enforcement Mode"
 
-#: app/routes/customer/user/index.tsx:198
+#: app/routes/customer/user/index.tsx:210
 msgid "Enter first name"
 msgstr "Enter first name"
 
@@ -1427,7 +1427,7 @@ msgstr "Feature Flags"
 #: app/routes/customer/project/detail/activity/index.tsx:14
 #: app/routes/customer/project/detail/layout.tsx:146
 #: app/routes/customer/user/detail/activity/index.tsx:23
-#: app/routes/customer/user/detail/layout.tsx:64
+#: app/routes/customer/user/detail/layout.tsx:57
 #: app/routes/operation/activity/feed.tsx:28
 #: app/routes/operation/activity/feed.tsx:31
 #: app/routes/operation/activity/layout.tsx:25
@@ -1470,13 +1470,13 @@ msgstr "First name"
 
 #: app/features/contact/components/contact-form.tsx:125
 #: app/features/profile/components/profile-form.tsx:46
-#: app/routes/customer/user/index.tsx:197
+#: app/routes/customer/user/index.tsx:209
 msgid "First Name"
 msgstr "First Name"
 
 #: app/features/contact/components/contact-form.tsx:46
 #: app/features/profile/components/profile-form.tsx:15
-#: app/routes/customer/user/index.tsx:139
+#: app/routes/customer/user/index.tsx:151
 msgid "First name is required"
 msgstr "First name is required"
 
@@ -1618,7 +1618,7 @@ msgid "HTML"
 msgstr "HTML"
 
 #: app/routes/customer/user/detail/index.tsx:244
-#: app/routes/customer/user/index.tsx:101
+#: app/routes/customer/user/index.tsx:113
 msgid "ID"
 msgstr "ID"
 
@@ -1627,7 +1627,7 @@ msgid "Inactive"
 msgstr "Inactive"
 
 #: app/features/contact/components/contact-form.tsx:48
-#: app/routes/customer/user/index.tsx:141
+#: app/routes/customer/user/index.tsx:153
 msgid "Invalid email address"
 msgstr "Invalid email address"
 
@@ -1645,12 +1645,12 @@ msgstr "Invitation cancelled successfully"
 msgid "Invitation resend successfully"
 msgstr "Invitation resend successfully"
 
-#: app/routes/customer/user/index.tsx:164
+#: app/routes/customer/user/index.tsx:176
 msgid "Invite"
 msgstr "Invite"
 
-#: app/routes/customer/user/index.tsx:163
-#: app/routes/customer/user/index.tsx:240
+#: app/routes/customer/user/index.tsx:175
+#: app/routes/customer/user/index.tsx:252
 msgid "Invite User"
 msgstr "Invite User"
 
@@ -1699,7 +1699,7 @@ msgstr "Issuing TLS certificate"
 msgid "Joined"
 msgstr "Joined"
 
-#: app/features/dashboard/components/recent-users-widget.tsx:107
+#: app/features/dashboard/components/recent-users-widget.tsx:109
 msgid "Last 10 new users who joined Datum"
 msgstr "Last 10 new users who joined Datum"
 
@@ -1713,13 +1713,13 @@ msgstr "Last name"
 
 #: app/features/contact/components/contact-form.tsx:128
 #: app/features/profile/components/profile-form.tsx:49
-#: app/routes/customer/user/index.tsx:200
+#: app/routes/customer/user/index.tsx:212
 msgid "Last Name"
 msgstr "Last Name"
 
 #: app/features/contact/components/contact-form.tsx:47
 #: app/features/profile/components/profile-form.tsx:16
-#: app/routes/customer/user/index.tsx:140
+#: app/routes/customer/user/index.tsx:152
 msgid "Last name is required"
 msgstr "Last name is required"
 
@@ -1802,7 +1802,7 @@ msgid "Log back into GitHub (with the new, desired email set as primary)"
 msgstr "Log back into GitHub (with the new, desired email set as primary)"
 
 #: app/components/app-sidebar/nav-user.tsx:96
-#: app/features/milo/components/navbar/milo-user-menu.tsx:83
+#: app/features/milo/components/navbar/milo-user-menu.tsx:80
 msgid "Log out"
 msgstr "Log out"
 
@@ -1823,7 +1823,7 @@ msgid "Mail Lists"
 msgstr "Mail Lists"
 
 #: app/features/user/components/user-identity-card.tsx:133
-#: app/routes/customer/user/index.tsx:46
+#: app/routes/customer/user/index.tsx:47
 msgid "Manage"
 msgstr "Manage"
 
@@ -1903,12 +1903,12 @@ msgid "More options"
 msgstr "More options"
 
 #: app/routes/customer/user/detail/index.tsx:225
-#: app/routes/customer/user/index.tsx:73
+#: app/routes/customer/user/index.tsx:74
 msgid "Move to Pending"
 msgstr "Move to Pending"
 
 #: app/components/app-sidebar/nav-user.tsx:86
-#: app/features/milo/components/navbar/milo-user-menu.tsx:73
+#: app/features/milo/components/navbar/milo-user-menu.tsx:70
 #: app/routes/profile/layout.tsx:9
 msgid "My Profile"
 msgstr "My Profile"
@@ -1933,7 +1933,7 @@ msgstr "My Profile"
 #: app/routes/customer/project/detail/secret.tsx:25
 #: app/routes/customer/project/index.tsx:24
 #: app/routes/customer/user/detail/organization.tsx:35
-#: app/routes/customer/user/index.tsx:91
+#: app/routes/customer/user/index.tsx:92
 #: app/routes/finance/billing-account/detail/index.tsx:67
 #: app/routes/marketing/contact-group/detail/member.tsx:181
 #: app/routes/marketing/contact-group/index.tsx:63
@@ -2185,11 +2185,11 @@ msgstr "No services found."
 msgid "No services match the current filters."
 msgstr "No services match the current filters."
 
-#: app/routes/customer/user/index.tsx:246
+#: app/routes/customer/user/index.tsx:258
 msgid "No users found."
 msgstr "No users found."
 
-#: app/features/dashboard/components/recent-users-widget.tsx:56
+#: app/features/dashboard/components/recent-users-widget.tsx:58
 msgid "No users yet"
 msgstr "No users yet"
 
@@ -2225,7 +2225,7 @@ msgid "Notes"
 msgstr "Notes"
 
 #: app/components/app-sidebar/nav-user.tsx:90
-#: app/features/milo/components/navbar/milo-user-menu.tsx:77
+#: app/features/milo/components/navbar/milo-user-menu.tsx:74
 msgid "Notifications"
 msgstr "Notifications"
 
@@ -2278,7 +2278,7 @@ msgstr "Organization deleted successfully"
 #: app/routes/customer/organization/index.tsx:14
 #: app/routes/customer/organization/layout.tsx:8
 #: app/routes/customer/project/detail/layout.tsx:40
-#: app/routes/customer/user/detail/layout.tsx:49
+#: app/routes/customer/user/detail/layout.tsx:42
 #: app/routes/customer/user/detail/organization.tsx:19
 #: app/routes/dashboard/index.tsx:67
 msgid "Organizations"
@@ -2291,7 +2291,7 @@ msgstr "Origin"
 #: app/routes/admin/service-catalog/detail/layout.tsx:37
 #: app/routes/customer/organization/detail/layout.tsx:56
 #: app/routes/customer/project/detail/layout.tsx:111
-#: app/routes/customer/user/detail/layout.tsx:43
+#: app/routes/customer/user/detail/layout.tsx:36
 msgid "Overview"
 msgstr "Overview"
 
@@ -2369,7 +2369,7 @@ msgstr "Personal"
 msgid "Phase"
 msgstr "Phase"
 
-#: app/routes/customer/user/index.tsx:213
+#: app/routes/customer/user/index.tsx:225
 msgid "Pick date and time Test"
 msgstr "Pick date and time Test"
 
@@ -2624,18 +2624,18 @@ msgstr "Records"
 msgid "Registrar"
 msgstr "Registrar"
 
-#: app/routes/customer/user/index.tsx:250
+#: app/routes/customer/user/index.tsx:262
 msgid "Registration"
 msgstr "Registration"
 
 #: app/routes/customer/user/detail/index.tsx:265
-#: app/routes/customer/user/index.tsx:113
+#: app/routes/customer/user/index.tsx:125
 msgid "Registration Approval"
 msgstr "Registration Approval"
 
 #: app/features/user/components/user-reject-dialog.tsx:29
 #: app/routes/customer/user/detail/index.tsx:206
-#: app/routes/customer/user/index.tsx:66
+#: app/routes/customer/user/index.tsx:67
 msgid "Reject"
 msgstr "Reject"
 
@@ -2769,15 +2769,15 @@ msgstr "Running"
 msgid "Save"
 msgstr "Save"
 
-#: app/routes/customer/user/index.tsx:210
+#: app/routes/customer/user/index.tsx:222
 msgid "Schedule At"
 msgstr "Schedule At"
 
-#: app/routes/customer/user/index.tsx:153
+#: app/routes/customer/user/index.tsx:165
 msgid "Schedule date and time is required"
 msgstr "Schedule date and time is required"
 
-#: app/routes/customer/user/index.tsx:207
+#: app/routes/customer/user/index.tsx:219
 msgid "Schedule invitation to be sent at specific time"
 msgstr "Schedule invitation to be sent at specific time"
 
@@ -2922,7 +2922,7 @@ msgstr "Search sessions..."
 msgid "Search users, organizations, and projects"
 msgstr "Search users, organizations, and projects"
 
-#: app/routes/customer/user/index.tsx:245
+#: app/routes/customer/user/index.tsx:257
 msgid "Search users..."
 msgstr "Search users..."
 
@@ -3093,8 +3093,8 @@ msgstr "Start Time"
 #: app/routes/customer/project/detail/export-policy/detail.tsx:171
 #: app/routes/customer/project/detail/export-policy/index.tsx:45
 #: app/routes/customer/user/detail/index.tsx:269
-#: app/routes/customer/user/index.tsx:107
-#: app/routes/customer/user/index.tsx:259
+#: app/routes/customer/user/index.tsx:119
+#: app/routes/customer/user/index.tsx:271
 #: app/routes/marketing/contact-group/detail/member.tsx:207
 #: app/routes/marketing/contact-group/index.tsx:80
 #: app/routes/marketing/contact/detail/group.tsx:101
@@ -3341,7 +3341,7 @@ msgstr "User deactivated successfully"
 msgid "User deleted successfully"
 msgstr "User deleted successfully"
 
-#: app/routes/customer/user/index.tsx:191
+#: app/routes/customer/user/index.tsx:203
 msgid "User invited successfully"
 msgstr "User invited successfully"
 
@@ -3377,13 +3377,13 @@ msgstr "User Type"
 #: app/components/app-search/use-app-search.ts:36
 #: app/components/app-sidebar/index.tsx:115
 #: app/routes/customer/breadcrumb-switchers.tsx:6
-#: app/routes/customer/user/index.tsx:29
+#: app/routes/customer/user/index.tsx:30
 #: app/routes/customer/user/layout.tsx:8
 #: app/routes/dashboard/index.tsx:59
 msgid "Users"
 msgstr "Users"
 
-#: app/features/dashboard/components/recent-users-widget.tsx:59
+#: app/features/dashboard/components/recent-users-widget.tsx:61
 msgid "Users will appear here once they join Datum"
 msgstr "Users will appear here once they join Datum"
 
@@ -3422,7 +3422,7 @@ msgstr "View activity logs"
 
 #: app/features/dashboard/components/fraud-alerts-widget.tsx:124
 #: app/features/dashboard/components/pending-approvals-widget.tsx:109
-#: app/features/dashboard/components/recent-users-widget.tsx:102
+#: app/features/dashboard/components/recent-users-widget.tsx:104
 msgid "View All"
 msgstr "View All"
 

--- a/app/modules/i18n/locales/fr.po
+++ b/app/modules/i18n/locales/fr.po
@@ -131,7 +131,7 @@ msgstr ""
 msgid "Account Management"
 msgstr ""
 
-#: app/features/milo/components/navbar/milo-user-menu.tsx:50
+#: app/features/milo/components/navbar/milo-user-menu.tsx:41
 msgid "Account menu"
 msgstr ""
 
@@ -170,7 +170,7 @@ msgstr ""
 #: app/routes/customer/project/detail/activity/layout.tsx:5
 #: app/routes/customer/project/detail/layout.tsx:142
 #: app/routes/customer/user/detail/activity/layout.tsx:5
-#: app/routes/customer/user/detail/layout.tsx:60
+#: app/routes/customer/user/detail/layout.tsx:53
 #: app/routes/operation/activity/layout.tsx:13
 msgid "Activity"
 msgstr ""
@@ -303,7 +303,7 @@ msgstr ""
 #: app/routes/admin/service-catalog/detail/approvals.tsx:50
 #: app/routes/admin/service-catalog/detail/consumers.tsx:53
 #: app/routes/customer/user/detail/index.tsx:199
-#: app/routes/customer/user/index.tsx:51
+#: app/routes/customer/user/index.tsx:52
 msgid "Approve"
 msgstr ""
 
@@ -414,7 +414,7 @@ msgstr ""
 #: app/routes/customer/project/detail/layout.tsx:148
 #: app/routes/customer/user/detail/activity/audit-logs.tsx:14
 #: app/routes/customer/user/detail/activity/audit-logs.tsx:17
-#: app/routes/customer/user/detail/layout.tsx:65
+#: app/routes/customer/user/detail/layout.tsx:58
 #: app/routes/operation/activity/audit-logs.tsx:11
 #: app/routes/operation/activity/audit-logs.tsx:14
 #: app/routes/operation/activity/layout.tsx:35
@@ -485,7 +485,7 @@ msgstr ""
 #: app/routes/admin/service-catalog/detail/consumers.tsx:207
 #: app/routes/customer/organization/detail/member.tsx:85
 #: app/routes/customer/user/detail/index.tsx:149
-#: app/routes/customer/user/index.tsx:165
+#: app/routes/customer/user/index.tsx:177
 #: app/routes/marketing/contact-group/detail/member.tsx:345
 #: app/routes/marketing/contact-group/detail/member.tsx:362
 #: app/routes/marketing/contact-group/index.tsx:109
@@ -687,7 +687,7 @@ msgstr ""
 #: app/components/app-sidebar/index.tsx:147
 #: app/components/app-sidebar/index.tsx:153
 #: app/routes/customer/user/detail/contacts.tsx:9
-#: app/routes/customer/user/detail/layout.tsx:53
+#: app/routes/customer/user/detail/layout.tsx:46
 #: app/routes/marketing/contact/index.tsx:14
 #: app/routes/marketing/contact/layout.tsx:5
 msgid "Contacts"
@@ -777,7 +777,7 @@ msgstr ""
 #: app/routes/customer/project/detail/index.tsx:99
 #: app/routes/customer/project/index.tsx:42
 #: app/routes/customer/user/detail/index.tsx:273
-#: app/routes/customer/user/index.tsx:119
+#: app/routes/customer/user/index.tsx:131
 #: app/routes/finance/billing-account/detail/index.tsx:208
 #: app/routes/marketing/contact-group/index.tsx:87
 #: app/routes/operation/fraud/providers/index.tsx:102
@@ -1172,7 +1172,7 @@ msgstr ""
 #: app/features/contact/components/contact-list.tsx:86
 #: app/features/dashboard/components/pending-approvals-widget.tsx:132
 #: app/routes/customer/user/detail/index.tsx:261
-#: app/routes/customer/user/index.tsx:203
+#: app/routes/customer/user/index.tsx:215
 #: app/routes/marketing/contact-group/detail/member.tsx:202
 #: app/routes/operation/fraud/index.tsx:122
 msgid "Email"
@@ -1180,7 +1180,7 @@ msgstr ""
 
 #: app/components/app-sidebar/index.tsx:169
 #: app/routes/customer/user/detail/email-activity.tsx:9
-#: app/routes/customer/user/detail/layout.tsx:55
+#: app/routes/customer/user/detail/layout.tsx:48
 #: app/routes/operation/email-activity/layout.tsx:5
 msgid "Email Activity"
 msgstr ""
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Email HTML preview"
 msgstr ""
 
-#: app/routes/customer/user/index.tsx:141
+#: app/routes/customer/user/index.tsx:153
 msgid "Email is required"
 msgstr ""
 
@@ -1256,7 +1256,7 @@ msgstr ""
 msgid "Enforcement Mode"
 msgstr ""
 
-#: app/routes/customer/user/index.tsx:198
+#: app/routes/customer/user/index.tsx:210
 msgid "Enter first name"
 msgstr ""
 
@@ -1427,7 +1427,7 @@ msgstr ""
 #: app/routes/customer/project/detail/activity/index.tsx:14
 #: app/routes/customer/project/detail/layout.tsx:146
 #: app/routes/customer/user/detail/activity/index.tsx:23
-#: app/routes/customer/user/detail/layout.tsx:64
+#: app/routes/customer/user/detail/layout.tsx:57
 #: app/routes/operation/activity/feed.tsx:28
 #: app/routes/operation/activity/feed.tsx:31
 #: app/routes/operation/activity/layout.tsx:25
@@ -1470,13 +1470,13 @@ msgstr ""
 
 #: app/features/contact/components/contact-form.tsx:125
 #: app/features/profile/components/profile-form.tsx:46
-#: app/routes/customer/user/index.tsx:197
+#: app/routes/customer/user/index.tsx:209
 msgid "First Name"
 msgstr ""
 
 #: app/features/contact/components/contact-form.tsx:46
 #: app/features/profile/components/profile-form.tsx:15
-#: app/routes/customer/user/index.tsx:139
+#: app/routes/customer/user/index.tsx:151
 msgid "First name is required"
 msgstr ""
 
@@ -1618,7 +1618,7 @@ msgid "HTML"
 msgstr ""
 
 #: app/routes/customer/user/detail/index.tsx:244
-#: app/routes/customer/user/index.tsx:101
+#: app/routes/customer/user/index.tsx:113
 msgid "ID"
 msgstr ""
 
@@ -1627,7 +1627,7 @@ msgid "Inactive"
 msgstr ""
 
 #: app/features/contact/components/contact-form.tsx:48
-#: app/routes/customer/user/index.tsx:141
+#: app/routes/customer/user/index.tsx:153
 msgid "Invalid email address"
 msgstr ""
 
@@ -1645,12 +1645,12 @@ msgstr ""
 msgid "Invitation resend successfully"
 msgstr ""
 
-#: app/routes/customer/user/index.tsx:164
+#: app/routes/customer/user/index.tsx:176
 msgid "Invite"
 msgstr ""
 
-#: app/routes/customer/user/index.tsx:163
-#: app/routes/customer/user/index.tsx:240
+#: app/routes/customer/user/index.tsx:175
+#: app/routes/customer/user/index.tsx:252
 msgid "Invite User"
 msgstr ""
 
@@ -1699,7 +1699,7 @@ msgstr ""
 msgid "Joined"
 msgstr ""
 
-#: app/features/dashboard/components/recent-users-widget.tsx:107
+#: app/features/dashboard/components/recent-users-widget.tsx:109
 msgid "Last 10 new users who joined Datum"
 msgstr ""
 
@@ -1713,13 +1713,13 @@ msgstr ""
 
 #: app/features/contact/components/contact-form.tsx:128
 #: app/features/profile/components/profile-form.tsx:49
-#: app/routes/customer/user/index.tsx:200
+#: app/routes/customer/user/index.tsx:212
 msgid "Last Name"
 msgstr ""
 
 #: app/features/contact/components/contact-form.tsx:47
 #: app/features/profile/components/profile-form.tsx:16
-#: app/routes/customer/user/index.tsx:140
+#: app/routes/customer/user/index.tsx:152
 msgid "Last name is required"
 msgstr ""
 
@@ -1802,7 +1802,7 @@ msgid "Log back into GitHub (with the new, desired email set as primary)"
 msgstr ""
 
 #: app/components/app-sidebar/nav-user.tsx:96
-#: app/features/milo/components/navbar/milo-user-menu.tsx:83
+#: app/features/milo/components/navbar/milo-user-menu.tsx:80
 msgid "Log out"
 msgstr ""
 
@@ -1823,7 +1823,7 @@ msgid "Mail Lists"
 msgstr ""
 
 #: app/features/user/components/user-identity-card.tsx:133
-#: app/routes/customer/user/index.tsx:46
+#: app/routes/customer/user/index.tsx:47
 msgid "Manage"
 msgstr ""
 
@@ -1903,12 +1903,12 @@ msgid "More options"
 msgstr ""
 
 #: app/routes/customer/user/detail/index.tsx:225
-#: app/routes/customer/user/index.tsx:73
+#: app/routes/customer/user/index.tsx:74
 msgid "Move to Pending"
 msgstr ""
 
 #: app/components/app-sidebar/nav-user.tsx:86
-#: app/features/milo/components/navbar/milo-user-menu.tsx:73
+#: app/features/milo/components/navbar/milo-user-menu.tsx:70
 #: app/routes/profile/layout.tsx:9
 msgid "My Profile"
 msgstr ""
@@ -1933,7 +1933,7 @@ msgstr ""
 #: app/routes/customer/project/detail/secret.tsx:25
 #: app/routes/customer/project/index.tsx:24
 #: app/routes/customer/user/detail/organization.tsx:35
-#: app/routes/customer/user/index.tsx:91
+#: app/routes/customer/user/index.tsx:92
 #: app/routes/finance/billing-account/detail/index.tsx:67
 #: app/routes/marketing/contact-group/detail/member.tsx:181
 #: app/routes/marketing/contact-group/index.tsx:63
@@ -2185,11 +2185,11 @@ msgstr ""
 msgid "No services match the current filters."
 msgstr ""
 
-#: app/routes/customer/user/index.tsx:246
+#: app/routes/customer/user/index.tsx:258
 msgid "No users found."
 msgstr ""
 
-#: app/features/dashboard/components/recent-users-widget.tsx:56
+#: app/features/dashboard/components/recent-users-widget.tsx:58
 msgid "No users yet"
 msgstr ""
 
@@ -2225,7 +2225,7 @@ msgid "Notes"
 msgstr ""
 
 #: app/components/app-sidebar/nav-user.tsx:90
-#: app/features/milo/components/navbar/milo-user-menu.tsx:77
+#: app/features/milo/components/navbar/milo-user-menu.tsx:74
 msgid "Notifications"
 msgstr ""
 
@@ -2278,7 +2278,7 @@ msgstr ""
 #: app/routes/customer/organization/index.tsx:14
 #: app/routes/customer/organization/layout.tsx:8
 #: app/routes/customer/project/detail/layout.tsx:40
-#: app/routes/customer/user/detail/layout.tsx:49
+#: app/routes/customer/user/detail/layout.tsx:42
 #: app/routes/customer/user/detail/organization.tsx:19
 #: app/routes/dashboard/index.tsx:67
 msgid "Organizations"
@@ -2291,7 +2291,7 @@ msgstr ""
 #: app/routes/admin/service-catalog/detail/layout.tsx:37
 #: app/routes/customer/organization/detail/layout.tsx:56
 #: app/routes/customer/project/detail/layout.tsx:111
-#: app/routes/customer/user/detail/layout.tsx:43
+#: app/routes/customer/user/detail/layout.tsx:36
 msgid "Overview"
 msgstr ""
 
@@ -2369,7 +2369,7 @@ msgstr ""
 msgid "Phase"
 msgstr ""
 
-#: app/routes/customer/user/index.tsx:213
+#: app/routes/customer/user/index.tsx:225
 msgid "Pick date and time Test"
 msgstr ""
 
@@ -2624,18 +2624,18 @@ msgstr ""
 msgid "Registrar"
 msgstr ""
 
-#: app/routes/customer/user/index.tsx:250
+#: app/routes/customer/user/index.tsx:262
 msgid "Registration"
 msgstr ""
 
 #: app/routes/customer/user/detail/index.tsx:265
-#: app/routes/customer/user/index.tsx:113
+#: app/routes/customer/user/index.tsx:125
 msgid "Registration Approval"
 msgstr ""
 
 #: app/features/user/components/user-reject-dialog.tsx:29
 #: app/routes/customer/user/detail/index.tsx:206
-#: app/routes/customer/user/index.tsx:66
+#: app/routes/customer/user/index.tsx:67
 msgid "Reject"
 msgstr ""
 
@@ -2769,15 +2769,15 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: app/routes/customer/user/index.tsx:210
+#: app/routes/customer/user/index.tsx:222
 msgid "Schedule At"
 msgstr ""
 
-#: app/routes/customer/user/index.tsx:153
+#: app/routes/customer/user/index.tsx:165
 msgid "Schedule date and time is required"
 msgstr ""
 
-#: app/routes/customer/user/index.tsx:207
+#: app/routes/customer/user/index.tsx:219
 msgid "Schedule invitation to be sent at specific time"
 msgstr ""
 
@@ -2922,7 +2922,7 @@ msgstr ""
 msgid "Search users, organizations, and projects"
 msgstr ""
 
-#: app/routes/customer/user/index.tsx:245
+#: app/routes/customer/user/index.tsx:257
 msgid "Search users..."
 msgstr ""
 
@@ -3093,8 +3093,8 @@ msgstr ""
 #: app/routes/customer/project/detail/export-policy/detail.tsx:171
 #: app/routes/customer/project/detail/export-policy/index.tsx:45
 #: app/routes/customer/user/detail/index.tsx:269
-#: app/routes/customer/user/index.tsx:107
-#: app/routes/customer/user/index.tsx:259
+#: app/routes/customer/user/index.tsx:119
+#: app/routes/customer/user/index.tsx:271
 #: app/routes/marketing/contact-group/detail/member.tsx:207
 #: app/routes/marketing/contact-group/index.tsx:80
 #: app/routes/marketing/contact/detail/group.tsx:101
@@ -3341,7 +3341,7 @@ msgstr ""
 msgid "User deleted successfully"
 msgstr ""
 
-#: app/routes/customer/user/index.tsx:191
+#: app/routes/customer/user/index.tsx:203
 msgid "User invited successfully"
 msgstr ""
 
@@ -3377,13 +3377,13 @@ msgstr ""
 #: app/components/app-search/use-app-search.ts:36
 #: app/components/app-sidebar/index.tsx:115
 #: app/routes/customer/breadcrumb-switchers.tsx:6
-#: app/routes/customer/user/index.tsx:29
+#: app/routes/customer/user/index.tsx:30
 #: app/routes/customer/user/layout.tsx:8
 #: app/routes/dashboard/index.tsx:59
 msgid "Users"
 msgstr ""
 
-#: app/features/dashboard/components/recent-users-widget.tsx:59
+#: app/features/dashboard/components/recent-users-widget.tsx:61
 msgid "Users will appear here once they join Datum"
 msgstr ""
 
@@ -3422,7 +3422,7 @@ msgstr ""
 
 #: app/features/dashboard/components/fraud-alerts-widget.tsx:124
 #: app/features/dashboard/components/pending-approvals-widget.tsx:109
-#: app/features/dashboard/components/recent-users-widget.tsx:102
+#: app/features/dashboard/components/recent-users-widget.tsx:104
 msgid "View All"
 msgstr ""
 

--- a/app/routes/customer/user/detail/layout.tsx
+++ b/app/routes/customer/user/detail/layout.tsx
@@ -1,10 +1,10 @@
 import type { Route } from './+types/layout';
+import { UserAvatar } from '@/components/user-avatar';
 import { DetailShell, type EntityTab } from '@/features/milo';
 import { authenticator } from '@/modules/auth';
 import { userDetailQuery } from '@/resources/request/server';
 import { ENTITY_ICONS, TAB_ICONS } from '@/utils/config/icons.config';
 import { userRoutes } from '@/utils/config/routes.config';
-import { Avatar, AvatarFallback } from '@datum-cloud/datum-ui/avatar';
 import { useLingui } from '@lingui/react/macro';
 import { ComMiloapisIamV1Alpha1User } from '@openapi/iam.miloapis.com/v1alpha1';
 import { useLoaderData } from 'react-router';
@@ -30,13 +30,6 @@ export default function Layout() {
 
   const userId = data.metadata?.name ?? '';
   const fullName = `${data.spec?.givenName ?? ''} ${data.spec?.familyName ?? ''}`.trim();
-  const initials =
-    fullName
-      .split(' ')
-      .map((n) => n[0])
-      .join('')
-      .substring(0, 2)
-      .toUpperCase() || '?';
 
   const tabs: EntityTab[] = [
     {
@@ -70,9 +63,12 @@ export default function Layout() {
   return (
     <DetailShell
       icon={
-        <Avatar className="size-10 rounded-md">
-          <AvatarFallback className="rounded-md">{initials}</AvatarFallback>
-        </Avatar>
+        <UserAvatar
+          name={fullName || userId}
+          avatarUrl={data.status?.avatarUrl}
+          className="size-10 rounded-md"
+          fallbackClassName="rounded-md"
+        />
       }
       name={fullName || userId}
       subtitle={data.spec?.email}

--- a/app/routes/customer/user/index.tsx
+++ b/app/routes/customer/user/index.tsx
@@ -3,6 +3,7 @@ import { BadgeState } from '@/components/badge';
 import { DateTime } from '@/components/date';
 import { DialogForm } from '@/components/dialog';
 import { DisplayId, DisplayName } from '@/components/display';
+import { UserAvatar } from '@/components/user-avatar';
 import { ListPage, ListTable } from '@/features/milo';
 import { UserRejectDialog, useUserApproval } from '@/features/user';
 import {
@@ -91,10 +92,21 @@ export default function Page() {
       header: ({ column }) => <DataTable.ColumnHeader column={column} title={t`Name`} />,
       cell: ({ row }) => {
         const userName = row.original.metadata?.name ?? '';
-        const displayName = `${row.original.spec?.givenName ?? ''} ${row.original.spec?.familyName ?? ''}`;
+        const displayName =
+          `${row.original.spec?.givenName ?? ''} ${row.original.spec?.familyName ?? ''}`.trim();
         const email = row.original.spec?.email ?? '';
 
-        return <DisplayName displayName={displayName} name={email} to={`./${userName}`} />;
+        return (
+          <div className="flex items-center gap-2.5">
+            <UserAvatar
+              name={displayName || email}
+              avatarUrl={row.original.status?.avatarUrl}
+              className="size-7 shrink-0 rounded-md"
+              fallbackClassName="rounded-md text-xs"
+            />
+            <DisplayName displayName={displayName} name={email} to={`./${userName}`} />
+          </div>
+        );
       },
     }),
     columnHelper.accessor('metadata.name', {


### PR DESCRIPTION
Renders real user avatars from the User resource's `status.avatarUrl` (auth-provider populated) — same field cloud-portal uses — with initials as the graceful fallback when there's no URL or the image fails to load.

Adds a shared `UserAvatar` component (image + initials fallback) and uses it in:
- **Users list** — new avatar next to the name
- User detail header
- Recent-users widget (dashboard)
- Navbar user menu (trigger + dropdown)

Not included: org-member and contact-group-member tables. Org members come from GraphQL and the query/type don't fetch `avatarUrl` yet (needs a query + type addition); contact-group members are Contacts, not Users.