### PR TITLE
fix: link org members list to the user, not the membership resource

### DIFF
--- a/app/components/display/display-name.tsx
+++ b/app/components/display/display-name.tsx
@@ -7,8 +7,8 @@ interface NameDisplayProps {
   displayName: string;
   /** The ID/name to show as subtext */
   name?: string;
-  /** The route to navigate to */
-  to: string;
+  /** The route to navigate to. Omit to render the display name as plain text (non-clickable). */
+  to?: string;
   /** Optional className for the container */
   className?: string;
   /** Whether to show the copy button */
@@ -37,9 +37,7 @@ export const NameDisplay = ({
 }: NameDisplayProps) => {
   return (
     <div className={`flex flex-col leading-tight ${className}`}>
-      <div>
-        <Link to={to}>{displayName}</Link>
-      </div>
+      <div>{to ? <Link to={to}>{displayName}</Link> : displayName}</div>
       <div className="flex items-center space-x-2">
         {name && (
           <Text size="sm" textColor="muted" className="leading-tight">

--- a/app/modules/graphql/organizations.ts
+++ b/app/modules/graphql/organizations.ts
@@ -36,6 +36,8 @@ export interface GqlOrgMember {
   type: 'member' | 'invitation';
   invitationState: string | null;
   createdAt: string | null;
+  /** The member's user resource name. Null for invitations, which have no user yet. */
+  userName: string | null;
 }
 
 const ORGANIZATIONS_QUERY = `
@@ -67,7 +69,7 @@ const ORG_PROJECTS_QUERY = `
 const ORG_MEMBERS_QUERY = `
   query OrgMembers($orgName: String!) {
     organizationMembers(orgName: $orgName) {
-      name givenName familyName email roles type invitationState createdAt
+      name givenName familyName email roles type invitationState createdAt userName
     }
   }
 `;

--- a/app/routes/customer/organization/detail/member.tsx
+++ b/app/routes/customer/organization/detail/member.tsx
@@ -102,14 +102,14 @@ export default function Page() {
     columnHelper.accessor('givenName', {
       header: ({ column }) => <DataTable.ColumnHeader column={column} title={tCore`Name`} />,
       cell: ({ row }) => {
-        const userName = row.original.name;
         const displayName = `${row.original.givenName} ${row.original.familyName}`;
         const email = row.original.email;
+        const userName = row.original.userName;
         return (
           <DisplayName
             displayName={displayName}
-            name={email || userName}
-            to={userRoutes.detail(userName)}
+            name={email || row.original.name}
+            to={userName ? userRoutes.detail(userName) : undefined}
           />
         );
       },


### PR DESCRIPTION
## Summary
- Clicking a member on an organization's members page navigated to `/customers/users/<membership-name>` and 404'd — the link was built from the `OrganizationMembership` resource's own `metadata.name` instead of the actual user ID.
- `member.tsx` now links via the gateway-provided `userName` field. Pending invitations have no user yet, so they render as plain text instead of a dead link (`DisplayName`'s `to` prop is now optional).

Depends on milo-os/graphql-gateway#41 (adds `userName` to the `organizationMembers` query).

Fixes #572.

## Test plan
- [x] `bun run typecheck` passes
- [ ] Manually verify: open an org's members page, click an accepted member → lands on their user detail page; click a pending invitation → no longer a clickable link