### PR TITLE
fix: Tolerate 403 on optional AI Edge detail fetches

### DIFF
--- a/app/resources/request/server/project.request.ts
+++ b/app/resources/request/server/project.request.ts
@@ -64,7 +64,11 @@ async function fetchControlPlaneJson<T>(
     },
   });
 
-  if (response.status === 404) return null;
+  // 404: the resource doesn't exist. 403: the viewer isn't allowed to read
+  // it (e.g. staff users can't read customer Secrets). Both are expected for
+  // these optional enrichment fetches, so render the page without them
+  // instead of failing the whole loader.
+  if (response.status === 404 || response.status === 403) return null;
   if (!response.ok) {
     throw new Response(`Control plane request failed: ${response.status}`, {
       status: response.status,


### PR DESCRIPTION
## Summary

Staff users get a 403 when opening any AI Edge detail page in the staff portal (reported on `ab-staging-website-c8nw6y` in project `ab-generic-1qnl3i`). The proxy itself was never the problem: SubjectAccessReviews against the project control plane confirm that staff can read HTTPProxies, TrafficProtectionPolicies, and SecurityPolicies through the `networking.datumapis.com-viewer` binding on the `staff-users` group.

The failure comes from the detail loader, which also fetches the `<edge>-basic-auth` core Secret to display basic auth usernames. Staff users are deliberately not granted `secrets.get` in customer project control planes, so that request returns 403 and `fetchControlPlaneJson` rethrows it as the page response. One optional fetch takes down the whole page.

This change treats 403 the same as the existing 404 case for these optional enrichment fetches: return `null` and render the page without the extra data. For staff users the basic auth card falls back to its "not enabled" state, which is the same behaviour as a proxy with no basic auth secret. Granting staff read access to customer Secrets was considered and rejected, since it would expose customer secret material.

## Test plan

- [ ] As a staff user in production, open the AI Edge detail page for `ab-staging-website-c8nw6y` (project `ab-generic-1qnl3i`) and confirm it renders instead of returning 403
- [ ] As a user with full project access including secrets, confirm basic auth usernames still render on a proxy that has them
- [ ] Confirm a genuinely missing proxy still surfaces an error rather than an empty page
- [ ] `tsc` and `eslint` pass (verified locally)

## Notes for reviewers

`fetchControlPlaneJson` is only used by the two optional fetches in `projectEdgeDetailBundleQuery`, so widening its tolerated statuses does not mask errors on any required data. The main HTTPProxy fetch goes through the generated SDK client and still fails loudly.