### PR TITLE
fix: Fall back to Anthropic when AI gateway unset

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -29,7 +29,9 @@ SENTRY_PROJECT=your-project-name
 SENTRY_AUTH_TOKEN=your-auth-token  # For source map uploads
 SENTRY_ENV=development
 
-# AI Assistant (Patch) — Datum internal AI gateway
+# AI Assistant (Patch)
+# Prefer the Datum AI gateway when available. Without gateway config the
+# server falls back to a direct Anthropic API key (current prod path).
 CHATBOT_ENABLED=false
 AI_GATEWAY_URL=https://ai.staging.env.datum.net
 # Local: Dex JWT with audience ai-gateway. In-cluster: use AI_GATEWAY_TOKEN_FILE instead.
@@ -37,6 +39,9 @@ AI_GATEWAY_TOKEN=
 AI_GATEWAY_TOKEN_FILE=
 # Prefer openai-claude-* aliases — those get Anthropic→Qwen failover on the gateway.
 AI_GATEWAY_MODEL=openai-claude-haiku-4-5-20251001
+# Direct Anthropic fallback (used when AI_GATEWAY_* is unset)
+ANTHROPIC_API_KEY=
+ANTHROPIC_MODEL=claude-sonnet-4-6
 
 # Sentry API (for chatbot Sentry tools)
 SENTRY_API_URL=https://sentry.prod.env.datum.net

--- a/app/features/assistant/constants.ts
+++ b/app/features/assistant/constants.ts
@@ -5,7 +5,8 @@
  * picker in the prompt card. Flip to `false` to hide the control entirely — the
  * client then sends no override and the server falls back to its default model.
  *
- * Model options themselves come from GET /api/assistant/models (gateway catalog).
+ * Model options themselves come from GET /api/assistant/models (gateway
+ * catalog, or the direct-Anthropic allowlist when the gateway is unset).
  */
 import type { EffortId, EffortOption } from './types';
 

