### PR TITLE
fix: collapse filters sidebar into mobile Sheet on tablet width

### DIFF
--- a/app/features/milo/components/page/list-table.tsx
+++ b/app/features/milo/components/page/list-table.tsx
@@ -129,13 +129,15 @@ export function ListTable<TData>({
   ...options
 }: ListTableProps<TData>) {
   const { t } = useLingui();
-  const isMobile = useBreakpoint() === 'mobile';
+  // Tablet (e.g. a phone in landscape) is just as cramped as mobile once the
+  // nav rail + a 240px inline sidebar are both on screen, so treat anything
+  // below desktop the same way: swap the sidebar for a Sheet trigger.
+  const isCompact = useBreakpoint() !== 'desktop';
   const showHeader = title != null || actions != null || bulkActions != null;
   const hasFilters = (filters?.length ?? 0) > 0;
   const sidebarMode = hasFilters && filterLayout === 'sidebar';
-  // Below `md`, the sidebar would crowd the table — swap it for a Sheet trigger.
-  const showSidebar = sidebarMode && !isMobile;
-  const showMobileFilter = sidebarMode && isMobile;
+  const showSidebar = sidebarMode && !isCompact;
+  const showMobileFilter = sidebarMode && isCompact;
   const hasInlineFilters = hasFilters && filterLayout === 'inline';
   const insetX = inset === 'tab' ? 'px-4' : 'px-6';
   const [filtersCollapsed, setFiltersCollapsed] = useState(false);

--- a/app/modules/i18n/locales/en.po
+++ b/app/modules/i18n/locales/en.po
@@ -1592,8 +1592,8 @@ msgstr "Group"
 msgid "Groups"
 msgstr "Groups"
 
-#: app/features/milo/components/page/list-table.tsx:219
-#: app/features/milo/components/page/list-table.tsx:223
+#: app/features/milo/components/page/list-table.tsx:221
+#: app/features/milo/components/page/list-table.tsx:225
 msgid "Hide filters"
 msgstr "Hide filters"
 
@@ -3075,8 +3075,8 @@ msgstr "Short-circuit < {0}"
 msgid "Short-circuit Below"
 msgstr "Short-circuit Below"
 
-#: app/features/milo/components/page/list-table.tsx:219
-#: app/features/milo/components/page/list-table.tsx:223
+#: app/features/milo/components/page/list-table.tsx:221
+#: app/features/milo/components/page/list-table.tsx:225
 msgid "Show filters"
 msgstr "Show filters"
 
@@ -3200,7 +3200,7 @@ msgstr "Tenant"
 msgid "The <0>services.miloapis.com-approver</0> role has not yet been provisioned for this staff token. Approval data is not visible until the role is deployed."
 msgstr "The <0>services.miloapis.com-approver</0> role has not yet been provisioned for this staff token. Approval data is not visible until the role is deployed."
 
-#: app/features/milo/components/page/list-table.tsx:289
+#: app/features/milo/components/page/list-table.tsx:291
 msgid "The list is limited to 2,000 results at a time. Refine your search to surface other items."
 msgstr "The list is limited to 2,000 results at a time. Refine your search to surface other items."
 

--- a/app/modules/i18n/locales/fr.po
+++ b/app/modules/i18n/locales/fr.po
@@ -1592,8 +1592,8 @@ msgstr ""
 msgid "Groups"
 msgstr ""
 
-#: app/features/milo/components/page/list-table.tsx:219
-#: app/features/milo/components/page/list-table.tsx:223
+#: app/features/milo/components/page/list-table.tsx:221
+#: app/features/milo/components/page/list-table.tsx:225
 msgid "Hide filters"
 msgstr ""
 
@@ -3075,8 +3075,8 @@ msgstr ""
 msgid "Short-circuit Below"
 msgstr ""
 
-#: app/features/milo/components/page/list-table.tsx:219
-#: app/features/milo/components/page/list-table.tsx:223
+#: app/features/milo/components/page/list-table.tsx:221
+#: app/features/milo/components/page/list-table.tsx:225
 msgid "Show filters"
 msgstr ""
 
@@ -3200,7 +3200,7 @@ msgstr ""
 msgid "The <0>services.miloapis.com-approver</0> role has not yet been provisioned for this staff token. Approval data is not visible until the role is deployed."
 msgstr ""
 
-#: app/features/milo/components/page/list-table.tsx:289
+#: app/features/milo/components/page/list-table.tsx:291
 msgid "The list is limited to 2,000 results at a time. Refine your search to surface other items."
 msgstr ""
 


### PR DESCRIPTION
## Summary
- Reported: the new Resources page looks funky in mobile view (screenshot from an iPhone in landscape orientation).
- Root cause: a phone in landscape (~932px logical width) lands in the "tablet" breakpoint tier (768–1023px). `ListTable` only swapped the inline 240px filters sidebar for the mobile Sheet trigger when strictly in the "mobile" tier (<768px), so at tablet width it rendered the full desktop chrome (nav rail + inline sidebar) at once, cramming the table.
- Fix: treat any non-desktop breakpoint (mobile or tablet) as "compact" for filter-sidebar purposes, so the Sheet-based mobile filter button is used any time we're below desktop width.

before
<img width="1080" height="475" alt="image" src="https://github.com/user-attachments/assets/4fdd2b29-8de9-4bfc-94de-e206cd0a4c51" />

after
<img width="1080" height="475" alt="image" src="https://github.com/user-attachments/assets/2d5b7c5f-b966-45c5-a687-14c29f2cda77" />

## Test plan
- [ ] Open Customers → Resources at ~932x430 (iPhone landscape) and confirm filters render via the Sheet button instead of an inline sidebar
- [ ] Confirm desktop (>=1024px) still shows the inline sidebar as before
- [ ] Spot check another list page using `ListTable` with `filterLayout="sidebar"` at tablet width