### PR TITLE
feat(display): width-based truncation option for DisplayId

### DIFF
--- a/app/components/display/display-id.tsx
+++ b/app/components/display/display-id.tsx
@@ -7,11 +7,35 @@ function truncateMiddle(str: string, maxLength = 16) {
   return `${str.slice(0, half)}...${str.slice(-half)}`;
 }
 
-function IDDisplay({ value, className }: { value: string; className?: string }) {
+interface IDDisplayProps {
+  value: string;
+  className?: string;
+  /**
+   * How a long id is shortened:
+   * - `'middle'` (default): collapse to a fixed `head…tail` string regardless of
+   *   width (e.g. `emailn...3a3ar9`).
+   * - `'fit'`: render the full id and let CSS ellipsize it only when it actually
+   *   overflows the column — so it uses whatever width is available instead of
+   *   clipping to a fixed length. Pair with a column `maxSize` to bound how wide
+   *   it can get.
+   */
+  truncate?: 'fit' | 'middle';
+  /** Character budget when `truncate="middle"`. */
+  maxLength?: number;
+}
+
+function IDDisplay({ value, className, truncate = 'middle', maxLength = 16 }: IDDisplayProps) {
+  const isMiddle = truncate === 'middle';
   return (
-    <div className={cn('flex items-center space-x-2', className)}>
-      <span className="font-mono text-xs">{truncateMiddle(value)}</span>
-      <ButtonCopy value={value} />
+    <div className={cn('flex min-w-0 items-center space-x-2', className)}>
+      <span
+        className={cn('font-mono text-xs', isMiddle ? 'whitespace-nowrap' : 'min-w-0 truncate')}
+        title={value}>
+        {isMiddle ? truncateMiddle(value, maxLength) : value}
+      </span>
+      <span className="shrink-0">
+        <ButtonCopy value={value} />
+      </span>
     </div>
   );
 }

--- a/app/features/milo/components/page/list-pagination.tsx
+++ b/app/features/milo/components/page/list-pagination.tsx
@@ -52,7 +52,7 @@ export function ListPagination({ className, pageSizes = LIST_PAGE_SIZES, resourc
           <SelectTrigger
             className={cn(
               'border-border text-muted-foreground h-7 w-[4.5rem] gap-1.5 rounded-md px-2.5 py-0',
-              'text-xs font-normal shadow-none'
+              'min-h-0 text-xs font-normal shadow-none'
             )}>
             <SelectValue placeholder={String(pageSize)} />
           </SelectTrigger>

--- a/app/routes/admin/group/index.tsx
+++ b/app/routes/admin/group/index.tsx
@@ -21,7 +21,7 @@ export default function Page() {
     columnHelper.accessor((row) => row.metadata?.name ?? '', {
       id: 'id',
       header: ({ column }) => <ListColumnHeader column={column} title={t`ID`} />,
-      cell: ({ getValue }) => <DisplayId value={getValue()} />,
+      cell: ({ getValue }) => <DisplayId value={getValue()} truncate="fit" />,
     }),
     columnHelper.accessor(
       (row) =>


### PR DESCRIPTION
## Problem
`DisplayId` hard-truncated every id to a fixed 16-char `head…tail` string in JS, so ids were clipped **even when the column had plenty of space** (e.g. the admin Groups list ID column).

## Change
Add a `truncate` prop to `DisplayId`:
- **`'middle'` (default)** — the existing fixed `head…tail` collapse (`maxLength` still configurable). No behavior change anywhere by default.
- **`'fit'`** — renders the full id and lets CSS ellipsize it **only when it overflows the column**, so it uses the available width. Full value on hover (`title`); copy button is `shrink-0` so it isn't squeezed. Pair with a column `maxSize` to bound width and get fill-then-ellipsize.

Opts the **admin Groups** list ID column into `truncate="fit"` as the first consumer.

## Notes
- Default is unchanged, so all other list pages (users, fraud, …) keep the 16-char cut.
- With the table's auto layout and no column cap, `'fit'` shows the full id and the column grows to use the space; add `maxSize` on the column to cap + ellipsize.

## Testing
- `bun run typecheck` + `bunx eslint` clean.
- Verified locally on the admin Groups list — ID now uses the full column width instead of clipping at 16 chars.