--- a/app/features/assistant/hooks/use-chat-logic.ts
+++ b/app/features/assistant/hooks/use-chat-logic.ts
@@ -52,19 +52,18 @@ export function useChatLogic(models: ModelOption[] = []) {
   const [chatList, setChatList] = useState<StoredChat[]>([]);
 
   // Selected model + effort (the prompt card's "Sonnet 4.6 · High" control).
-  // Mirrored into refs so the memoized transport reads the latest value. The
-  // initial model honors AI_GATEWAY_MODEL when it appears in the gateway catalog.
+  // Mirrored into refs so the memoized transport reads the latest value. Prefer
+  // AI_GATEWAY_MODEL; fall back to ANTHROPIC_MODEL for direct-Anthropic deploys.
   const env = useEnv();
-  const [modelId, setModelId] = useState<string>(() =>
-    pickDefaultModelId(models, env?.AI_GATEWAY_MODEL)
-  );
+  const preferredModel = env?.AI_GATEWAY_MODEL || env?.ANTHROPIC_MODEL;
+  const [modelId, setModelId] = useState<string>(() => pickDefaultModelId(models, preferredModel));
   const [effortId, setEffortId] = useState<EffortId>(DEFAULT_EFFORT_ID);
   const modelIdRef = useRef(modelId);
   modelIdRef.current = modelId;
   const effortIdRef = useRef(effortId);
   effortIdRef.current = effortId;
 
-  // When the gateway catalog loads (or changes), keep the selection valid —
+  // When the catalog loads (or changes), keep the selection valid —
   // including remapping legacy Anthropic ids onto openai-claude-* failover aliases.
   useEffect(() => {
     if (models.length === 0) return;
@@ -74,9 +73,9 @@ export function useChatLogic(models: ModelOption[] = []) {
         const failover = `openai-${prev}`;
         if (models.some((m) => m.id === failover)) return failover;
       }
-      return pickDefaultModelId(models, env?.AI_GATEWAY_MODEL);
+      return pickDefaultModelId(models, preferredModel);
     });
-  }, [models, env?.AI_GATEWAY_MODEL]);
+  }, [models, preferredModel]);
 
   useEffect(() => {
     setChatList(listChats());

--- a/app/hooks/use-env.ts
+++ b/app/hooks/use-env.ts
@@ -13,8 +13,10 @@ export interface PublicEnv {
   AUTH_OIDC_ISSUER?: string;
   CLOUD_PORTAL_URL?: string;
   CHATBOT_ENABLED?: boolean;
-  /** Configured default model id; seeds the picker's default when present in the gateway catalog. */
+  /** Gateway default model id when present in the catalog. */
   AI_GATEWAY_MODEL?: string;
+  /** Direct Anthropic default (prod fallback until gateway ships there). */
+  ANTHROPIC_MODEL?: string;
   MCP_ENABLED?: boolean;
   MAXMIND_ACCOUNT_ID?: string;
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -56,6 +56,7 @@ export async function loader({ request }: Route.LoaderArgs) {
         CLOUD_PORTAL_URL: env.CLOUD_PORTAL_URL,
         CHATBOT_ENABLED: env.chatbotEnabled,
         AI_GATEWAY_MODEL: env.aiGatewayModel,
+        ANTHROPIC_MODEL: env.anthropicModel,
         MCP_ENABLED: !!(env.mcpUrl && env.mcpApiKey),
         MAXMIND_ACCOUNT_ID: env.MAXMIND_ACCOUNT_ID,
       } satisfies PublicEnv,

--- a/app/server/lib/ai-gateway.ts
+++ b/app/server/lib/ai-gateway.ts
@@ -32,6 +32,11 @@ export function isAiGatewayConfigured(): boolean {
   return Boolean(env.aiGatewayUrl && getAiGatewayToken());
 }
 
+/** Gateway preferred; direct Anthropic API key is the prod fallback. */
+export function isAssistantConfigured(): boolean {
+  return isAiGatewayConfigured() || Boolean(env.anthropicApiKey?.trim());
+}
+
 function requireGatewayAuth(): { token: string; baseUrl: string } {
   const token = getAiGatewayToken();
   const baseUrl = env.aiGatewayUrl?.replace(/\/$/, '');

--- a/app/server/routes/assistant.ts
+++ b/app/server/routes/assistant.ts
@@ -4,11 +4,13 @@ import {
   createGatewayLanguageModel,
   fetchGatewayModels,
   isAiGatewayConfigured,
+  isAssistantConfigured,
   resolveGatewayModel,
 } from '@/server/lib/ai-gateway';
 import { authMiddleware, getToken, getUserId } from '@/server/middleware';
 import { env } from '@/utils/config/env.server';
 import { logger } from '@/utils/logger';
+import { createAnthropic } from '@ai-sdk/anthropic';
 import {
   APICallError,
   convertToModelMessages,
@@ -22,6 +24,17 @@ import { Hono } from 'hono';
 export const assistantRoutes = new Hono<{ Variables: EnvVariables }>();
 
 const MAX_MESSAGES = 50;
+
+/**
+ * Direct Anthropic allowlist (prod / local without gateway). Keep labels in
+ * sync with what GET /models returns on the Anthropic path.
+ */
+const DIRECT_ANTHROPIC_MODELS: Array<{ id: string; label: string }> = [
+  { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
+  { id: 'claude-haiku-4-5', label: 'Haiku 4.5' },
+];
+const ALLOWED_DIRECT_MODELS = new Set(DIRECT_ANTHROPIC_MODELS.map((m) => m.id));
+const DEFAULT_DIRECT_MODEL = DIRECT_ANTHROPIC_MODELS[0].id;
 
 /** Effort → Anthropic extended-thinking token budget (Claude 4.x `enabled` thinking). */
 const EFFORT_BUDGETS = { low: 4000, medium: 10000, high: 20000 } as const;
@@ -96,9 +109,21 @@ function checkRateLimit(userId: string): boolean {
   return true;
 }
 
+function resolveDirectAnthropicModel(requested?: string): string {
+  if (requested && ALLOWED_DIRECT_MODELS.has(requested)) return requested;
+  if (env.anthropicModel && ALLOWED_DIRECT_MODELS.has(env.anthropicModel)) {
+    return env.anthropicModel;
+  }
+  return DEFAULT_DIRECT_MODEL;
+}
+
 assistantRoutes.get('/models', authMiddleware(), async (c) => {
-  if (!env.chatbotEnabled || !isAiGatewayConfigured()) {
+  if (!env.chatbotEnabled || !isAssistantConfigured()) {
     return c.json({ error: 'AI assistant is not configured' }, 503);
+  }
+
+  if (!isAiGatewayConfigured()) {
+    return c.json({ models: [...DIRECT_ANTHROPIC_MODELS] });
   }
 
   try {
@@ -117,7 +142,7 @@ assistantRoutes.get('/models', authMiddleware(), async (c) => {
 });
 
 assistantRoutes.post('/', authMiddleware(), async (c) => {
-  if (!env.chatbotEnabled || !isAiGatewayConfigured()) {
+  if (!env.chatbotEnabled || !isAssistantConfigured()) {
     return c.json({ error: 'AI assistant is not configured' }, 503);
   }
 
@@ -149,74 +174,26 @@ assistantRoutes.post('/', authMiddleware(), async (c) => {
   }
 
   try {
-    const selected = await resolveGatewayModel(requestedModel);
-    const languageModel = createGatewayLanguageModel(selected.id, selected.protocol);
-
-    const thinkingBudget = resolveEffortBudget(requestedEffort);
-    const reasoningEffort = resolveReasoningEffort(requestedEffort);
-    const adaptive = selected.protocol === 'anthropic' && usesAdaptiveThinking(selected.id);
-
-    const result = streamText({
-      model: languageModel,
-      system: buildSystemPrompt(clientOs),
-      messages: await convertToModelMessages(messages.slice(-MAX_MESSAGES)),
-      // Anthropic requires max_tokens > thinking budget when extended thinking is on.
-      maxOutputTokens:
-        selected.protocol === 'anthropic' && !adaptive ? thinkingBudget + 4096 : 8192,
-      experimental_transform: smoothStream({ chunking: 'word', delayInMs: 40 }),
-      providerOptions:
-        selected.protocol === 'anthropic'
-          ? {
-              anthropic: {
-                thinking: adaptive
-                  ? { type: 'adaptive' as const, display: 'summarized' as const }
-                  : { type: 'enabled' as const, budgetTokens: thinkingBudget },
-                ...(adaptive ? { effort: reasoningEffort as 'low' | 'medium' | 'high' } : {}),
-                metadata: { userId },
-              },
-            }
-          : {
-              // Provider name is `datum-ai-gateway` → camelCase key `datumAiGateway`.
-              datumAiGateway: {
-                reasoningEffort,
-                user: userId,
-              },
-            },
-      stopWhen: stepCountIs(10),
-      tools: createAssistantTools({ accessToken: token }),
-    });
-
-    result.response.then(undefined, (err: unknown) => {
-      logger.error('assistant stream failed', {
+    if (isAiGatewayConfigured()) {
+      return await streamViaGateway({
+        messages,
+        clientOs,
+        requestedModel,
+        requestedEffort,
+        token,
         userId,
-        model: selected.id,
-        protocol: selected.protocol,
         userMessage,
-        error: formatAssistantError(err),
-        stack: err instanceof Error ? err.stack : undefined,
       });
-    });
+    }
 
-    result.usage.then(
-      (usage) => {
-        logger.info('assistant request completed', {
-          userId,
-          model: selected.id,
-          protocol: selected.protocol,
-          userMessage,
-          inputTokens: usage.inputTokens,
-          outputTokens: usage.outputTokens,
-          totalTokens: usage.totalTokens,
-        });
-      },
-      () => {}
-    );
-
-    return result.toUIMessageStreamResponse({
-      sendReasoning: true,
-      // SDK defaults to "An error occurred." to avoid leaking details; staff
-      // operators need the real provider message when debugging the gateway.
-      onError: formatAssistantError,
+    return await streamViaAnthropic({
+      messages,
+      clientOs,
+      requestedModel,
+      requestedEffort,
+      token,
+      userId,
+      userMessage,
     });
   } catch (err) {
     const message = formatAssistantError(err);
@@ -229,3 +206,154 @@ assistantRoutes.post('/', authMiddleware(), async (c) => {
     return c.json({ error: message }, 500);
   }
 });
+
+async function streamViaGateway(args: {
+  messages: UIMessage[];
+  clientOs?: string;
+  requestedModel?: string;
+  requestedEffort?: string;
+  token: string;
+  userId: string;
+  userMessage?: string;
+}) {
+  const { messages, clientOs, requestedModel, requestedEffort, token, userId, userMessage } = args;
+
+  const selected = await resolveGatewayModel(requestedModel);
+  const languageModel = createGatewayLanguageModel(selected.id, selected.protocol);
+
+  const thinkingBudget = resolveEffortBudget(requestedEffort);
+  const reasoningEffort = resolveReasoningEffort(requestedEffort);
+  const adaptive = selected.protocol === 'anthropic' && usesAdaptiveThinking(selected.id);
+
+  const result = streamText({
+    model: languageModel,
+    system: buildSystemPrompt(clientOs),
+    messages: await convertToModelMessages(messages.slice(-MAX_MESSAGES)),
+    // Anthropic requires max_tokens > thinking budget when extended thinking is on.
+    maxOutputTokens: selected.protocol === 'anthropic' && !adaptive ? thinkingBudget + 4096 : 8192,
+    experimental_transform: smoothStream({ chunking: 'word', delayInMs: 40 }),
+    providerOptions:
+      selected.protocol === 'anthropic'
+        ? {
+            anthropic: {
+              thinking: adaptive
+                ? { type: 'adaptive' as const, display: 'summarized' as const }
+                : { type: 'enabled' as const, budgetTokens: thinkingBudget },
+              ...(adaptive ? { effort: reasoningEffort as 'low' | 'medium' | 'high' } : {}),
+              metadata: { userId },
+            },
+          }
+        : {
+            // Provider name is `datum-ai-gateway` → camelCase key `datumAiGateway`.
+            datumAiGateway: {
+              reasoningEffort,
+              user: userId,
+            },
+          },
+    stopWhen: stepCountIs(10),
+    tools: createAssistantTools({ accessToken: token }),
+  });
+
+  result.response.then(undefined, (err: unknown) => {
+    logger.error('assistant stream failed', {
+      userId,
+      model: selected.id,
+      protocol: selected.protocol,
+      userMessage,
+      error: formatAssistantError(err),
+      stack: err instanceof Error ? err.stack : undefined,
+    });
+  });
+
+  result.usage.then(
+    (usage) => {
+      logger.info('assistant request completed', {
+        userId,
+        model: selected.id,
+        protocol: selected.protocol,
+        userMessage,
+        inputTokens: usage.inputTokens,
+        outputTokens: usage.outputTokens,
+        totalTokens: usage.totalTokens,
+      });
+    },
+    () => {}
+  );
+
+  return result.toUIMessageStreamResponse({
+    sendReasoning: true,
+    onError: formatAssistantError,
+  });
+}
+
+async function streamViaAnthropic(args: {
+  messages: UIMessage[];
+  clientOs?: string;
+  requestedModel?: string;
+  requestedEffort?: string;
+  token: string;
+  userId: string;
+  userMessage?: string;
+}) {
+  const { messages, clientOs, requestedModel, requestedEffort, token, userId, userMessage } = args;
+
+  if (!env.anthropicApiKey) {
+    throw new Error('Anthropic API key is not configured');
+  }
+
+  const anthropic = createAnthropic({ apiKey: env.anthropicApiKey });
+  const modelId = resolveDirectAnthropicModel(requestedModel);
+  const thinkingBudget = resolveEffortBudget(requestedEffort);
+  const reasoningEffort = resolveReasoningEffort(requestedEffort);
+  const adaptive = usesAdaptiveThinking(modelId);
+
+  const result = streamText({
+    model: anthropic(modelId),
+    system: buildSystemPrompt(clientOs),
+    messages: await convertToModelMessages(messages.slice(-MAX_MESSAGES)),
+    maxOutputTokens: adaptive ? 8192 : thinkingBudget + 4096,
+    experimental_transform: smoothStream({ chunking: 'word', delayInMs: 40 }),
+    providerOptions: {
+      anthropic: {
+        thinking: adaptive
+          ? { type: 'adaptive' as const, display: 'summarized' as const }
+          : { type: 'enabled' as const, budgetTokens: thinkingBudget },
+        ...(adaptive ? { effort: reasoningEffort as 'low' | 'medium' | 'high' } : {}),
+        metadata: { userId },
+      },
+    },
+    stopWhen: stepCountIs(10),
+    tools: createAssistantTools({ accessToken: token }),
+  });
+
+  result.response.then(undefined, (err: unknown) => {
+    logger.error('assistant stream failed', {
+      userId,
+      model: modelId,
+      protocol: 'anthropic-direct',
+      userMessage,
+      error: formatAssistantError(err),
+      stack: err instanceof Error ? err.stack : undefined,
+    });
+  });
+
+  result.usage.then(
+    (usage) => {
+      logger.info('assistant request completed', {
+        userId,
+        model: modelId,
+        protocol: 'anthropic-direct',
+        userMessage,
+        inputTokens: usage.inputTokens,
+        outputTokens: usage.outputTokens,
+        totalTokens: usage.totalTokens,
+      });
+    },
+    () => {}
+  );
+
+  return result.toUIMessageStreamResponse({
+    sendReasoning: true,
+    onError: formatAssistantError,
+  });
+}

--- a/app/utils/config/env.server.ts
+++ b/app/utils/config/env.server.ts
@@ -21,12 +21,15 @@ const envSchema = z.object({
   SENTRY_ENV: z.string().optional(),
   SENTRY_DSN: z.string().optional(),
 
-  // Chatbot / AI assistant (Datum internal AI gateway)
+  // Chatbot / AI assistant — prefer AI gateway; fall back to direct Anthropic
+  // (prod still uses ANTHROPIC_* until the gateway is released there).
   CHATBOT_ENABLED: z.string().optional(),
   AI_GATEWAY_URL: z.url().optional(),
   AI_GATEWAY_TOKEN: z.string().optional(),
   AI_GATEWAY_TOKEN_FILE: z.string().optional(),
   AI_GATEWAY_MODEL: z.string().optional(),
+  ANTHROPIC_API_KEY: z.string().optional(),
+  ANTHROPIC_MODEL: z.string().optional(),
 
   // Sentry API (for chatbot tools)
   SENTRY_API_URL: z.string().optional(),
@@ -90,6 +93,8 @@ export const env = {
   aiGatewayToken: parsedEnv.AI_GATEWAY_TOKEN,
   aiGatewayTokenFile: parsedEnv.AI_GATEWAY_TOKEN_FILE,
   aiGatewayModel: parsedEnv.AI_GATEWAY_MODEL,
+  anthropicApiKey: parsedEnv.ANTHROPIC_API_KEY,
+  anthropicModel: parsedEnv.ANTHROPIC_MODEL,
   sentryApiUrl: parsedEnv.SENTRY_API_URL,
   sentryApiToken: parsedEnv.SENTRY_API_TOKEN,
   sentryOrganization: parsedEnv.SENTRY_ORGANIZATION ?? 'sentry',


### PR DESCRIPTION
## Summary

Prod staff-portal is on the AI-gateway assistant build (`v0.22.12+`) but production infra still only injects `ANTHROPIC_API_KEY` / `ANTHROPIC_MODEL` — the gateway is staging-only. `isAiGatewayConfigured()` was false, so `/api/assistant` returned 503 and Patch stopped working.

This restores a direct Anthropic path when `AI_GATEWAY_*` is unset, while keeping the gateway path for staging. Prefer gateway when both are present.

## Test plan

- [ ] With only `ANTHROPIC_*` set: `GET /api/assistant/models` returns Sonnet/Haiku; chat streams via Anthropic
- [ ] With `AI_GATEWAY_*` set (staging): still uses gateway catalog + failover aliases
- [ ] Prod deploy: chatbot works again without infra AI gateway changes