### PR TITLE
fix(contacts): show real visibility, status & joined on contact groups list

### DIFF
--- a/app/modules/graphql/generated/guards.esm.js
+++ b/app/modules/graphql/generated/guards.esm.js
@@ -46,6 +46,20 @@ export var isEnrichedContact = function (obj) {
   return EnrichedContact_possibleTypes.includes(obj.__typename);
 };
 
+var ContactGroupCondition_possibleTypes = ['ContactGroupCondition'];
+export var isContactGroupCondition = function (obj) {
+  if (!obj || !obj.__typename)
+    throw new Error('__typename is missing in "isContactGroupCondition"');
+  return ContactGroupCondition_possibleTypes.includes(obj.__typename);
+};
+
+var EnrichedContactGroupStatus_possibleTypes = ['EnrichedContactGroupStatus'];
+export var isEnrichedContactGroupStatus = function (obj) {
+  if (!obj || !obj.__typename)
+    throw new Error('__typename is missing in "isEnrichedContactGroupStatus"');
+  return EnrichedContactGroupStatus_possibleTypes.includes(obj.__typename);
+};
+
 var EnrichedContactGroup_possibleTypes = ['EnrichedContactGroup'];
 export var isEnrichedContactGroup = function (obj) {
   if (!obj || !obj.__typename) throw new Error('__typename is missing in "isEnrichedContactGroup"');
@@ -84,4 +98,40 @@ var UserSummary_possibleTypes = ['UserSummary'];
 export var isUserSummary = function (obj) {
   if (!obj || !obj.__typename) throw new Error('__typename is missing in "isUserSummary"');
   return UserSummary_possibleTypes.includes(obj.__typename);
+};
+
+var OrgContactInfo_possibleTypes = ['OrgContactInfo'];
+export var isOrgContactInfo = function (obj) {
+  if (!obj || !obj.__typename) throw new Error('__typename is missing in "isOrgContactInfo"');
+  return OrgContactInfo_possibleTypes.includes(obj.__typename);
+};
+
+var Organization_possibleTypes = ['Organization'];
+export var isOrganization = function (obj) {
+  if (!obj || !obj.__typename) throw new Error('__typename is missing in "isOrganization"');
+  return Organization_possibleTypes.includes(obj.__typename);
+};
+
+var OrganizationList_possibleTypes = ['OrganizationList'];
+export var isOrganizationList = function (obj) {
+  if (!obj || !obj.__typename) throw new Error('__typename is missing in "isOrganizationList"');
+  return OrganizationList_possibleTypes.includes(obj.__typename);
+};
+
+var Project_possibleTypes = ['Project'];
+export var isProject = function (obj) {
+  if (!obj || !obj.__typename) throw new Error('__typename is missing in "isProject"');
+  return Project_possibleTypes.includes(obj.__typename);
+};
+
+var ProjectList_possibleTypes = ['ProjectList'];
+export var isProjectList = function (obj) {
+  if (!obj || !obj.__typename) throw new Error('__typename is missing in "isProjectList"');
+  return ProjectList_possibleTypes.includes(obj.__typename);
+};
+
+var OrgMember_possibleTypes = ['OrgMember'];
+export var isOrgMember = function (obj) {
+  if (!obj || !obj.__typename) throw new Error('__typename is missing in "isOrgMember"');
+  return OrgMember_possibleTypes.includes(obj.__typename);
 };

--- a/app/modules/graphql/generated/schema.graphql
+++ b/app/modules/graphql/generated/schema.graphql
@@ -4,7 +4,7 @@ type Query {
   consumer project's human-readable display name (the
   kubernetes.io/description annotation on the Project, falling back to the
   project name).
-  
+
   Authorization uses the caller's bearer token for both the consumer list
   (in the producer project's control plane) and the per-project lookups (at
   the core resourcemanager API). A list failure returns an empty list; a
@@ -14,7 +14,7 @@ type Query {
 
   """
   Returns sessions for the authenticated caller by default.
-  
+
   When userID is provided and differs from the caller, the request is
   forwarded to milo with a status.userUID field selector. milo authorizes
   the cross-user lookup via SubjectAccessReview against
@@ -28,19 +28,61 @@ type Query {
   Contact data for each membership. Resolves all contacts in parallel.
   fieldSelector supports standard Kubernetes field selectors.
   """
-  contactGroupMembershipsWithContacts(fieldSelector: String, limit: Int, cursor: String): EnrichedContactGroupMembershipList!
+  contactGroupMembershipsWithContacts(
+    namespace: String
+    fieldSelector: String
+    limit: Int
+    cursor: String
+  ): EnrichedContactGroupMembershipList!
 
   """
-  Lists ContactGroupMemberships across all namespaces, enriched with full
+  Lists ContactGroupMemberships in the given namespace, enriched with full
   ContactGroup data for each membership. Resolves all contact groups in parallel.
   """
-  contactMembershipsWithGroups(fieldSelector: String, limit: Int, cursor: String): EnrichedContactMembershipList!
+  contactMembershipsWithGroups(
+    namespace: String
+    fieldSelector: String
+    limit: Int
+    cursor: String
+  ): EnrichedContactMembershipList!
 
   """
   Batch-fetches User summaries by name. Fetches run in parallel; individual
   lookup failures return null for that entry (filtered from the result).
   """
   userSummaries(names: [String!]!): [UserSummary!]!
+
+  """
+  Lists all organizations the caller can access. When `search` is set, matches
+  substring against name, displayName, company, and contact fields (walks
+  upstream pages until `limit` matches).
+  """
+  organizations(limit: Int, cursor: String, search: String): OrganizationList!
+
+  """
+  Returns a single organization by name.
+  """
+  organization(name: String!): Organization
+
+  """
+  Lists projects in an organization via its control plane.
+  """
+  organizationProjects(orgName: String!, limit: Int, cursor: String): ProjectList!
+
+  """
+  Lists members and pending invitations for an organization.
+  """
+  organizationMembers(orgName: String!): [OrgMember!]!
+
+  """
+  Lists all projects the caller can access.
+  """
+  projects(limit: Int, cursor: String, search: String): ProjectList!
+
+  """
+  Returns a single project by name.
+  """
+  project(name: String!): Project
 }
 
 type ParsedUserAgent {
@@ -69,17 +111,21 @@ type ExtendedSession {
 }
 
 type ConsumerProject {
-  """The project's machine name (metadata.name)."""
+  """
+  The project's machine name (metadata.name).
+  """
   name: String!
 
   """
-  Human-readable name from the kubernetes.io/description annotation, falling back to name.
+  Human-readable name from the kubernetes.io/display-name annotation, falling back to kubernetes.io/description, then name.
   """
   displayName: String!
 }
 
 type ServiceConsumer {
-  """The ServiceConsumer's name (metadata.name)."""
+  """
+  The ServiceConsumer's name (metadata.name).
+  """
   name: String!
 
   """
@@ -87,19 +133,29 @@ type ServiceConsumer {
   """
   serviceName: String
 
-  """Lifecycle phase (status.phase), e.g. Active, PendingApproval."""
+  """
+  Lifecycle phase (status.phase), e.g. Active, PendingApproval.
+  """
   phase: String
 
-  """Approval decision (spec.approval.decision), e.g. Approved, Denied."""
+  """
+  Approval decision (spec.approval.decision), e.g. Approved, Denied.
+  """
   approvalDecision: String
 
-  """Optional approval note (spec.approval.message)."""
+  """
+  Optional approval note (spec.approval.message).
+  """
   approvalMessage: String
 
-  """When the consumer was requested (metadata.creationTimestamp)."""
+  """
+  When the consumer was requested (metadata.creationTimestamp).
+  """
   requestedAt: String
 
-  """The consuming project, enriched with its display name."""
+  """
+  The consuming project, enriched with its display name.
+  """
   consumerProject: ConsumerProject!
 }
 
@@ -117,34 +173,75 @@ type EnrichedContact {
   displayName: String
 }
 
+"""
+A single Kubernetes-style status condition on a ContactGroup.
+"""
+type ContactGroupCondition {
+  type: String!
+  status: String!
+  reason: String
+  message: String
+  lastTransitionTime: String
+  observedGeneration: Int
+}
+
+type EnrichedContactGroupStatus {
+  conditions: [ContactGroupCondition!]
+}
+
 type EnrichedContactGroup {
   name: String!
   namespace: String!
   displayName: String
+
+  """
+  Whether the group allows opt-in/opt-out membership: 'public' or 'private'.
+  """
+  visibility: String
+
+  """
+  Observed status of the ContactGroup (Ready condition, provider sync).
+  """
+  status: EnrichedContactGroupStatus
 }
 
 type ContactGroupMembershipEnriched {
-  """metadata.name of the ContactGroupMembership resource."""
+  """
+  metadata.name of the ContactGroupMembership resource.
+  """
   name: String!
   contactRef: ContactRef!
 
-  """Full Contact data, null if lookup failed."""
+  """
+  Full Contact data, null if lookup failed.
+  """
   contact: EnrichedContact
 }
 
 type ContactMembershipEnriched {
-  """metadata.name of the ContactGroupMembership resource."""
+  """
+  metadata.name of the ContactGroupMembership resource.
+  """
   name: String!
+
+  """
+  When the contact joined the group (membership metadata.creationTimestamp).
+  """
+  creationTimestamp: String
   contactGroupRef: ContactRef!
 
-  """Full ContactGroup data, null if lookup failed."""
+  """
+  Full ContactGroup data, null if lookup failed.
+  """
   contactGroup: EnrichedContactGroup
 }
 
 type EnrichedContactGroupMembershipList {
   items: [ContactGroupMembershipEnriched!]!
 
-  """Kubernetes continue token for pagination."""
+  """
+  Kubernetes continue token for pagination.
+  """
   continue: String
 }
 
@@ -154,9 +251,174 @@ type EnrichedContactMembershipList {
 }
 
 type UserSummary {
-  """metadata.name of the User resource."""
+  """
+  metadata.name of the User resource.
+  """
   name: String!
   email: String
   givenName: String
   familyName: String
+}
+
+type OrgContactInfo {
+  """
+  Legal / company name from spec.contactInfo.businessName.
+  """
+  businessName: String
+
+  """
+  Primary contact name from spec.contactInfo.name.
+  """
+  name: String
+
+  """
+  Primary contact email from spec.contactInfo.email.
+  """
+  email: String
+}
+
+type Organization {
+  """
+  metadata.name — the stable organization ID.
+  """
+  name: String!
+
+  """
+  Human-readable name from the kubernetes.io/display-name annotation, falling back to name.
+  """
+  displayName: String!
+
+  """
+  Organization type: Personal or Standard.
+  """
+  type: String!
+  createdAt: String
+
+  """
+  Status of the Ready condition.
+  """
+  state: String
+
+  """
+  Contact details from spec.contactInfo.
+  """
+  contactInfo: OrgContactInfo
+
+  """
+  True when the OnboardingComplete condition status is True.
+  """
+  onboardingComplete: Boolean!
+
+  """
+  Reason from the OnboardingComplete condition.
+  """
+  onboardingReason: String
+
+  """
+  Human-readable message from the OnboardingComplete condition.
+  """
+  onboardingMessage: String
+
+  """
+  Members and pending invitations for this organization.
+  """
+  members: [OrgMember!]!
+
+  """
+  Projects owned by this organization (via its control plane).
+  """
+  projects(limit: Int, cursor: String): ProjectList!
+}
+
+type OrganizationList {
+  items: [Organization!]!
+
+  """
+  Pagination cursor — pass as cursor on the next call to continue listing.
+  """
+  continueToken: String
+}
+
+type Project {
+  """
+  metadata.name — the stable project ID.
+  """
+  name: String!
+
+  """
+  Human-readable name from the kubernetes.io/display-name annotation, falling back to kubernetes.io/description, then name.
+  """
+  displayName: String!
+
+  """
+  Name of the owning organization.
+  """
+  organizationName: String!
+
+  """
+  Owning organization's display name (kubernetes.io/display-name), falling back to organizationName.
+  """
+  organizationDisplayName: String!
+
+  """
+  Owning organization's company / legal name from contactInfo.businessName.
+  """
+  organizationBusinessName: String
+
+  """
+  True when the project has an Active billing-account binding to an account with a default payment method.
+  """
+  hasActiveBillingAccount: Boolean!
+
+  """
+  Bound billing account name when hasActiveBillingAccount is true.
+  """
+  billingAccountName: String
+  createdAt: String
+
+  """
+  Status of the Ready condition.
+  """
+  state: String
+}
+
+type ProjectList {
+  items: [Project!]!
+
+  """
+  Pagination cursor — pass as cursor on the next call to continue listing.
+  """
+  continueToken: String
+}
+
+type OrgMember {
+  """
+  Resource name of the membership or invitation.
+  """
+  name: String!
+  givenName: String
+  familyName: String
+  email: String!
+  roles: [String!]!
+
+  """
+  member or invitation
+  """
+  type: String!
+
+  """
+  Only set for invitations: Pending, Accepted, Declined.
+  """
+  invitationState: String
+  createdAt: String
+
+  """
+  The member's user resource name. Null for invitations, which have no user yet.
+  """
+  userName: String
+
+  """
+  Avatar URL from the membership user status. Null for invitations.
+  """
+  avatarUrl: String
 }

--- a/app/modules/graphql/generated/schema.ts
+++ b/app/modules/graphql/generated/schema.ts
@@ -35,7 +35,7 @@ export interface Query {
    */
   contactGroupMembershipsWithContacts: EnrichedContactGroupMembershipList;
   /**
-   * Lists ContactGroupMemberships across all namespaces, enriched with full
+   * Lists ContactGroupMemberships in the given namespace, enriched with full
    * ContactGroup data for each membership. Resolves all contact groups in parallel.
    */
   contactMembershipsWithGroups: EnrichedContactMembershipList;
@@ -44,6 +44,22 @@ export interface Query {
    * lookup failures return null for that entry (filtered from the result).
    */
   userSummaries: UserSummary[];
+  /**
+   * Lists all organizations the caller can access. When `search` is set, matches
+   * substring against name, displayName, company, and contact fields (walks
+   * upstream pages until `limit` matches).
+   */
+  organizations: OrganizationList;
+  /** Returns a single organization by name. */
+  organization?: Organization;
+  /** Lists projects in an organization via its control plane. */
+  organizationProjects: ProjectList;
+  /** Lists members and pending invitations for an organization. */
+  organizationMembers: OrgMember[];
+  /** Lists all projects the caller can access. */
+  projects: ProjectList;
+  /** Returns a single project by name. */
+  project?: Project;
   __typename: 'Query';
 }
 
@@ -78,7 +94,7 @@ export interface ExtendedSession {
 export interface ConsumerProject {
   /** The project's machine name (metadata.name). */
   name: Scalars['String'];
-  /** Human-readable name from the kubernetes.io/description annotation, falling back to name. */
+  /** Human-readable name from the kubernetes.io/display-name annotation, falling back to kubernetes.io/description, then name. */
   displayName: Scalars['String'];
   __typename: 'ConsumerProject';
 }
@@ -117,10 +133,30 @@ export interface EnrichedContact {
   __typename: 'EnrichedContact';
 }
 
+/** A single Kubernetes-style status condition on a ContactGroup. */
+export interface ContactGroupCondition {
+  type: Scalars['String'];
+  status: Scalars['String'];
+  reason?: Scalars['String'];
+  message?: Scalars['String'];
+  lastTransitionTime?: Scalars['String'];
+  observedGeneration?: Scalars['Int'];
+  __typename: 'ContactGroupCondition';
+}
+
+export interface EnrichedContactGroupStatus {
+  conditions?: ContactGroupCondition[];
+  __typename: 'EnrichedContactGroupStatus';
+}
+
 export interface EnrichedContactGroup {
   name: Scalars['String'];
   namespace: Scalars['String'];
   displayName?: Scalars['String'];
+  /** Whether the group allows opt-in/opt-out membership: 'public' or 'private'. */
+  visibility?: Scalars['String'];
+  /** Observed status of the ContactGroup (Ready condition, provider sync). */
+  status?: EnrichedContactGroupStatus;
   __typename: 'EnrichedContactGroup';
 }
 
@@ -136,6 +172,8 @@ export interface ContactGroupMembershipEnriched {
 export interface ContactMembershipEnriched {
   /** metadata.name of the ContactGroupMembership resource. */
   name: Scalars['String'];
+  /** When the contact joined the group (membership metadata.creationTimestamp). */
+  creationTimestamp?: Scalars['String'];
   contactGroupRef: ContactRef;
   /** Full ContactGroup data, null if lookup failed. */
   contactGroup?: EnrichedContactGroup;
@@ -162,6 +200,95 @@ export interface UserSummary {
   givenName?: Scalars['String'];
   familyName?: Scalars['String'];
   __typename: 'UserSummary';
+}
+
+export interface OrgContactInfo {
+  /** Legal / company name from spec.contactInfo.businessName. */
+  businessName?: Scalars['String'];
+  /** Primary contact name from spec.contactInfo.name. */
+  name?: Scalars['String'];
+  /** Primary contact email from spec.contactInfo.email. */
+  email?: Scalars['String'];
+  __typename: 'OrgContactInfo';
+}
+
+export interface Organization {
+  /** metadata.name — the stable organization ID. */
+  name: Scalars['String'];
+  /** Human-readable name from the kubernetes.io/display-name annotation, falling back to name. */
+  displayName: Scalars['String'];
+  /** Organization type: Personal or Standard. */
+  type: Scalars['String'];
+  createdAt?: Scalars['String'];
+  /** Status of the Ready condition. */
+  state?: Scalars['String'];
+  /** Contact details from spec.contactInfo. */
+  contactInfo?: OrgContactInfo;
+  /** True when the OnboardingComplete condition status is True. */
+  onboardingComplete: Scalars['Boolean'];
+  /** Reason from the OnboardingComplete condition. */
+  onboardingReason?: Scalars['String'];
+  /** Human-readable message from the OnboardingComplete condition. */
+  onboardingMessage?: Scalars['String'];
+  /** Members and pending invitations for this organization. */
+  members: OrgMember[];
+  /** Projects owned by this organization (via its control plane). */
+  projects: ProjectList;
+  __typename: 'Organization';
+}
+
+export interface OrganizationList {
+  items: Organization[];
+  /** Pagination cursor — pass as cursor on the next call to continue listing. */
+  continueToken?: Scalars['String'];
+  __typename: 'OrganizationList';
+}
+
+export interface Project {
+  /** metadata.name — the stable project ID. */
+  name: Scalars['String'];
+  /** Human-readable name from the kubernetes.io/display-name annotation, falling back to kubernetes.io/description, then name. */
+  displayName: Scalars['String'];
+  /** Name of the owning organization. */
+  organizationName: Scalars['String'];
+  /** Owning organization's display name (kubernetes.io/display-name), falling back to organizationName. */
+  organizationDisplayName: Scalars['String'];
+  /** Owning organization's company / legal name from contactInfo.businessName. */
+  organizationBusinessName?: Scalars['String'];
+  /** True when the project has an Active billing-account binding to an account with a default payment method. */
+  hasActiveBillingAccount: Scalars['Boolean'];
+  /** Bound billing account name when hasActiveBillingAccount is true. */
+  billingAccountName?: Scalars['String'];
+  createdAt?: Scalars['String'];
+  /** Status of the Ready condition. */
+  state?: Scalars['String'];
+  __typename: 'Project';
+}
+
+export interface ProjectList {
+  items: Project[];
+  /** Pagination cursor — pass as cursor on the next call to continue listing. */
+  continueToken?: Scalars['String'];
+  __typename: 'ProjectList';
+}
+
+export interface OrgMember {
+  /** Resource name of the membership or invitation. */
+  name: Scalars['String'];
+  givenName?: Scalars['String'];
+  familyName?: Scalars['String'];
+  email: Scalars['String'];
+  roles: Scalars['String'][];
+  /** member or invitation */
+  type: Scalars['String'];
+  /** Only set for invitations: Pending, Accepted, Declined. */
+  invitationState?: Scalars['String'];
+  createdAt?: Scalars['String'];
+  /** The member's user resource name. Null for invitations, which have no user yet. */
+  userName?: Scalars['String'];
+  /** Avatar URL from the membership user status. Null for invitations. */
+  avatarUrl?: Scalars['String'];
+  __typename: 'OrgMember';
 }
 
 export interface QueryRequest {
@@ -195,6 +322,7 @@ export interface QueryRequest {
   contactGroupMembershipsWithContacts?:
     | [
         {
+          namespace?: Scalars['String'] | null;
           fieldSelector?: Scalars['String'] | null;
           limit?: Scalars['Int'] | null;
           cursor?: Scalars['String'] | null;
@@ -203,12 +331,13 @@ export interface QueryRequest {
       ]
     | EnrichedContactGroupMembershipListRequest;
   /**
-   * Lists ContactGroupMemberships across all namespaces, enriched with full
+   * Lists ContactGroupMemberships in the given namespace, enriched with full
    * ContactGroup data for each membership. Resolves all contact groups in parallel.
    */
   contactMembershipsWithGroups?:
     | [
         {
+          namespace?: Scalars['String'] | null;
           fieldSelector?: Scalars['String'] | null;
           limit?: Scalars['Int'] | null;
           cursor?: Scalars['String'] | null;
@@ -221,6 +350,47 @@ export interface QueryRequest {
    * lookup failures return null for that entry (filtered from the result).
    */
   userSummaries?: [{ names: Scalars['String'][] }, UserSummaryRequest];
+  /**
+   * Lists all organizations the caller can access. When `search` is set, matches
+   * substring against name, displayName, company, and contact fields (walks
+   * upstream pages until `limit` matches).
+   */
+  organizations?:
+    | [
+        {
+          limit?: Scalars['Int'] | null;
+          cursor?: Scalars['String'] | null;
+          search?: Scalars['String'] | null;
+        },
+        OrganizationListRequest,
+      ]
+    | OrganizationListRequest;
+  /** Returns a single organization by name. */
+  organization?: [{ name: Scalars['String'] }, OrganizationRequest];
+  /** Lists projects in an organization via its control plane. */
+  organizationProjects?: [
+    {
+      orgName: Scalars['String'];
+      limit?: Scalars['Int'] | null;
+      cursor?: Scalars['String'] | null;
+    },
+    ProjectListRequest,
+  ];
+  /** Lists members and pending invitations for an organization. */
+  organizationMembers?: [{ orgName: Scalars['String'] }, OrgMemberRequest];
+  /** Lists all projects the caller can access. */
+  projects?:
+    | [
+        {
+          limit?: Scalars['Int'] | null;
+          cursor?: Scalars['String'] | null;
+          search?: Scalars['String'] | null;
+        },
+        ProjectListRequest,
+      ]
+    | ProjectListRequest;
+  /** Returns a single project by name. */
+  project?: [{ name: Scalars['String'] }, ProjectRequest];
   __typename?: boolean | number;
   __scalar?: boolean | number;
   __alias?: {
@@ -271,7 +441,7 @@ export interface ExtendedSessionRequest {
 export interface ConsumerProjectRequest {
   /** The project's machine name (metadata.name). */
   name?: boolean | number;
-  /** Human-readable name from the kubernetes.io/description annotation, falling back to name. */
+  /** Human-readable name from the kubernetes.io/display-name annotation, falling back to kubernetes.io/description, then name. */
   displayName?: boolean | number;
   __typename?: boolean | number;
   __scalar?: boolean | number;
@@ -326,10 +496,38 @@ export interface EnrichedContactRequest {
   };
 }
 
+/** A single Kubernetes-style status condition on a ContactGroup. */
+export interface ContactGroupConditionRequest {
+  type?: boolean | number;
+  status?: boolean | number;
+  reason?: boolean | number;
+  message?: boolean | number;
+  lastTransitionTime?: boolean | number;
+  observedGeneration?: boolean | number;
+  __typename?: boolean | number;
+  __scalar?: boolean | number;
+  __alias?: {
+    [alias: string]: ContactGroupConditionRequest;
+  };
+}
+
+export interface EnrichedContactGroupStatusRequest {
+  conditions?: ContactGroupConditionRequest;
+  __typename?: boolean | number;
+  __scalar?: boolean | number;
+  __alias?: {
+    [alias: string]: EnrichedContactGroupStatusRequest;
+  };
+}
+
 export interface EnrichedContactGroupRequest {
   name?: boolean | number;
   namespace?: boolean | number;
   displayName?: boolean | number;
+  /** Whether the group allows opt-in/opt-out membership: 'public' or 'private'. */
+  visibility?: boolean | number;
+  /** Observed status of the ContactGroup (Ready condition, provider sync). */
+  status?: EnrichedContactGroupStatusRequest;
   __typename?: boolean | number;
   __scalar?: boolean | number;
   __alias?: {
@@ -353,6 +551,8 @@ export interface ContactGroupMembershipEnrichedRequest {
 export interface ContactMembershipEnrichedRequest {
   /** metadata.name of the ContactGroupMembership resource. */
   name?: boolean | number;
+  /** When the contact joined the group (membership metadata.creationTimestamp). */
+  creationTimestamp?: boolean | number;
   contactGroupRef?: ContactRefRequest;
   /** Full ContactGroup data, null if lookup failed. */
   contactGroup?: EnrichedContactGroupRequest;
@@ -394,6 +594,121 @@ export interface UserSummaryRequest {
   __scalar?: boolean | number;
   __alias?: {
     [alias: string]: UserSummaryRequest;
+  };
+}
+
+export interface OrgContactInfoRequest {
+  /** Legal / company name from spec.contactInfo.businessName. */
+  businessName?: boolean | number;
+  /** Primary contact name from spec.contactInfo.name. */
+  name?: boolean | number;
+  /** Primary contact email from spec.contactInfo.email. */
+  email?: boolean | number;
+  __typename?: boolean | number;
+  __scalar?: boolean | number;
+  __alias?: {
+    [alias: string]: OrgContactInfoRequest;
+  };
+}
+
+export interface OrganizationRequest {
+  /** metadata.name — the stable organization ID. */
+  name?: boolean | number;
+  /** Human-readable name from the kubernetes.io/display-name annotation, falling back to name. */
+  displayName?: boolean | number;
+  /** Organization type: Personal or Standard. */
+  type?: boolean | number;
+  createdAt?: boolean | number;
+  /** Status of the Ready condition. */
+  state?: boolean | number;
+  /** Contact details from spec.contactInfo. */
+  contactInfo?: OrgContactInfoRequest;
+  /** True when the OnboardingComplete condition status is True. */
+  onboardingComplete?: boolean | number;
+  /** Reason from the OnboardingComplete condition. */
+  onboardingReason?: boolean | number;
+  /** Human-readable message from the OnboardingComplete condition. */
+  onboardingMessage?: boolean | number;
+  /** Members and pending invitations for this organization. */
+  members?: OrgMemberRequest;
+  /** Projects owned by this organization (via its control plane). */
+  projects?:
+    | [{ limit?: Scalars['Int'] | null; cursor?: Scalars['String'] | null }, ProjectListRequest]
+    | ProjectListRequest;
+  __typename?: boolean | number;
+  __scalar?: boolean | number;
+  __alias?: {
+    [alias: string]: OrganizationRequest;
+  };
+}
+
+export interface OrganizationListRequest {
+  items?: OrganizationRequest;
+  /** Pagination cursor — pass as cursor on the next call to continue listing. */
+  continueToken?: boolean | number;
+  __typename?: boolean | number;
+  __scalar?: boolean | number;
+  __alias?: {
+    [alias: string]: OrganizationListRequest;
+  };
+}
+
+export interface ProjectRequest {
+  /** metadata.name — the stable project ID. */
+  name?: boolean | number;
+  /** Human-readable name from the kubernetes.io/display-name annotation, falling back to kubernetes.io/description, then name. */
+  displayName?: boolean | number;
+  /** Name of the owning organization. */
+  organizationName?: boolean | number;
+  /** Owning organization's display name (kubernetes.io/display-name), falling back to organizationName. */
+  organizationDisplayName?: boolean | number;
+  /** Owning organization's company / legal name from contactInfo.businessName. */
+  organizationBusinessName?: boolean | number;
+  /** True when the project has an Active billing-account binding to an account with a default payment method. */
+  hasActiveBillingAccount?: boolean | number;
+  /** Bound billing account name when hasActiveBillingAccount is true. */
+  billingAccountName?: boolean | number;
+  createdAt?: boolean | number;
+  /** Status of the Ready condition. */
+  state?: boolean | number;
+  __typename?: boolean | number;
+  __scalar?: boolean | number;
+  __alias?: {
+    [alias: string]: ProjectRequest;
+  };
+}
+
+export interface ProjectListRequest {
+  items?: ProjectRequest;
+  /** Pagination cursor — pass as cursor on the next call to continue listing. */
+  continueToken?: boolean | number;
+  __typename?: boolean | number;
+  __scalar?: boolean | number;
+  __alias?: {
+    [alias: string]: ProjectListRequest;
+  };
+}
+
+export interface OrgMemberRequest {
+  /** Resource name of the membership or invitation. */
+  name?: boolean | number;
+  givenName?: boolean | number;
+  familyName?: boolean | number;
+  email?: boolean | number;
+  roles?: boolean | number;
+  /** member or invitation */
+  type?: boolean | number;
+  /** Only set for invitations: Pending, Accepted, Declined. */
+  invitationState?: boolean | number;
+  createdAt?: boolean | number;
+  /** The member's user resource name. Null for invitations, which have no user yet. */
+  userName?: boolean | number;
+  /** Avatar URL from the membership user status. Null for invitations. */
+  avatarUrl?: boolean | number;
+  __typename?: boolean | number;
+  __scalar?: boolean | number;
+  __alias?: {
+    [alias: string]: OrgMemberRequest;
   };
 }
 
@@ -445,6 +760,22 @@ export const isEnrichedContact = (obj?: { __typename?: any } | null): obj is Enr
   return EnrichedContact_possibleTypes.includes(obj.__typename);
 };
 
+const ContactGroupCondition_possibleTypes: string[] = ['ContactGroupCondition'];
+export const isContactGroupCondition = (
+  obj?: { __typename?: any } | null
+): obj is ContactGroupCondition => {
+  if (!obj?.__typename) throw new Error('__typename is missing in "isContactGroupCondition"');
+  return ContactGroupCondition_possibleTypes.includes(obj.__typename);
+};
+
+const EnrichedContactGroupStatus_possibleTypes: string[] = ['EnrichedContactGroupStatus'];
+export const isEnrichedContactGroupStatus = (
+  obj?: { __typename?: any } | null
+): obj is EnrichedContactGroupStatus => {
+  if (!obj?.__typename) throw new Error('__typename is missing in "isEnrichedContactGroupStatus"');
+  return EnrichedContactGroupStatus_possibleTypes.includes(obj.__typename);
+};
+
 const EnrichedContactGroup_possibleTypes: string[] = ['EnrichedContactGroup'];
 export const isEnrichedContactGroup = (
   obj?: { __typename?: any } | null
@@ -494,4 +825,40 @@ const UserSummary_possibleTypes: string[] = ['UserSummary'];
 export const isUserSummary = (obj?: { __typename?: any } | null): obj is UserSummary => {
   if (!obj?.__typename) throw new Error('__typename is missing in "isUserSummary"');
   return UserSummary_possibleTypes.includes(obj.__typename);
+};
+
+const OrgContactInfo_possibleTypes: string[] = ['OrgContactInfo'];
+export const isOrgContactInfo = (obj?: { __typename?: any } | null): obj is OrgContactInfo => {
+  if (!obj?.__typename) throw new Error('__typename is missing in "isOrgContactInfo"');
+  return OrgContactInfo_possibleTypes.includes(obj.__typename);
+};
+
+const Organization_possibleTypes: string[] = ['Organization'];
+export const isOrganization = (obj?: { __typename?: any } | null): obj is Organization => {
+  if (!obj?.__typename) throw new Error('__typename is missing in "isOrganization"');
+  return Organization_possibleTypes.includes(obj.__typename);
+};
+
+const OrganizationList_possibleTypes: string[] = ['OrganizationList'];
+export const isOrganizationList = (obj?: { __typename?: any } | null): obj is OrganizationList => {
+  if (!obj?.__typename) throw new Error('__typename is missing in "isOrganizationList"');
+  return OrganizationList_possibleTypes.includes(obj.__typename);
+};
+
+const Project_possibleTypes: string[] = ['Project'];
+export const isProject = (obj?: { __typename?: any } | null): obj is Project => {
+  if (!obj?.__typename) throw new Error('__typename is missing in "isProject"');
+  return Project_possibleTypes.includes(obj.__typename);
+};
+
+const ProjectList_possibleTypes: string[] = ['ProjectList'];
+export const isProjectList = (obj?: { __typename?: any } | null): obj is ProjectList => {
+  if (!obj?.__typename) throw new Error('__typename is missing in "isProjectList"');
+  return ProjectList_possibleTypes.includes(obj.__typename);
+};
+
+const OrgMember_possibleTypes: string[] = ['OrgMember'];
+export const isOrgMember = (obj?: { __typename?: any } | null): obj is OrgMember => {
+  if (!obj?.__typename) throw new Error('__typename is missing in "isOrgMember"');
+  return OrgMember_possibleTypes.includes(obj.__typename);
 };

--- a/app/modules/graphql/generated/types.esm.js
+++ b/app/modules/graphql/generated/types.esm.js
@@ -1,5 +1,5 @@
 export default {
-  scalars: [1, 2, 3, 17],
+  scalars: [1, 2, 3, 21],
   types: {
     Query: {
       serviceConsumers: [
@@ -15,25 +15,69 @@ export default {
         },
       ],
       contactGroupMembershipsWithContacts: [
-        14,
+        16,
         {
+          namespace: [2],
           fieldSelector: [2],
           limit: [3],
           cursor: [2],
         },
       ],
       contactMembershipsWithGroups: [
-        15,
+        17,
         {
+          namespace: [2],
           fieldSelector: [2],
           limit: [3],
           cursor: [2],
         },
       ],
       userSummaries: [
-        16,
+        18,
         {
           names: [2, '[String!]!'],
+        },
+      ],
+      organizations: [
+        22,
+        {
+          limit: [3],
+          cursor: [2],
+          search: [2],
+        },
+      ],
+      organization: [
+        20,
+        {
+          name: [2, 'String!'],
+        },
+      ],
+      organizationProjects: [
+        24,
+        {
+          orgName: [2, 'String!'],
+          limit: [3],
+          cursor: [2],
+        },
+      ],
+      organizationMembers: [
+        25,
+        {
+          orgName: [2, 'String!'],
+        },
+      ],
+      projects: [
+        24,
+        {
+          limit: [3],
+          cursor: [2],
+          search: [2],
+        },
+      ],
+      project: [
+        23,
+        {
+          name: [2, 'String!'],
         },
       ],
       __typename: [2],
@@ -95,10 +139,25 @@ export default {
       displayName: [2],
       __typename: [2],
     },
+    ContactGroupCondition: {
+      type: [2],
+      status: [2],
+      reason: [2],
+      message: [2],
+      lastTransitionTime: [2],
+      observedGeneration: [3],
+      __typename: [2],
+    },
+    EnrichedContactGroupStatus: {
+      conditions: [11],
+      __typename: [2],
+    },
     EnrichedContactGroup: {
       name: [2],
       namespace: [2],
       displayName: [2],
+      visibility: [2],
+      status: [12],
       __typename: [2],
     },
     ContactGroupMembershipEnriched: {
@@ -109,17 +168,18 @@ export default {
     },
     ContactMembershipEnriched: {
       name: [2],
+      creationTimestamp: [2],
       contactGroupRef: [9],
-      contactGroup: [11],
+      contactGroup: [13],
       __typename: [2],
     },
     EnrichedContactGroupMembershipList: {
-      items: [12],
+      items: [14],
       continue: [2],
       __typename: [2],
     },
     EnrichedContactMembershipList: {
-      items: [13],
+      items: [15],
       continue: [2],
       __typename: [2],
     },
@@ -130,6 +190,67 @@ export default {
       familyName: [2],
       __typename: [2],
     },
+    OrgContactInfo: {
+      businessName: [2],
+      name: [2],
+      email: [2],
+      __typename: [2],
+    },
+    Organization: {
+      name: [2],
+      displayName: [2],
+      type: [2],
+      createdAt: [2],
+      state: [2],
+      contactInfo: [19],
+      onboardingComplete: [21],
+      onboardingReason: [2],
+      onboardingMessage: [2],
+      members: [25],
+      projects: [
+        24,
+        {
+          limit: [3],
+          cursor: [2],
+        },
+      ],
+      __typename: [2],
+    },
     Boolean: {},
+    OrganizationList: {
+      items: [20],
+      continueToken: [2],
+      __typename: [2],
+    },
+    Project: {
+      name: [2],
+      displayName: [2],
+      organizationName: [2],
+      organizationDisplayName: [2],
+      organizationBusinessName: [2],
+      hasActiveBillingAccount: [21],
+      billingAccountName: [2],
+      createdAt: [2],
+      state: [2],
+      __typename: [2],
+    },
+    ProjectList: {
+      items: [23],
+      continueToken: [2],
+      __typename: [2],
+    },
+    OrgMember: {
+      name: [2],
+      givenName: [2],
+      familyName: [2],
+      email: [2],
+      roles: [2],
+      type: [2],
+      invitationState: [2],
+      createdAt: [2],
+      userName: [2],
+      avatarUrl: [2],
+      __typename: [2],
+    },
   },
 };

--- a/app/resources/request/client/apis/contact-membership.api.ts
+++ b/app/resources/request/client/apis/contact-membership.api.ts
@@ -85,11 +85,23 @@ export const contactMembershipForContactListQuery = async (
         continue: true,
         items: {
           name: true,
+          creationTimestamp: true,
           contactGroupRef: { name: true, namespace: true },
           contactGroup: {
             name: true,
             namespace: true,
             displayName: true,
+            visibility: true,
+            status: {
+              conditions: {
+                type: true,
+                status: true,
+                reason: true,
+                message: true,
+                lastTransitionTime: true,
+                observedGeneration: true,
+              },
+            },
           },
         },
       },
@@ -102,7 +114,7 @@ export const contactMembershipForContactListQuery = async (
   return {
     metadata: { continue: data?.continue ?? undefined },
     items: (data?.items ?? []).map((item: ContactMembershipEnriched) => ({
-      metadata: { name: item.name },
+      metadata: { name: item.name, creationTimestamp: item.creationTimestamp ?? undefined },
       spec: {
         contactGroupRef: {
           name: item.contactGroupRef.name,
@@ -117,7 +129,20 @@ export const contactMembershipForContactListQuery = async (
             },
             spec: {
               displayName: item.contactGroup.displayName ?? undefined,
+              visibility: item.contactGroup.visibility as 'public' | 'private' | undefined,
             },
+            status: item.contactGroup.status
+              ? {
+                  conditions: (item.contactGroup.status.conditions ?? []).map((c) => ({
+                    type: c.type,
+                    status: c.status as 'True' | 'False' | 'Unknown',
+                    reason: c.reason ?? '',
+                    message: c.message ?? '',
+                    lastTransitionTime: c.lastTransitionTime ?? '',
+                    observedGeneration: c.observedGeneration ?? undefined,
+                  })),
+                }
+              : undefined,
           }
         : undefined,
     })),

--- a/app/routes/marketing/contact/detail/group.tsx
+++ b/app/routes/marketing/contact/detail/group.tsx
@@ -89,12 +89,10 @@ export default function Page() {
         },
       }
     ),
-    columnHelper.accessor((row) => row.contactGroup?.spec?.visibility ?? 'public', {
+    columnHelper.accessor((row) => row.contactGroup?.spec?.visibility ?? '', {
       id: 'visibility',
       header: ({ column }) => <ListColumnHeader column={column} title={t`Visibility`} />,
-      cell: ({ row }) => (
-        <BadgeState state={row.original.contactGroup?.spec?.visibility ?? 'public'} />
-      ),
+      cell: ({ row }) => <BadgeState state={row.original.contactGroup?.spec?.visibility ?? ''} />,
     }),
     columnHelper.accessor((row) => row.contactGroup?.status ?? null, {
       id: 'status',

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "dotenv": "^17.0.0",
-        "graphql": "^17.0.0",
+        "graphql": "^16.0.0",
         "hono": "^4.7.9",
         "intl-parse-accept-language": "^1.0.0",
         "isbot": "^5.1.27",
@@ -115,6 +115,7 @@
   },
   "overrides": {
     "form-data": "^4.0.6",
+    "graphql": "16.14.2",
     "react-is": "^19.0.0-rc-69d4b800-20241021",
   },
   "packages": {
@@ -1934,7 +1935,7 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "graphql": ["graphql@17.0.1", "", {}, "sha512-8eWbg5Zcv/8o20nzEjHUGPTj20MLFJjc5kagbIPxbaeGxvFwpitJhemEC/k17n5+UD4M/9ea5rTuce78mELujQ=="],
+    "graphql": ["graphql@16.14.2", "", {}, "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA=="],
 
     "graphql-ws": ["graphql-ws@6.0.8", "", { "peerDependencies": { "@fastify/websocket": "^10 || ^11", "crossws": "~0.3", "graphql": "^15.10.1 || ^16", "ws": "^8" }, "optionalPeers": ["@fastify/websocket", "crossws", "ws"] }, "sha512-m3EOaNsUBXwAnkBWbzPfe0Nq8pXUfxsWnolC54sru3FzHvhTZL0Ouf/BoQsaGAXqM+YPerXOJ47BUnmgmoupCw=="],
 
@@ -3233,8 +3234,6 @@
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@eslint/config-array/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
-
-    "@gqlts/cli/graphql": ["graphql@16.14.2", "", {}, "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA=="],
 
     "@gqlts/runtime/axios": ["axios@1.16.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A=="],
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "dotenv": "^17.0.0",
-    "graphql": "^17.0.0",
+    "graphql": "^16.0.0",
     "hono": "^4.7.9",
     "intl-parse-accept-language": "^1.0.0",
     "isbot": "^5.1.27",
@@ -135,6 +135,7 @@
   },
   "overrides": {
     "react-is": "^19.0.0-rc-69d4b800-20241021",
-    "form-data": "^4.0.6"
+    "form-data": "^4.0.6",
+    "graphql": "16.14.2"
   }
 }


### PR DESCRIPTION
Fixes the contact **groups list** showing wrong data vs. the group **detail** view (e.g. visibility "public" in the list but "private" in detail).

## Root cause

Both views read `spec.visibility ?? 'public'`, but the list's data source — the GraphQL `contactMembershipsWithGroups` enriched query — only returned `displayName`. So `visibility` was always `undefined` → defaulted to `"public"`, `status` was empty, and the "Joined" date was blank. The detail view reads the real `ContactGroup` resource, hence the mismatch. Depends on milo-os/graphql-gateway#49 (merged + deployed), which now exposes these fields.

## Changes

**`chore` commit — unblock the codegen**
- The `graphql` devDep had been bumped to `^17`, but `@gqlts/cli` (and graphql-ws / urql / @0no-co/graphql.web) all require graphql `16` — the codegen failed with *"Cannot use GraphQLSchema from another module or realm."* graphql isn't used at runtime, so pinned it to `^16` and added an `overrides` entry to dedupe to a single instance. `bun install` + `bun run graphql` now work cleanly.

**`fix` commit — the actual fix**
- Regenerated the GraphQL client against the updated staging gateway.
- `contactMembershipForContactListQuery` now selects + maps `contactGroup.visibility`, `contactGroup.status.conditions`, and the membership `creationTimestamp`.
- Dropped the misleading `?? 'public'` fallback in the visibility column — a missing value now renders neutral instead of a wrong-but-plausible "public".

## Result

Visibility, Status, and Joined columns on the groups list now show the real values, matching the detail view.

## Testing

- `typecheck` clean, `eslint` clean, prettier clean
- Gateway schema verified live on staging (`EnrichedContactGroup` exposes `visibility` + `status`).