### PR TITLE
fix(preferences): make theme mode picker clickable in Safari

### DIFF
--- a/app/features/preferences/components/theme-preview.tsx
+++ b/app/features/preferences/components/theme-preview.tsx
@@ -45,7 +45,17 @@ export const ThemePreview = ({
     disabled && 'opacity-50 cursor-not-allowed'
   );
   return (
-    <div className="relative" data-testid={`theme-${value}`}>
+    // A <label> (not an invisible overlay input) is the click target: label→input
+    // activation is native and fires reliably in Safari, which does not deliver
+    // clicks to a zero-opacity radio the way Chrome/FF/Edge do. cursor-pointer is
+    // also required for iOS Safari to dispatch the click at all.
+    <label
+      className={cn(
+        'relative block rounded',
+        'has-[:focus-visible]:ring-primary has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-offset-2',
+        disabled ? 'cursor-not-allowed' : 'cursor-pointer'
+      )}
+      data-testid={`theme-${value}`}>
       <div className={containerClass} data-selected={selected}>
         {value === 'system' ? (
           <>
@@ -77,8 +87,8 @@ export const ThemePreview = ({
         checked={selected}
         disabled={disabled}
         onChange={() => !disabled && onSelect(value)}
-        className="absolute inset-0 cursor-pointer opacity-0 disabled:cursor-not-allowed"
+        className="sr-only"
       />
-    </div>
+    </label>
   );
 };


### PR DESCRIPTION
## Problem
The **Theme Mode** picker under Profile → Settings was not clickable in **Safari** (works fine in Chrome, Firefox, Edge).

## Cause
Each theme option box relied on an invisible `<input type="radio">` overlaid with `absolute inset-0 opacity-0` to capture the click. Safari does not reliably deliver clicks to a zero-opacity, `appearance`-less radio, and iOS Safari additionally requires a `cursor: pointer` ancestor to dispatch the click at all — so the picker was inert there.

## Fix
`app/features/preferences/components/theme-preview.tsx`:
- Wrap the preview in a `<label>` so selection goes through native **label → input** activation, which fires reliably across all browsers including Safari.
- Make the radio `sr-only` instead of a transparent overlay (keeps proper form/radio semantics and keyboard access).
- Add a keyboard `focus-visible` ring (the old overlay had none).

No visual or behavioral change in Chrome/FF/Edge; same radio semantics.

## Testing
- `bun run typecheck` → clean
- `bunx eslint` on the file → clean
- Manual: click each option (Dark / Light / System) in Safari — now selects; Chrome/FF/Edge unchanged.
