### PR TITLE
feat(operations): Add Chainsaw Tests dashboard page

### DIFF
--- a/app/features/chainsaw-tests/components/chainsaw-tests-widget.tsx
+++ b/app/features/chainsaw-tests/components/chainsaw-tests-widget.tsx
@@ -1,0 +1,285 @@
+import { useChainsawTests } from '../hooks/use-chainsaw-tests';
+import type { ChainsawTestRow, ChainsawTestRun } from '../hooks/use-chainsaw-tests';
+import { DateTime } from '@/components/date';
+import { ACTION_ICONS, STATUS_ICONS } from '@/utils/config/icons.config';
+import { Button, LinkButton } from '@datum-cloud/datum-ui/button';
+import { Card, CardContent, CardHeader } from '@datum-cloud/datum-ui/card';
+import { Skeleton } from '@datum-cloud/datum-ui/skeleton';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@datum-cloud/datum-ui/table';
+import { Tooltip } from '@datum-cloud/datum-ui/tooltip';
+import { Text, Title } from '@datum-cloud/datum-ui/typography';
+import { Trans } from '@lingui/react/macro';
+import { FlaskConical } from 'lucide-react';
+
+function LoadingSkeleton() {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow className="bg-muted hover:bg-muted">
+          <TableHead>
+            <Skeleton className="h-3.5 w-24" />
+          </TableHead>
+          <TableHead>
+            <Skeleton className="h-3.5 w-16" />
+          </TableHead>
+          <TableHead>
+            <Skeleton className="h-3.5 w-32" />
+          </TableHead>
+          <TableHead>
+            <Skeleton className="h-3.5 w-12" />
+          </TableHead>
+          <TableHead>
+            <Skeleton className="h-3.5 w-20" />
+          </TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {Array.from({ length: 4 }).map((_, i) => (
+          <TableRow key={i}>
+            <TableCell>
+              <Skeleton className="h-4 w-32" />
+            </TableCell>
+            <TableCell>
+              <Skeleton className="h-4 w-16" />
+            </TableCell>
+            <TableCell>
+              <Skeleton className="h-4 w-40" />
+            </TableCell>
+            <TableCell>
+              <Skeleton className="h-5 w-14 rounded-full" />
+            </TableCell>
+            <TableCell>
+              <Skeleton className="h-6 w-20" />
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center py-6 text-center">
+      <FlaskConical className="text-muted-foreground mb-3 h-8 w-8" />
+      <Title level={5} className="mb-1">
+        <Trans>No stable tests labeled yet</Trans>
+      </Title>
+      <Text size="sm" textColor="muted">
+        <Trans>
+          Tests show up here once tagged metadata.labels.stability: stable in their
+          chainsaw-test.yaml
+        </Trans>
+      </Text>
+    </div>
+  );
+}
+
+function ErrorState({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-6 text-center">
+      <STATUS_ICONS.alert className="text-muted-foreground mb-3 h-8 w-8" />
+      <Title level={5} className="mb-1">
+        <Trans>Could not load test results</Trans>
+      </Title>
+      <Button type="secondary" size="small" onClick={onRetry}>
+        <Trans>Retry</Trans>
+      </Button>
+    </div>
+  );
+}
+
+function RunTick({ run }: { run: ChainsawTestRun }) {
+  const color = run.passed
+    ? 'bg-green-500 dark:bg-green-400'
+    : 'bg-red-500 dark:bg-red-400';
+  return (
+    <Tooltip
+      side="top"
+      message={
+        <div className="flex flex-col leading-tight">
+          <span className="font-medium">{run.passed ? 'Passed' : 'Failed'}</span>
+          <DateTime date={new Date(run.timestamp).toISOString()} variant="relative" />
+        </div>
+      }>
+      <span className={`inline-block h-3 w-1.5 rounded-sm ${color}`} />
+    </Tooltip>
+  );
+}
+
+function HistoryStrip({ history }: { history: ChainsawTestRun[] }) {
+  if (history.length === 0) {
+    return (
+      <Text size="sm" textColor="muted">
+        <Trans>No runs</Trans>
+      </Text>
+    );
+  }
+  return (
+    <div className="flex items-center gap-0.5">
+      {history.map((run) => (
+        <RunTick key={run.timestamp} run={run} />
+      ))}
+    </div>
+  );
+}
+
+function LatestBadge({ latest }: { latest: ChainsawTestRow['latest'] }) {
+  if (!latest) {
+    return (
+      <Text size="sm" textColor="muted">
+        <Trans>Unknown</Trans>
+      </Text>
+    );
+  }
+  return latest.passed ? (
+    <span className="inline-flex items-center gap-1 text-green-600 dark:text-green-400">
+      <STATUS_ICONS.success className="h-3.5 w-3.5" />
+      <Text size="sm" className="font-medium">
+        <Trans>Passing</Trans>
+      </Text>
+    </span>
+  ) : (
+    <span className="inline-flex items-center gap-1 text-red-600 dark:text-red-400">
+      <STATUS_ICONS.error className="h-3.5 w-3.5" />
+      <Text size="sm" className="font-medium">
+        <Trans>Failing</Trans>
+      </Text>
+    </span>
+  );
+}
+
+export function ChainsawTestsWidget() {
+  const { data, isLoading, isError, refetch } = useChainsawTests();
+  const tests = data?.tests ?? [];
+
+  return (
+    <Card className="min-w-0 gap-0 py-0">
+      <CardHeader className="px-4 py-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <FlaskConical className="text-muted-foreground h-4 w-4" />
+            <Title level={4}>
+              <Trans>Chainsaw Tests</Trans>
+            </Title>
+            <Text size="sm" textColor="muted">
+              <Trans>Last 3 days · tests expected to pass every run</Trans>
+            </Text>
+          </div>
+          {data?.githubActionsUrl && (
+            <LinkButton
+              href={data.githubActionsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              theme="outline"
+              size="small"
+              icon={<ACTION_ICONS.externalLink size={12} />}
+              iconPosition="right">
+              <Trans>CI runs</Trans>
+            </LinkButton>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="min-h-[180px] px-4 pt-0 pb-3">
+        {isLoading ? (
+          <LoadingSkeleton />
+        ) : isError ? (
+          <ErrorState onRetry={refetch} />
+        ) : tests.length === 0 ? (
+          <EmptyState />
+        ) : (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow className="bg-muted hover:bg-muted">
+                  <TableHead>
+                    <Text size="sm" textColor="muted">
+                      <Trans>Test</Trans>
+                    </Text>
+                  </TableHead>
+                  <TableHead>
+                    <Text size="sm" textColor="muted">
+                      <Trans>Suite</Trans>
+                    </Text>
+                  </TableHead>
+                  <TableHead className="hidden md:table-cell">
+                    <Text size="sm" textColor="muted">
+                      <Trans>Last 3 days</Trans>
+                    </Text>
+                  </TableHead>
+                  <TableHead>
+                    <Text size="sm" textColor="muted">
+                      <Trans>Latest</Trans>
+                    </Text>
+                  </TableHead>
+                  <TableHead>
+                    <Text size="sm" textColor="muted">
+                      <Trans>Links</Trans>
+                    </Text>
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {tests.map((row) => (
+                  <TableRow key={row.key}>
+                    <TableCell className="max-w-[180px]">
+                      <Text size="sm" className="truncate font-medium">
+                        {row.test}
+                      </Text>
+                      <Text size="sm" textColor="muted" className="md:hidden">
+                        {row.environment}
+                      </Text>
+                    </TableCell>
+                    <TableCell>
+                      <Text size="sm" textColor="muted">
+                        {row.suite}
+                        <span className="hidden md:inline"> · {row.environment}</span>
+                      </Text>
+                    </TableCell>
+                    <TableCell className="hidden md:table-cell">
+                      <HistoryStrip history={row.history} />
+                    </TableCell>
+                    <TableCell>
+                      <LatestBadge latest={row.latest} />
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        <LinkButton
+                          href={row.grafanaUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          theme="outline"
+                          size="small"
+                          icon={<ACTION_ICONS.externalLink size={12} />}
+                          iconPosition="right">
+                          <Trans>Grafana</Trans>
+                        </LinkButton>
+                        <LinkButton
+                          href={row.docsUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          theme="outline"
+                          size="small"
+                          icon={<ACTION_ICONS.externalLink size={12} />}
+                          iconPosition="right">
+                          <Trans>Test docs</Trans>
+                        </LinkButton>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/features/chainsaw-tests/hooks/use-chainsaw-tests.ts
+++ b/app/features/chainsaw-tests/hooks/use-chainsaw-tests.ts
@@ -1,0 +1,44 @@
+import { httpClient } from '@/modules/axios/axios.client';
+import { useQuery } from '@tanstack/react-query';
+
+export interface ChainsawTestRun {
+  timestamp: number;
+  passed: boolean;
+}
+
+export interface ChainsawTestRow {
+  key: string;
+  test: string;
+  suite: string;
+  environment: string;
+  history: ChainsawTestRun[];
+  latest: ChainsawTestRun | null;
+  grafanaUrl: string;
+  docsUrl: string;
+}
+
+export interface ChainsawTestsData {
+  tests: ChainsawTestRow[];
+  githubActionsUrl: string;
+}
+
+function parseResponse(raw: any): ChainsawTestsData {
+  const payload = raw?.data;
+  if (!payload?.tests) {
+    return { tests: [], githubActionsUrl: '' };
+  }
+  return payload;
+}
+
+export function useChainsawTests() {
+  return useQuery({
+    queryKey: ['dashboard', 'chainsaw-tests'],
+    queryFn: async () => {
+      const { data } = await httpClient.post('/api/chainsaw-tests', {}, { baseURL: '' });
+      return parseResponse(data);
+    },
+    staleTime: 60 * 1000,
+    refetchInterval: 5 * 60 * 1000,
+    retry: 1,
+  });
+}

--- a/app/features/chainsaw-tests/index.ts
+++ b/app/features/chainsaw-tests/index.ts
@@ -1,0 +1,1 @@
+export { ChainsawTestsWidget } from './components/chainsaw-tests-widget';

--- a/app/features/milo/lib/nav-config.ts
+++ b/app/features/milo/lib/nav-config.ts
@@ -2,6 +2,7 @@ import { ENTITY_ICONS, SECTION_ICONS } from '@/utils/config/icons.config';
 import {
   activityRoutes,
   billingAccountRoutes,
+  chainsawTestRoutes,
   contactGroupRoutes,
   contactRoutes,
   fraudRoutes,
@@ -139,6 +140,11 @@ export const NAV_SECTIONS: NavSection[] = [
               label: 'Email Activity',
               href: routes.emailActivity(),
               icon: ENTITY_ICONS.emailActivity,
+            },
+            {
+              label: 'Chainsaw Tests',
+              href: chainsawTestRoutes.list(),
+              icon: ENTITY_ICONS.chainsawTest,
             },
           ],
         },

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -144,6 +144,7 @@ export default [
 
     // Operations
     route('operations', 'routes/operation/layout.tsx', [
+      route('chainsaw-tests', 'routes/operation/chainsaw-tests.tsx'),
       route('activity', 'routes/operation/activity/layout.tsx', [
         index('routes/operation/activity/index.tsx'),
         route('feed', 'routes/operation/activity/feed.tsx'),

--- a/app/routes/operation/chainsaw-tests.tsx
+++ b/app/routes/operation/chainsaw-tests.tsx
@@ -1,0 +1,20 @@
+import type { Route } from './+types/chainsaw-tests';
+import { ChainsawTestsWidget } from '@/features/chainsaw-tests';
+import { metaObject } from '@/utils/helpers';
+import { Trans } from '@lingui/react/macro';
+
+export const meta: Route.MetaFunction = () => {
+  return metaObject('Chainsaw Tests');
+};
+
+export const handle = {
+  breadcrumb: () => <Trans>Chainsaw Tests</Trans>,
+};
+
+export default function Page() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4">
+      <ChainsawTestsWidget />
+    </div>
+  );
+}

--- a/app/server/routes/api.ts
+++ b/app/server/routes/api.ts
@@ -6,6 +6,7 @@ import { logApiError, logApiSuccess } from '@/server/logger';
 import { authMiddleware, getToken } from '@/server/middleware';
 import { createErrorResponse, createSuccessResponse } from '@/server/response';
 import { assistantRoutes } from '@/server/routes/assistant';
+import { chainsawTestsRoutes } from '@/server/routes/chainsaw-tests';
 import { clusterRoutes } from '@/server/routes/cluster';
 import { graphqlRoutes } from '@/server/routes/graphql';
 import { usageRoutes } from '@/server/routes/usage';
@@ -268,6 +269,7 @@ api.post('/metrics', authMiddleware(), async (c) => {
 });
 
 api.route('/assistant', assistantRoutes);
+api.route('/chainsaw-tests', chainsawTestsRoutes);
 api.route('/cluster', clusterRoutes);
 api.route('/graphql', graphqlRoutes);
 api.route('/usage', usageRoutes);

--- a/app/server/routes/chainsaw-tests.ts
+++ b/app/server/routes/chainsaw-tests.ts
@@ -1,0 +1,162 @@
+import { EnvVariables } from '@/server/iface';
+import { logApiError, logApiSuccess } from '@/server/logger';
+import { authMiddleware } from '@/server/middleware';
+import { createErrorResponse, createSuccessResponse } from '@/server/response';
+import { captureApiError, createRequestLogger } from '@/utils/logger';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { Hono } from 'hono';
+
+export const chainsawTestsRoutes = new Hono<{ Variables: EnvVariables }>();
+
+const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000;
+const STEP = '1h';
+const GITHUB_ACTIONS_URL =
+  'https://github.com/datum-cloud/infra/actions/workflows/run-e2e-tests.yaml';
+
+interface ChainsawTestRun {
+  timestamp: number;
+  passed: boolean;
+}
+
+interface ChainsawTestRow {
+  key: string;
+  test: string;
+  suite: string;
+  environment: string;
+  history: ChainsawTestRun[];
+  latest: ChainsawTestRun | null;
+  grafanaUrl: string;
+  docsUrl: string;
+}
+
+function grafanaHost(environment: string): string {
+  return environment === 'staging'
+    ? 'grafana.staging.env.datum.net'
+    : 'grafana.prod.env.datum.net';
+}
+
+function grafanaUrlFor(suite: string, test: string, environment: string): string {
+  const host = grafanaHost(environment);
+  return `https://${host}/d/chainsaw-e2e/chainsaw-e2e-tests?var-suite=${encodeURIComponent(suite)}&var-test=${encodeURIComponent(test)}`;
+}
+
+// Every construct test's README.md lives at this path by convention
+// (see datum-cloud/infra's tests/README.md anatomy section) — the
+// "Validates" / "Stability" / "Skips" writeup for that specific test.
+function docsUrlFor(suite: string, test: string): string {
+  return `https://github.com/datum-cloud/infra/blob/main/tests/construct/${encodeURIComponent(suite)}/${encodeURIComponent(test)}/README.md`;
+}
+
+// victoria-metrics-mcp-server__query_range returns the raw VM JSON response
+// wrapped in an MCP content block; unwrap it the same way runVmQuery does in
+// server/routes/cluster.ts, but for a matrix (range) result: entries carry
+// `values` (a [timestamp, value] tuple array), not a single `value`.
+async function runVmRangeQuery(client: Client, query: string): Promise<any[]> {
+  const result = await client.callTool({
+    name: 'victoria-metrics-mcp-server__query_range',
+    arguments: {
+      query,
+      start: new Date(Date.now() - THREE_DAYS_MS).toISOString(),
+      end: new Date().toISOString(),
+      step: STEP,
+    },
+  });
+
+  if ((result as any)?.isError) {
+    throw new Error((result as any)?.content?.[0]?.text ?? 'VictoriaMetrics range query failed');
+  }
+
+  const textContent = (result as any)?.content?.find((c: any) => c.type === 'text');
+  try {
+    const parsed = JSON.parse(textContent?.text ?? '{}');
+    return parsed?.data?.result ?? [];
+  } catch {
+    return [];
+  }
+}
+
+chainsawTestsRoutes.post('/', authMiddleware(), async (c) => {
+  const startTime = performance.now();
+  const reqLogger = createRequestLogger(c);
+  const reqId = c.get('requestId');
+
+  reqLogger.info('Chainsaw Tests API Request Started', {
+    path: c.req.path,
+    method: c.req.method,
+  });
+
+  try {
+    const { getMcpClient } = await import('@/modules/assistant/tools/mcp-client');
+
+    const client = await getMcpClient();
+    if (!client) {
+      throw new Error('MCP is not configured or unreachable');
+    }
+
+    // Only tests someone has explicitly vouched for as "expected to pass
+    // every run" — an unlabeled test is excluded, not defaulted in. See
+    // metadata.labels.stability on each tests/construct/**/chainsaw-test.yaml.
+    const results = await runVmRangeQuery(client, 'chainsaw_test_result{stability="stable"}');
+
+    const tests: ChainsawTestRow[] = results
+      .map((series: any) => {
+        const labels = series.metric ?? {};
+        const test = labels.test ?? 'unknown';
+        const suite = labels.suite ?? 'unknown';
+        const environment = labels.environment ?? 'unknown';
+        const history: ChainsawTestRun[] = (series.values ?? [])
+          .map(([ts, value]: [number, string]) => ({
+            timestamp: ts * 1000,
+            passed: parseFloat(value) === 1,
+          }))
+          .sort((a: ChainsawTestRun, b: ChainsawTestRun) => a.timestamp - b.timestamp);
+
+        return {
+          key: `${suite}/${test}/${environment}`,
+          test,
+          suite,
+          environment,
+          history,
+          latest: history.length > 0 ? history[history.length - 1] : null,
+          grafanaUrl: grafanaUrlFor(suite, test, environment),
+          docsUrl: docsUrlFor(suite, test),
+        };
+      })
+      .sort((a, b) => a.test.localeCompare(b.test));
+
+    const data = { tests, githubActionsUrl: GITHUB_ACTIONS_URL };
+
+    const duration = Math.round(performance.now() - startTime);
+
+    logApiSuccess(reqLogger, {
+      path: c.req.path,
+      method: c.req.method,
+      duration,
+    });
+
+    return c.json(createSuccessResponse(reqId, data, c.req.path), 200, {
+      'Cache-Control': 'no-cache, no-store, must-revalidate',
+      Pragma: 'no-cache',
+      Expires: '0',
+    });
+  } catch (error) {
+    const duration = Math.round(performance.now() - startTime);
+
+    await logApiError(reqLogger, error, {
+      path: c.req.path,
+      method: c.req.method,
+      duration,
+    });
+
+    if (error instanceof Error) {
+      captureApiError(error, {
+        url: c.req.path,
+        method: c.req.method,
+        requestId: reqId,
+      });
+    }
+
+    const { response, status } = await createErrorResponse(reqId, error, '/chainsaw-tests');
+    return c.json(response, status as any);
+  }
+});

--- a/app/utils/config/icons.config.ts
+++ b/app/utils/config/icons.config.ts
@@ -20,6 +20,7 @@ import {
   FileLock,
   FileText,
   Flag,
+  FlaskConical,
   Folders,
   Gauge,
   Info,
@@ -85,6 +86,7 @@ export const ENTITY_ICONS = {
   billingAccount: ReceiptText,
   // Operations
   activity: SquareActivity,
+  chainsawTest: FlaskConical,
   emailActivity: Mail,
   // Admin
   group: ShieldUser,

--- a/app/utils/config/routes.config.ts
+++ b/app/utils/config/routes.config.ts
@@ -156,6 +156,11 @@ export const activityRoutes = {
   },
 } as const;
 
+// Operations → Chainsaw Tests
+export const chainsawTestRoutes = {
+  list: () => '/operations/chainsaw-tests',
+} as const;
+
 // Operations → Email Activity
 export const emailActivityRoutes = {
   list: () => '/operations/email-activity',
@@ -216,6 +221,7 @@ export const routes = {
 
   // Operations
   activity: activityRoutes,
+  chainsawTests: chainsawTestRoutes,
   emailActivity: emailActivityRoutes.list,
   emailActivityDetail: emailActivityRoutes.detail,
 

--- a/cypress/component/chainsaw-tests-widget.cy.tsx
+++ b/cypress/component/chainsaw-tests-widget.cy.tsx
@@ -1,0 +1,56 @@
+import { ChainsawTestsWidget } from '@/features/chainsaw-tests/components/chainsaw-tests-widget';
+import { chainsawTestsFixture } from '@/tests/fixtures/chainsaw-tests';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// Renders the REAL ChainsawTestsWidget. Seed the React Query cache with
+// staleTime: Infinity so the widget reads our fixture and never calls the
+// real queryFn / network. The widget reads the cache under the
+// ['dashboard', 'chainsaw-tests'] key (see use-chainsaw-tests.ts).
+const mountWithData = (data: unknown) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity, staleTime: Infinity },
+    },
+  });
+  queryClient.setQueryData(['dashboard', 'chainsaw-tests'], data);
+
+  cy.mount(
+    <QueryClientProvider client={queryClient}>
+      <ChainsawTestsWidget />
+    </QueryClientProvider>
+  );
+};
+
+describe('ChainsawTestsWidget', () => {
+  it('renders the widget chrome (title, description, CI runs link)', () => {
+    mountWithData(chainsawTestsFixture.empty);
+    cy.contains('Chainsaw Tests').should('be.visible');
+    cy.contains('Last 3 days').should('be.visible');
+    cy.contains('a', 'CI runs').should('have.attr', 'href').and('include', 'run-e2e-tests.yaml');
+  });
+
+  it('renders the empty state when no tests are labeled stable', () => {
+    mountWithData(chainsawTestsFixture.empty);
+    cy.contains('No stable tests labeled yet').should('be.visible');
+  });
+
+  it('renders a passing test with Grafana and test-docs links', () => {
+    mountWithData(chainsawTestsFixture.allPassing);
+    cy.contains('dns-setup').should('be.visible');
+    cy.contains('Passing').should('be.visible');
+    cy.contains('a', 'Grafana')
+      .should('have.attr', 'href')
+      .and('include', 'var-test=dns-setup');
+    cy.contains('a', 'Test docs')
+      .should('have.attr', 'href')
+      .and('include', 'tests/construct/networking/dns-setup/README.md');
+  });
+
+  it('renders a mix of passing and failing tests', () => {
+    mountWithData(chainsawTestsFixture.mixed);
+    cy.contains('dns-setup').should('be.visible');
+    cy.contains('api-health').should('be.visible');
+    cy.contains('Passing').should('be.visible');
+    cy.contains('Failing').should('be.visible');
+  });
+});

--- a/cypress/component/chainsaw-tests-widget.cy.tsx
+++ b/cypress/component/chainsaw-tests-widget.cy.tsx
@@ -38,9 +38,7 @@ describe('ChainsawTestsWidget', () => {
     mountWithData(chainsawTestsFixture.allPassing);
     cy.contains('dns-setup').should('be.visible');
     cy.contains('Passing').should('be.visible');
-    cy.contains('a', 'Grafana')
-      .should('have.attr', 'href')
-      .and('include', 'var-test=dns-setup');
+    cy.contains('a', 'Grafana').should('have.attr', 'href').and('include', 'var-test=dns-setup');
     cy.contains('a', 'Test docs')
       .should('have.attr', 'href')
       .and('include', 'tests/construct/networking/dns-setup/README.md');

--- a/tests/fixtures/chainsaw-tests.ts
+++ b/tests/fixtures/chainsaw-tests.ts
@@ -1,0 +1,70 @@
+// Fixture for the parsed chainsaw tests widget data (post useChainsawTests
+// parseResponse — the shape the widget itself reads, not the raw API envelope).
+const GITHUB_ACTIONS_URL =
+  'https://github.com/datum-cloud/infra/actions/workflows/run-e2e-tests.yaml';
+
+const now = 1761955200000; // fixed reference point so fixtures stay deterministic
+
+function historyOf(pattern: boolean[]) {
+  const stepMs = 2 * 60 * 60 * 1000;
+  return pattern.map((passed, i) => ({
+    timestamp: now - (pattern.length - 1 - i) * stepMs,
+    passed,
+  }));
+}
+
+function docsUrlFor(suite: string, test: string) {
+  return `https://github.com/datum-cloud/infra/blob/main/tests/construct/${suite}/${test}/README.md`;
+}
+
+export const chainsawTestsFixture = {
+  empty: {
+    tests: [],
+    githubActionsUrl: GITHUB_ACTIONS_URL,
+  },
+
+  allPassing: {
+    tests: [
+      {
+        key: 'networking/dns-setup/prod',
+        test: 'dns-setup',
+        suite: 'networking',
+        environment: 'prod',
+        history: historyOf([true, true, true, true, true, true]),
+        latest: { timestamp: now, passed: true },
+        grafanaUrl:
+          'https://grafana.prod.env.datum.net/d/chainsaw-e2e/chainsaw-e2e-tests?var-suite=networking&var-test=dns-setup',
+        docsUrl: docsUrlFor('networking', 'dns-setup'),
+      },
+    ],
+    githubActionsUrl: GITHUB_ACTIONS_URL,
+  },
+
+  mixed: {
+    tests: [
+      {
+        key: 'networking/dns-setup/prod',
+        test: 'dns-setup',
+        suite: 'networking',
+        environment: 'prod',
+        history: historyOf([true, true, true, true, true, true]),
+        latest: { timestamp: now, passed: true },
+        grafanaUrl:
+          'https://grafana.prod.env.datum.net/d/chainsaw-e2e/chainsaw-e2e-tests?var-suite=networking&var-test=dns-setup',
+        docsUrl: docsUrlFor('networking', 'dns-setup'),
+      },
+      {
+        key: 'health/api-health/prod',
+        test: 'api-health',
+        suite: 'health',
+        environment: 'prod',
+        history: historyOf([true, true, false, true, true, false]),
+        latest: { timestamp: now, passed: false },
+        grafanaUrl:
+          'https://grafana.prod.env.datum.net/d/chainsaw-e2e/chainsaw-e2e-tests?var-suite=health&var-test=api-health',
+        docsUrl: docsUrlFor('health', 'api-health'),
+      },
+    ],
+    githubActionsUrl: GITHUB_ACTIONS_URL,
+  },
+};


### PR DESCRIPTION
## Summary

Staff had no single place to see which Chainsaw e2e tests (`datum-cloud/infra`) are expected to pass every run, or to jump straight from a failure to the Grafana dashboard, that test's own docs, or the CI workflow to start troubleshooting.

This adds a new Operations page, `/operations/chainsaw-tests`, showing the last 3 days of pass/fail history for tests tagged `stability: stable`. Each row links to that test's row on the shared Grafana dashboard, its `README.md` in `datum-cloud/infra` (for the "Validates" / "Services spanned" / troubleshooting writeup), and a "CI runs" link to the GitHub Actions workflow.

Data comes from the existing Victoria Metrics MCP integration (`victoria-metrics-mcp-server__query_range`, already wired up for the chatbot's cluster tools) rather than the `PROMETHEUS_URL`-based `PrometheusService` path — that env var points at a different, unrelated VM instance with no visibility into CI-pushed Chainsaw metrics.

> [!IMPORTANT]
> This depends on `datum-cloud/infra#3735`, which adds the `stability` label to `chainsaw_test_result`. Until that merges and at least one test run has landed, this page returns zero rows — that's expected, not a bug. Marked as draft for that reason, and because this machine had no `bun` available to run `typecheck`/`lint`/Cypress locally, so CI is the first real verification pass.

## Test plan

- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] `bun run test:unit:prod` (Cypress component: `chainsaw-tests-widget.cy.tsx`) passes
- [ ] Once infra#3735 merges and a run lands, the page shows real data in staging
- [ ] Empty/loading/error states render sensibly (covered by the component test's fixture variants)