### PR TITLE
feat: add ProviderPortalPlugin CRD

### DIFF
--- a/app/modules/plugins/server/index.ts
+++ b/app/modules/plugins/server/index.ts
@@ -1,17 +1,18 @@
 /**
  * Server-side plugin registry singleton + wiring.
  *
- * Ported from cloud-portal, trimmed: only the `static` (dev, `PORTAL_PLUGINS`)
- * source is wired up. cloud-portal's `kubeconfig` source and its production
- * `platform` (CRD-watched) source are intentionally out of scope — staff-portal
- * has no `PortalPlugin` CRD / `ServiceConfiguration.spec.userInterface`
- * equivalent today. Loaders and routes read the registry through
- * {@link getPlugins} / {@link getPlugin}.
+ * Ported from cloud-portal. Two sources: `static` (dev, `PORTAL_PLUGINS`) and
+ * `platform` (production, watches `ProviderPortalPlugin` on milo's control
+ * plane). Loaders and routes read the registry through {@link getPlugins} /
+ * {@link getPlugin}.
  */
 import type { PluginRegistryEntry } from '../types';
+import { KubeClient, parseKubeconfig, resolveKubeContext } from './kubeconfig';
+import { PlatformSource } from './platform-source';
 import { PluginRegistry } from './registry';
 import { StaticSource } from './static-source';
 import { env } from '@/utils/config/env.server';
+import { readFileSync } from 'node:fs';
 
 // Re-export the sanitizer on the server accessor surface (alongside
 // getPlugin/getPlugins) so a server loader can project a getPlugin(slug) result
@@ -34,9 +35,10 @@ export function getPlugin(slug: string): PluginRegistryEntry | undefined {
 let initialized = false;
 
 /**
- * Wires the registry's static source. Idempotent. Hard-disabled outside
+ * Wires the registry's sources. Idempotent. `static` is hard-disabled outside
  * development — it is a plugin-loading vector and must never populate the
- * registry in production.
+ * registry in production. `platform` is the opposite: not dev-gated at all,
+ * since it's the real production discovery path.
  */
 export function initPluginRegistry(): void {
   if (initialized) return;
@@ -49,8 +51,20 @@ export function initPluginRegistry(): void {
           'ignored outside NODE_ENV=development'
       );
     }
-    return;
+  } else {
+    void new StaticSource(pluginRegistry).start();
   }
 
-  void new StaticSource(pluginRegistry).start();
+  const platformKubeconfigPath = env.PLATFORM_REGISTRY_KUBECONFIG;
+  if (platformKubeconfigPath) {
+    try {
+      const config = parseKubeconfig(readFileSync(platformKubeconfigPath, 'utf8'));
+      const context = resolveKubeContext(config);
+      const client = new KubeClient(context);
+      new PlatformSource(pluginRegistry, client).start();
+      console.info(`[plugins] platform source watching ${context.server}`);
+    } catch (err) {
+      console.error(`[plugins] failed to start platform source: ${String(err)}`);
+    }
+  }
 }

--- a/app/modules/plugins/server/kubeconfig.test.ts
+++ b/app/modules/plugins/server/kubeconfig.test.ts
@@ -1,0 +1,273 @@
+/// <reference types="bun-types/test" />
+import {
+  ExecCredentialProvider,
+  KubeClient,
+  parseKubeconfig,
+  resolveKubeContext,
+  type ExecAuth,
+} from './kubeconfig';
+import { describe, expect, mock, test } from 'bun:test';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const INSECURE_LOOPBACK = `
+apiVersion: v1
+kind: Config
+current-context: kwok
+clusters:
+- name: kwok-cluster
+  cluster:
+    server: http://127.0.0.1:8080
+    insecure-skip-tls-verify: true
+contexts:
+- name: kwok
+  context:
+    cluster: kwok-cluster
+    user: kwok-user
+users:
+- name: kwok-user
+  user: {}
+`;
+
+const BEARER = `
+apiVersion: v1
+kind: Config
+current-context: datum
+clusters:
+- name: datum-cluster
+  cluster:
+    server: https://api.datum.example.com/
+contexts:
+- name: datum
+  context:
+    cluster: datum-cluster
+    user: datum-user
+users:
+- name: datum-user
+  user:
+    token: static-bearer-token
+`;
+
+// A kubeconfig as produced by `datumctl auth update-kubeconfig`.
+const EXEC_CREDENTIAL = `
+apiVersion: v1
+kind: Config
+current-context: datum
+clusters:
+- name: datum-cluster
+  cluster:
+    server: https://api.datum.example.com
+contexts:
+- name: datum
+  context:
+    cluster: datum-cluster
+    user: datum-user
+users:
+- name: datum-user
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1
+      command: datumctl
+      args:
+      - auth
+      - get-token
+      env:
+      - name: DATUM_ENV
+        value: staging
+`;
+
+describe('resolveKubeContext', () => {
+  test('resolves an insecure no-auth loopback cluster', () => {
+    const ctx = resolveKubeContext(parseKubeconfig(INSECURE_LOOPBACK));
+    expect(ctx.server).toBe('http://127.0.0.1:8080');
+    expect(ctx.tls.insecureSkipTlsVerify).toBe(true);
+    expect(ctx.auth).toEqual({ kind: 'none' });
+  });
+
+  test('resolves a static bearer token and trims the server trailing slash', () => {
+    const ctx = resolveKubeContext(parseKubeconfig(BEARER));
+    expect(ctx.server).toBe('https://api.datum.example.com');
+    expect(ctx.auth).toEqual({ kind: 'bearer', token: 'static-bearer-token' });
+  });
+
+  test('resolves an exec credential plugin with args and env', () => {
+    const ctx = resolveKubeContext(parseKubeconfig(EXEC_CREDENTIAL));
+    expect(ctx.auth.kind).toBe('exec');
+    const auth = ctx.auth as ExecAuth;
+    expect(auth.command).toBe('datumctl');
+    expect(auth.args).toEqual(['auth', 'get-token']);
+    expect(auth.env).toEqual({ DATUM_ENV: 'staging' });
+    expect(auth.apiVersion).toBe('client.authentication.k8s.io/v1');
+  });
+
+  test('throws on a missing context', () => {
+    expect(() => resolveKubeContext(parseKubeconfig(BEARER), 'does-not-exist')).toThrow();
+  });
+
+  test('parseKubeconfig throws on non-mapping YAML', () => {
+    expect(() => parseKubeconfig('- just\n- a\n- list')).toThrow();
+  });
+
+  // Regression: a cert-manager CSI-mounted client cert is referenced by file
+  // path (client-certificate/client-key/certificate-authority), not inline
+  // base64 (client-certificate-data/client-key-data). Silently dropping the
+  // file-path form means the client connects with no client cert at all —
+  // TLS still completes (if the server allows optional client certs), but
+  // every request authenticates as anonymous instead of the intended
+  // identity, surfacing as a confusing 403 rather than a connection error.
+  test('resolves client-certificate/client-key/certificate-authority given as file paths', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kubeconfig-test-'));
+    const caPath = join(dir, 'ca.crt');
+    const certPath = join(dir, 'tls.crt');
+    const keyPath = join(dir, 'tls.key');
+    writeFileSync(caPath, 'fake-ca-pem');
+    writeFileSync(certPath, 'fake-cert-pem');
+    writeFileSync(keyPath, 'fake-key-pem');
+
+    const kubeconfig = `
+apiVersion: v1
+kind: Config
+current-context: milo
+clusters:
+- name: milo-cluster
+  cluster:
+    server: https://milo-apiserver.datum-system.svc.cluster.local:6443
+    certificate-authority: ${caPath}
+contexts:
+- name: milo
+  context:
+    cluster: milo-cluster
+    user: plugin-reader
+users:
+- name: plugin-reader
+  user:
+    client-certificate: ${certPath}
+    client-key: ${keyPath}
+`;
+
+    const ctx = resolveKubeContext(parseKubeconfig(kubeconfig));
+    expect(ctx.tls.caPem).toBe('fake-ca-pem');
+    expect(ctx.tls.clientCertPem).toBe('fake-cert-pem');
+    expect(ctx.tls.clientKeyPem).toBe('fake-key-pem');
+  });
+});
+
+function execAuth(): ExecAuth {
+  return {
+    kind: 'exec',
+    apiVersion: 'client.authentication.k8s.io/v1',
+    command: 'datumctl',
+    args: ['auth', 'get-token'],
+    env: {},
+  };
+}
+
+function credential(token: string, expirationTimestamp?: string): string {
+  return JSON.stringify({
+    apiVersion: 'client.authentication.k8s.io/v1',
+    kind: 'ExecCredential',
+    status: { token, expirationTimestamp },
+  });
+}
+
+describe('ExecCredentialProvider', () => {
+  test('spawns the command and returns the parsed token', async () => {
+    const runner = mock(async () =>
+      credential('tok-1', new Date(Date.now() + 3_600_000).toISOString())
+    );
+    const provider = new ExecCredentialProvider(execAuth(), { runner });
+
+    expect(await provider.getToken()).toBe('tok-1');
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+
+  test('passes KUBERNETES_EXEC_INFO to the command', async () => {
+    let capturedEnv: Record<string, string> = {};
+    const runner = mock(async (_cmd: string, _args: string[], env: Record<string, string>) => {
+      capturedEnv = env;
+      return credential('tok-1');
+    });
+    await new ExecCredentialProvider(execAuth(), { runner }).getToken();
+    expect(capturedEnv.KUBERNETES_EXEC_INFO).toBeDefined();
+    expect(JSON.parse(capturedEnv.KUBERNETES_EXEC_INFO).kind).toBe('ExecCredential');
+  });
+
+  test('caches the token until near expiry, then re-runs', async () => {
+    let now = 1_000_000;
+    let n = 0;
+    const runner = mock(async () => credential(`tok-${++n}`, new Date(now + 60_000).toISOString()));
+    const provider = new ExecCredentialProvider(execAuth(), { runner, now: () => now });
+
+    expect(await provider.getToken()).toBe('tok-1');
+    // Well within validity — served from cache.
+    now += 30_000;
+    expect(await provider.getToken()).toBe('tok-1');
+    expect(runner).toHaveBeenCalledTimes(1);
+
+    // Past expiry (minus skew) — re-runs the command.
+    now += 40_000;
+    expect(await provider.getToken()).toBe('tok-2');
+    expect(runner).toHaveBeenCalledTimes(2);
+  });
+
+  test('throws when the plugin returns non-JSON', async () => {
+    const provider = new ExecCredentialProvider(execAuth(), { runner: async () => 'not json' });
+    await expect(provider.getToken()).rejects.toThrow(/non-JSON/);
+  });
+
+  test('throws when the plugin returns no token', async () => {
+    const provider = new ExecCredentialProvider(execAuth(), {
+      runner: async () => JSON.stringify({ status: {} }),
+    });
+    await expect(provider.getToken()).rejects.toThrow(/no token/);
+  });
+});
+
+describe('KubeClient', () => {
+  test('injects a static bearer token on requests', async () => {
+    let captured: Record<string, string> = {};
+    const fetchImpl = mock(async (_url: string, init: RequestInit) => {
+      captured = init.headers as Record<string, string>;
+      return new Response('{}', { status: 200 });
+    });
+    const client = new KubeClient(resolveKubeContext(parseKubeconfig(BEARER)), {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await client.request('/apis/portal.miloapis.com/v1alpha1/portalplugins');
+    expect(captured.Authorization).toBe('Bearer static-bearer-token');
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://api.datum.example.com/apis/portal.miloapis.com/v1alpha1/portalplugins'
+    );
+  });
+
+  test('injects an exec-resolved token on requests', async () => {
+    let captured: Record<string, string> = {};
+    const fetchImpl = mock(async (_url: string, init: RequestInit) => {
+      captured = init.headers as Record<string, string>;
+      return new Response('{}', { status: 200 });
+    });
+    const client = new KubeClient(resolveKubeContext(parseKubeconfig(EXEC_CREDENTIAL)), {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      runner: async () => credential('exec-token'),
+    });
+
+    await client.request('/healthz');
+    expect(captured.Authorization).toBe('Bearer exec-token');
+  });
+
+  test('sends no auth header for a no-auth cluster', async () => {
+    let captured: Record<string, string> = {};
+    const fetchImpl = mock(async (_url: string, init: RequestInit) => {
+      captured = init.headers as Record<string, string>;
+      return new Response('{}', { status: 200 });
+    });
+    const client = new KubeClient(resolveKubeContext(parseKubeconfig(INSECURE_LOOPBACK)), {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await client.request('/healthz');
+    expect(captured.Authorization).toBeUndefined();
+  });
+});

--- a/app/modules/plugins/server/kubeconfig.ts
+++ b/app/modules/plugins/server/kubeconfig.ts
@@ -1,0 +1,327 @@
+/**
+ * Kubeconfig parsing + credential resolution for the platform registry
+ * source. Ported from cloud-portal unchanged (including the file-path
+ * client-certificate/client-key fix — a cert-manager CSI-mounted cert is
+ * referenced by file path, not inline base64, so both forms need to work).
+ *
+ * Supports the three auth shapes `PLATFORM_REGISTRY_KUBECONFIG` may carry:
+ * - **No-auth / insecure** loopback clusters.
+ * - **Static bearer tokens**.
+ * - **Exec credential plugins** (`client.authentication.k8s.io` ExecCredential).
+ *
+ * Client-certificate auth (the shape actually used in production — a
+ * cert-manager CSI-issued client cert) is honored via `client-certificate`/
+ * `client-key` (file paths) or `client-certificate-data`/`client-key-data`
+ * (inline base64), passed through to the TLS layer.
+ */
+import type { TlsFetchInit } from './plugin-fetch';
+import { load as loadYaml } from 'js-yaml';
+import { execFile } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+// ── Raw kubeconfig shape (only the fields we consume) ──────────────────────
+
+interface RawExec {
+  apiVersion?: string;
+  command?: string;
+  args?: string[];
+  env?: { name: string; value: string }[] | null;
+}
+
+interface RawUser {
+  token?: string;
+  exec?: RawExec;
+  'client-certificate-data'?: string;
+  'client-key-data'?: string;
+  'client-certificate'?: string;
+  'client-key'?: string;
+}
+
+interface RawCluster {
+  server?: string;
+  'certificate-authority-data'?: string;
+  'certificate-authority'?: string;
+  'insecure-skip-tls-verify'?: boolean;
+}
+
+interface RawKubeconfig {
+  'current-context'?: string;
+  contexts?: { name: string; context: { cluster: string; user: string } }[];
+  clusters?: { name: string; cluster: RawCluster }[];
+  users?: { name: string; user: RawUser }[];
+}
+
+// ── Resolved, normalized shape ─────────────────────────────────────────────
+
+export interface ExecAuth {
+  kind: 'exec';
+  apiVersion: string;
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+}
+
+export type ResolvedAuth = { kind: 'none' } | { kind: 'bearer'; token: string } | ExecAuth;
+
+export interface ResolvedTls {
+  caPem?: string;
+  insecureSkipTlsVerify: boolean;
+  clientCertPem?: string;
+  clientKeyPem?: string;
+}
+
+export interface ResolvedKubeContext {
+  server: string;
+  tls: ResolvedTls;
+  auth: ResolvedAuth;
+}
+
+function decodeBase64(data: string): string {
+  return Buffer.from(data, 'base64').toString('utf8');
+}
+
+/** Parses raw kubeconfig YAML into a structured object. Throws on invalid YAML. */
+export function parseKubeconfig(yamlText: string): RawKubeconfig {
+  const doc = loadYaml(yamlText);
+  if (!doc || typeof doc !== 'object' || Array.isArray(doc)) {
+    throw new Error('kubeconfig is empty or not a YAML mapping');
+  }
+  return doc as RawKubeconfig;
+}
+
+/**
+ * Resolves the active context of a kubeconfig into a normalized server + TLS +
+ * auth descriptor. `contextName` overrides `current-context`.
+ */
+export function resolveKubeContext(
+  config: RawKubeconfig,
+  contextName?: string
+): ResolvedKubeContext {
+  const targetContext = contextName ?? config['current-context'];
+  if (!targetContext) {
+    throw new Error('kubeconfig has no current-context and none was provided');
+  }
+
+  const context = config.contexts?.find((c) => c.name === targetContext)?.context;
+  if (!context) {
+    throw new Error(`kubeconfig context "${targetContext}" not found`);
+  }
+
+  const cluster = config.clusters?.find((c) => c.name === context.cluster)?.cluster;
+  if (!cluster?.server) {
+    throw new Error(`kubeconfig cluster "${context.cluster}" not found or has no server`);
+  }
+
+  const user = config.users?.find((u) => u.name === context.user)?.user ?? {};
+
+  const tls: ResolvedTls = {
+    insecureSkipTlsVerify: cluster['insecure-skip-tls-verify'] === true,
+  };
+  if (cluster['certificate-authority-data']) {
+    tls.caPem = decodeBase64(cluster['certificate-authority-data']);
+  } else if (cluster['certificate-authority']) {
+    tls.caPem = readFileSync(cluster['certificate-authority'], 'utf8');
+  }
+  if (user['client-certificate-data']) {
+    tls.clientCertPem = decodeBase64(user['client-certificate-data']);
+  } else if (user['client-certificate']) {
+    tls.clientCertPem = readFileSync(user['client-certificate'], 'utf8');
+  }
+  if (user['client-key-data']) {
+    tls.clientKeyPem = decodeBase64(user['client-key-data']);
+  } else if (user['client-key']) {
+    tls.clientKeyPem = readFileSync(user['client-key'], 'utf8');
+  }
+
+  return {
+    server: cluster.server.replace(/\/+$/, ''),
+    tls,
+    auth: resolveAuth(user),
+  };
+}
+
+function resolveAuth(user: RawUser): ResolvedAuth {
+  if (user.token) {
+    return { kind: 'bearer', token: user.token };
+  }
+  if (user.exec?.command) {
+    const env: Record<string, string> = {};
+    for (const e of user.exec.env ?? []) env[e.name] = e.value;
+    return {
+      kind: 'exec',
+      apiVersion: user.exec.apiVersion ?? 'client.authentication.k8s.io/v1',
+      command: user.exec.command,
+      args: user.exec.args ?? [],
+      env,
+    };
+  }
+  return { kind: 'none' };
+}
+
+// ── Exec credential plugin protocol ────────────────────────────────────────
+
+interface ExecCredential {
+  apiVersion?: string;
+  kind?: string;
+  status?: {
+    token?: string;
+    expirationTimestamp?: string;
+    clientCertificateData?: string;
+    clientKeyData?: string;
+  };
+}
+
+/** Runs an exec-plugin command and returns its stdout. Injectable for tests. */
+export type CommandRunner = (
+  command: string,
+  args: string[],
+  env: Record<string, string>
+) => Promise<string>;
+
+const defaultRunner: CommandRunner = (command, args, env) =>
+  new Promise((resolve, reject) => {
+    execFile(
+      command,
+      args,
+      { env: { ...process.env, ...env }, timeout: 30_000, maxBuffer: 1024 * 1024 },
+      (error, stdout) => {
+        if (error) reject(error);
+        else resolve(stdout);
+      }
+    );
+  });
+
+/** Refresh a token this many ms before its stated expiry to avoid edge races. */
+const EXPIRY_SKEW_MS = 10_000;
+
+/**
+ * Resolves and caches a bearer token from an exec credential plugin. Re-runs
+ * the command only once the cached token is within {@link EXPIRY_SKEW_MS} of
+ * expiry (or has none), mirroring kubectl's credential caching.
+ */
+export class ExecCredentialProvider {
+  private readonly auth: ExecAuth;
+  private readonly runner: CommandRunner;
+  private readonly now: () => number;
+  private cached: { token: string; expiresAt: number } | undefined;
+  private inFlight: Promise<string> | undefined;
+
+  constructor(auth: ExecAuth, options: { runner?: CommandRunner; now?: () => number } = {}) {
+    this.auth = auth;
+    this.runner = options.runner ?? defaultRunner;
+    this.now = options.now ?? Date.now;
+  }
+
+  async getToken(): Promise<string> {
+    const cached = this.cached;
+    if (cached && cached.expiresAt - EXPIRY_SKEW_MS > this.now()) {
+      return cached.token;
+    }
+    // Collapse concurrent misses into a single command execution.
+    if (this.inFlight) return this.inFlight;
+
+    this.inFlight = this.run().finally(() => {
+      this.inFlight = undefined;
+    });
+    return this.inFlight;
+  }
+
+  private async run(): Promise<string> {
+    const execInfo = JSON.stringify({
+      apiVersion: this.auth.apiVersion,
+      kind: 'ExecCredential',
+      spec: { interactive: false },
+    });
+
+    const stdout = await this.runner(this.auth.command, this.auth.args, {
+      ...this.auth.env,
+      KUBERNETES_EXEC_INFO: execInfo,
+    });
+
+    let credential: ExecCredential;
+    try {
+      credential = JSON.parse(stdout);
+    } catch {
+      throw new Error(`exec credential plugin "${this.auth.command}" returned non-JSON output`);
+    }
+
+    const token = credential.status?.token;
+    if (!token) {
+      throw new Error(`exec credential plugin "${this.auth.command}" returned no token`);
+    }
+
+    const expiration = credential.status?.expirationTimestamp;
+    // No expiry → cache briefly so we still avoid spawning per request.
+    const expiresAt = expiration ? new Date(expiration).getTime() : this.now() + 60_000;
+    this.cached = { token, expiresAt };
+    return token;
+  }
+}
+
+// ── Kube API client ────────────────────────────────────────────────────────
+
+export interface KubeClientOptions {
+  runner?: CommandRunner;
+  now?: () => number;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * A minimal authenticated Kubernetes API client over the resolved context.
+ * Injects the bearer/exec token and applies TLS config on every request.
+ */
+export class KubeClient {
+  readonly server: string;
+  private readonly tls: ResolvedTls;
+  private readonly auth: ResolvedAuth;
+  private readonly fetchImpl: typeof fetch;
+  private readonly execProvider?: ExecCredentialProvider;
+
+  constructor(context: ResolvedKubeContext, options: KubeClientOptions = {}) {
+    this.server = context.server;
+    this.tls = context.tls;
+    this.auth = context.auth;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    if (context.auth.kind === 'exec') {
+      this.execProvider = new ExecCredentialProvider(context.auth, {
+        runner: options.runner,
+        now: options.now,
+      });
+    }
+  }
+
+  private async authHeader(): Promise<Record<string, string>> {
+    switch (this.auth.kind) {
+      case 'bearer':
+        return { Authorization: `Bearer ${this.auth.token}` };
+      case 'exec':
+        return { Authorization: `Bearer ${await this.execProvider!.getToken()}` };
+      case 'none':
+        return {};
+    }
+  }
+
+  private tlsInit(): TlsFetchInit['tls'] {
+    const tls: NonNullable<TlsFetchInit['tls']> & {
+      cert?: string;
+      key?: string;
+    } = {};
+    if (this.tls.insecureSkipTlsVerify) tls.rejectUnauthorized = false;
+    if (this.tls.caPem) tls.ca = this.tls.caPem;
+    if (this.tls.clientCertPem) tls.cert = this.tls.clientCertPem;
+    if (this.tls.clientKeyPem) tls.key = this.tls.clientKeyPem;
+    return Object.keys(tls).length > 0 ? tls : undefined;
+  }
+
+  /** Issues an authenticated request against `{server}{path}`. */
+  async request(path: string, init: RequestInit = {}): Promise<Response> {
+    const auth = await this.authHeader();
+    const tls = this.tlsInit();
+    const fetchInit: TlsFetchInit = {
+      ...init,
+      headers: { ...auth, ...(init.headers as Record<string, string> | undefined) },
+    };
+    if (tls) fetchInit.tls = tls;
+    return this.fetchImpl(`${this.server}${path}`, fetchInit as RequestInit);
+  }
+}

--- a/app/modules/plugins/server/platform-source.test.ts
+++ b/app/modules/plugins/server/platform-source.test.ts
@@ -1,0 +1,296 @@
+/// <reference types="bun-types/test" />
+import { KubeClient, resolveKubeContext, parseKubeconfig } from './kubeconfig';
+import { PlatformSource, specFromProviderPortalPlugin } from './platform-source';
+import { PluginRegistry } from './registry';
+import { describe, expect, mock, test } from 'bun:test';
+
+const VALID_MANIFEST = {
+  name: 'workloads.staff-portal.datumapis.com',
+  version: '0.2.0',
+  sdk: { name: '@datum-cloud/portal-plugin-sdk', range: '^1.0.0' },
+  remoteEntry: 'remoteEntry.js',
+  exposedModules: {},
+  extensions: [
+    {
+      type: 'portal.resource/platform',
+      properties: {
+        id: 'compute-workload',
+        type: 'workload',
+        label: 'Workload',
+        icon: 'box',
+        searchTarget: { group: 'compute.datumapis.com', version: 'v1alpha', kind: 'Workload' },
+      },
+    },
+  ],
+};
+
+const NO_AUTH_KUBECONFIG = `
+apiVersion: v1
+kind: Config
+current-context: milo
+clusters:
+- name: c
+  cluster:
+    server: http://127.0.0.1:8080
+contexts:
+- name: milo
+  context: { cluster: c, user: u }
+users:
+- name: u
+  user: {}
+`;
+
+function providerPortalPluginResource(
+  spec: Record<string, unknown> = {},
+  meta: { generation?: number; resourceVersion?: string } = {},
+
+  status?: { conditions?: any[] }
+) {
+  return {
+    metadata: {
+      name: 'compute-datumapis-com',
+      generation: meta.generation ?? 1,
+      resourceVersion: meta.resourceVersion ?? '100',
+    },
+    spec: {
+      slug: 'compute',
+      displayName: 'Compute',
+      deprecated: false,
+      suspend: false,
+      assets: { baseURL: 'http://plugin.example.com' },
+      ...spec,
+    },
+    ...(status ? { status } : {}),
+  };
+}
+
+/** The status.conditions block the source writes for the valid fixture (Ready). */
+function readyConditions(patchBody: string): any[] {
+  return JSON.parse(patchBody).status.conditions;
+}
+
+/** A registry whose manifest pipeline always resolves the valid fixture. */
+function makeRegistry() {
+  const fetchImpl = mock(async () => new Response(JSON.stringify(VALID_MANIFEST), { status: 200 }));
+  const registry = new PluginRegistry({ fetchImpl: fetchImpl as unknown as typeof fetch });
+  return { registry, fetchImpl };
+}
+
+/** A KubeClient whose requests (status patches) succeed. */
+function makeClient() {
+  const calls: { url: string; init: RequestInit }[] = [];
+  const fetchImpl = mock(async (url: string, init: RequestInit) => {
+    calls.push({ url, init });
+    return new Response('{}', { status: 200 });
+  });
+  const client = new KubeClient(resolveKubeContext(parseKubeconfig(NO_AUTH_KUBECONFIG)), {
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+  return { client, calls };
+}
+
+const silentLogger = { warn: mock(() => {}), info: mock(() => {}), error: mock(() => {}) };
+
+describe('specFromProviderPortalPlugin', () => {
+  test('maps a resource spec with defaults applied', () => {
+    const spec = specFromProviderPortalPlugin(providerPortalPluginResource(), silentLogger);
+    expect(spec).not.toBeNull();
+    expect(spec!.slug).toBe('compute');
+    expect(spec!.assets.manifestPath).toBe('/plugin-manifest.json');
+    // No visibility block on ProviderPortalPlugin — always defaulted to None.
+    expect(spec!.visibility.entitlement).toBe('None');
+  });
+
+  test('returns null when slug or assets.baseURL is missing', () => {
+    expect(specFromProviderPortalPlugin({ spec: { slug: 'x' } }, silentLogger)).toBeNull();
+    expect(
+      specFromProviderPortalPlugin({ spec: { assets: { baseURL: 'http://x' } } }, silentLogger)
+    ).toBeNull();
+  });
+
+  test('reads assets.caBundle as a flat string (no live ref resolution)', () => {
+    const spec = specFromProviderPortalPlugin(
+      providerPortalPluginResource({
+        assets: {
+          baseURL: 'https://plugin.example.com',
+          caBundle: '-----BEGIN CERTIFICATE-----\nfake\n',
+        },
+      }),
+      silentLogger
+    );
+    expect(spec?.assets.caBundle).toBe('-----BEGIN CERTIFICATE-----\nfake\n');
+  });
+});
+
+describe('PlatformSource.applyWatchEvent', () => {
+  test('ADDED reduces into a servable registry entry', async () => {
+    const { registry } = makeRegistry();
+    const { client } = makeClient();
+    const source = new PlatformSource(registry, client, { logger: silentLogger });
+
+    await source.applyWatchEvent({ type: 'ADDED', object: providerPortalPluginResource() });
+
+    const plugin = registry.getPlugin('compute');
+    expect(plugin).toBeDefined();
+    expect(plugin?.source).toBe('platform');
+    expect(plugin?.devMode).toBe(false);
+    expect(plugin?.manifest?.version).toBe('0.2.0');
+  });
+
+  test('best-effort PATCHes the status subresource', async () => {
+    const { registry } = makeRegistry();
+    const { client, calls } = makeClient();
+    const source = new PlatformSource(registry, client, { logger: silentLogger });
+
+    await source.applyWatchEvent({ type: 'ADDED', object: providerPortalPluginResource() });
+
+    const patch = calls.find((c) =>
+      c.url.endsWith('/providerportalplugins/compute-datumapis-com/status')
+    );
+    expect(patch).toBeDefined();
+    expect(patch?.init.method).toBe('PATCH');
+    const body = JSON.parse(patch!.init.body as string);
+    expect(
+      body.status.conditions.some((cond: any) => cond.type === 'Ready' && cond.status === 'True')
+    ).toBe(true);
+  });
+
+  test('spec-only MODIFIED hot-applies the new spec (displayName change)', async () => {
+    const { registry } = makeRegistry();
+    const { client } = makeClient();
+    const source = new PlatformSource(registry, client, { logger: silentLogger });
+
+    await source.applyWatchEvent({ type: 'ADDED', object: providerPortalPluginResource() });
+    expect(registry.getPlugin('compute')?.spec.displayName).toBe('Compute');
+
+    await source.applyWatchEvent({
+      type: 'MODIFIED',
+      object: providerPortalPluginResource(
+        { displayName: 'Compute (renamed)' },
+        { generation: 2, resourceVersion: '200' }
+      ),
+    });
+
+    expect(registry.getPlugin('compute')?.spec.displayName).toBe('Compute (renamed)');
+  });
+
+  test('suspend kill switch takes effect within one watch event, and un-suspend restores', async () => {
+    const { registry } = makeRegistry();
+    const { client } = makeClient();
+    const source = new PlatformSource(registry, client, { logger: silentLogger });
+
+    await source.applyWatchEvent({ type: 'ADDED', object: providerPortalPluginResource() });
+    expect(registry.getPlugin('compute')).toBeDefined();
+
+    await source.applyWatchEvent({
+      type: 'MODIFIED',
+      object: providerPortalPluginResource(
+        { suspend: true },
+        { generation: 2, resourceVersion: '200' }
+      ),
+    });
+    expect(registry.getPlugin('compute')).toBeUndefined();
+
+    await source.applyWatchEvent({
+      type: 'MODIFIED',
+      object: providerPortalPluginResource(
+        { suspend: false },
+        { generation: 3, resourceVersion: '300' }
+      ),
+    });
+    expect(registry.getPlugin('compute')).toBeDefined();
+  });
+
+  test('ignores a status-only MODIFIED (spec unchanged) — breaks the reconcile feedback loop', async () => {
+    const { registry, fetchImpl } = makeRegistry();
+    const { client, calls } = makeClient();
+    const source = new PlatformSource(registry, client, { logger: silentLogger });
+
+    await source.applyWatchEvent({ type: 'ADDED', object: providerPortalPluginResource() });
+    const fetchesAfterAdd = fetchImpl.mock.calls.length;
+    const patchesAfterAdd = calls.filter((c) => c.init.method === 'PATCH').length;
+    expect(patchesAfterAdd).toBe(1);
+
+    const writtenConditions = readyConditions(
+      calls.find((c) => c.init.method === 'PATCH')!.init.body as string
+    );
+    await source.applyWatchEvent({
+      type: 'MODIFIED',
+      object: providerPortalPluginResource(
+        {},
+        { generation: 1, resourceVersion: '101' },
+        { conditions: writtenConditions }
+      ),
+    });
+
+    expect(fetchImpl.mock.calls.length).toBe(fetchesAfterAdd);
+    expect(calls.filter((c) => c.init.method === 'PATCH').length).toBe(patchesAfterAdd);
+  });
+
+  test('applies a spec change even when metadata.generation does NOT bump', async () => {
+    const { registry } = makeRegistry();
+    const { client } = makeClient();
+    const source = new PlatformSource(registry, client, { logger: silentLogger });
+
+    await source.applyWatchEvent({ type: 'ADDED', object: providerPortalPluginResource() });
+    expect(registry.getPlugin('compute')?.spec.suspend).toBe(false);
+
+    await source.applyWatchEvent({
+      type: 'MODIFIED',
+      object: providerPortalPluginResource(
+        { suspend: true },
+        { generation: 1, resourceVersion: '150' }
+      ),
+    });
+    expect(registry.getPlugin('compute')).toBeUndefined();
+  });
+
+  test('a spec change that does not alter conditions reconciles but skips a redundant status patch', async () => {
+    const { registry } = makeRegistry();
+    const { client, calls } = makeClient();
+    const source = new PlatformSource(registry, client, { logger: silentLogger });
+
+    await source.applyWatchEvent({ type: 'ADDED', object: providerPortalPluginResource() });
+    const writtenConditions = readyConditions(
+      calls.find((c) => c.init.method === 'PATCH')!.init.body as string
+    );
+    const patchesAfterAdd = calls.filter((c) => c.init.method === 'PATCH').length;
+
+    await source.applyWatchEvent({
+      type: 'MODIFIED',
+      object: providerPortalPluginResource(
+        { deprecated: true },
+        { generation: 2, resourceVersion: '200' },
+        { conditions: writtenConditions }
+      ),
+    });
+
+    expect(registry.getPlugin('compute')?.spec.deprecated).toBe(true);
+    expect(calls.filter((c) => c.init.method === 'PATCH').length).toBe(patchesAfterAdd);
+  });
+
+  test('DELETED removes the plugin from the registry', async () => {
+    const { registry } = makeRegistry();
+    const { client } = makeClient();
+    const source = new PlatformSource(registry, client, { logger: silentLogger });
+
+    await source.applyWatchEvent({ type: 'ADDED', object: providerPortalPluginResource() });
+    expect(registry.getPlugin('compute')).toBeDefined();
+
+    await source.applyWatchEvent({
+      type: 'DELETED',
+      object: { metadata: { name: 'compute-datumapis-com' }, spec: { slug: 'compute' } },
+    });
+    expect(registry.getPlugin('compute')).toBeUndefined();
+  });
+
+  test('ERROR event throws to trigger a re-list', async () => {
+    const { registry } = makeRegistry();
+    const { client } = makeClient();
+    const source = new PlatformSource(registry, client, { logger: silentLogger });
+
+    await expect(
+      source.applyWatchEvent({ type: 'ERROR', object: { code: 410, message: 'too old' } })
+    ).rejects.toThrow();
+  });
+});

--- a/app/modules/plugins/server/platform-source.ts
+++ b/app/modules/plugins/server/platform-source.ts
@@ -1,0 +1,386 @@
+/**
+ * Platform registry source (production).
+ *
+ * Lists and watches the cluster-scoped `ProviderPortalPlugin` CRD
+ * (portal.miloapis.com/v1alpha1) on milo's control plane via fetch
+ * streaming, reducing ADDED/MODIFIED/DELETED events into the registry, and
+ * best-effort PATCHing each resource's status subresource with
+ * Discovered / Compatible / Ready conditions. Ported from cloud-portal's
+ * `platform-source.ts` (same list/watch/backoff/reconcile shape) — the
+ * differences are the CRD it targets and the spec shape: `ProviderPortalPlugin`
+ * has no `visibility` block (staff-portal has no per-project entitlement
+ * concept), so `visibility.entitlement` is always defaulted to `'None'`
+ * rather than read from the resource, matching `static-source.ts`'s
+ * existing convention.
+ */
+import {
+  DEFAULT_MANIFEST_PATH,
+  PROVIDER_PORTAL_PLUGIN_GROUP,
+  PROVIDER_PORTAL_PLUGIN_PLURAL,
+  PROVIDER_PORTAL_PLUGIN_VERSION,
+  type PluginEntryStatus,
+  type PortalPluginSpec,
+} from '../types';
+import type { KubeClient } from './kubeconfig';
+import type { PluginRegistry } from './registry';
+
+interface ProviderPortalPluginConditionResource {
+  type?: string;
+  status?: string;
+  reason?: string;
+  message?: string;
+  lastTransitionTime?: string;
+}
+
+/** A cluster-scoped ProviderPortalPlugin resource as returned by the API server. */
+interface ProviderPortalPluginResource {
+  apiVersion?: string;
+  kind?: string;
+  metadata?: { name?: string; generation?: number; resourceVersion?: string };
+  spec?: Record<string, any>;
+  status?: { conditions?: ProviderPortalPluginConditionResource[] };
+}
+
+interface WatchEvent {
+  type: 'ADDED' | 'MODIFIED' | 'DELETED' | 'BOOKMARK' | 'ERROR';
+  object: ProviderPortalPluginResource & { code?: number; message?: string };
+}
+
+const RESOURCE_PATH = `/apis/${PROVIDER_PORTAL_PLUGIN_GROUP}/${PROVIDER_PORTAL_PLUGIN_VERSION}/${PROVIDER_PORTAL_PLUGIN_PLURAL}`;
+
+const INITIAL_BACKOFF_MS = 1_000;
+const MAX_BACKOFF_MS = 30_000;
+
+export interface PlatformSourceOptions {
+  /** Best-effort status writes; disable if the client lacks status permission. */
+  patchStatus?: boolean;
+  logger?: Pick<Console, 'warn' | 'info' | 'error'>;
+  /** Injectable delay for tests. */
+  delay?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Normalizes a ProviderPortalPlugin resource's spec into the internal spec
+ * shape. Returns null for a malformed resource — missing slug or
+ * assets.baseURL — rather than serving a broken entry.
+ */
+export function specFromProviderPortalPlugin(
+  resource: ProviderPortalPluginResource,
+  logger: Pick<Console, 'warn'> = console
+): PortalPluginSpec | null {
+  const s = resource.spec ?? {};
+  const slug = typeof s.slug === 'string' ? s.slug : undefined;
+  if (!slug) return null;
+  if (!s.assets?.baseURL) {
+    logger.warn(`[plugins] ProviderPortalPlugin "${slug}" is missing assets.baseURL`);
+    return null;
+  }
+
+  return {
+    slug,
+    displayName: typeof s.displayName === 'string' && s.displayName ? s.displayName : slug,
+    deprecated: s.deprecated === true,
+    suspend: s.suspend === true,
+    assets: {
+      baseURL: s.assets.baseURL,
+      manifestPath: s.assets.manifestPath || DEFAULT_MANIFEST_PATH,
+      caBundle: typeof s.assets.caBundle === 'string' ? s.assets.caBundle : undefined,
+    },
+    // No visibility block on ProviderPortalPlugin — staff-portal has no
+    // per-project entitlement concept. Always None, matching static-source.ts.
+    visibility: { entitlement: 'None' },
+    contentSecurityPolicy: Array.isArray(s.contentSecurityPolicy)
+      ? s.contentSecurityPolicy
+      : undefined,
+  };
+}
+
+/**
+ * Whether the desired conditions already match the resource's current ones,
+ * comparing type/status/reason/message but IGNORING `lastTransitionTime` — so a
+ * status write is only issued when something meaningful actually changed.
+ */
+function conditionsMatch(
+  desired: PluginEntryStatus['conditions'],
+  current: ProviderPortalPluginConditionResource[] | undefined
+): boolean {
+  if (!current || current.length !== desired.length) return false;
+  return desired.every((d) => {
+    const c = current.find((e) => e.type === d.type);
+    return (
+      c !== undefined &&
+      c.status === d.status &&
+      (c.reason ?? '') === (d.reason ?? '') &&
+      (c.message ?? '') === (d.message ?? '')
+    );
+  });
+}
+
+export class PlatformSource {
+  private readonly registry: PluginRegistry;
+  private readonly client: KubeClient;
+  private readonly patchStatusEnabled: boolean;
+  private readonly logger: Pick<Console, 'warn' | 'info' | 'error'>;
+  private readonly delay: (ms: number) => Promise<void>;
+
+  private readonly abort = new AbortController();
+  private resourceVersion: string | undefined;
+  /** Resource name → slug, so DELETED and status patches resolve correctly. */
+  private readonly nameToSlug = new Map<string, string>();
+  /**
+   * Resource name → a stable key of the last reconciled (normalized) spec. Watch
+   * MODIFIED events that carry only our own status patch back have an unchanged
+   * spec, so they're ignored here — preventing an endless reconcile →
+   * status-patch → MODIFIED → reconcile feedback loop. Keying on spec CONTENT
+   * (rather than `metadata.generation`) means a real spec change always applies,
+   * without depending on the apiserver's generation-bump semantics.
+   */
+  private readonly lastSpecKey = new Map<string, string>();
+  private stopped = false;
+
+  constructor(registry: PluginRegistry, client: KubeClient, options: PlatformSourceOptions = {}) {
+    this.registry = registry;
+    this.client = client;
+    this.patchStatusEnabled = options.patchStatus ?? true;
+    this.logger = options.logger ?? console;
+    this.delay = options.delay ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+  }
+
+  /** Starts the list+watch loop in the background (does not block boot). */
+  start(): void {
+    void this.listAndWatchLoop();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.abort.abort();
+  }
+
+  private async listAndWatchLoop(): Promise<void> {
+    let backoff = INITIAL_BACKOFF_MS;
+    while (!this.stopped) {
+      try {
+        await this.list();
+        backoff = INITIAL_BACKOFF_MS; // a clean list resets backoff
+        await this.watch();
+      } catch (err) {
+        if (this.stopped) return;
+        this.logger.warn(
+          `[plugins] platform watch error, retrying in ${backoff}ms: ${String(err)}`
+        );
+        await this.delay(backoff);
+        backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
+      }
+    }
+  }
+
+  /** Seeds the registry from a full list and prunes entries that disappeared. */
+  private async list(): Promise<void> {
+    const response = await this.client.request(RESOURCE_PATH, {
+      headers: { Accept: 'application/json' },
+      signal: this.abort.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`list ProviderPortalPlugins failed: HTTP ${response.status}`);
+    }
+
+    const body = (await response.json()) as {
+      items?: ProviderPortalPluginResource[];
+      metadata?: { resourceVersion?: string };
+    };
+    this.resourceVersion = body.metadata?.resourceVersion;
+
+    const seenSlugs = new Set<string>();
+    for (const item of body.items ?? []) {
+      // Force a full reconcile on (re)list so a resync always refreshes.
+      const slug = await this.reconcile(item, true);
+      if (slug) seenSlugs.add(slug);
+    }
+
+    // Prune slugs that are no longer present in the cluster.
+    for (const [name, slug] of [...this.nameToSlug]) {
+      if (!seenSlugs.has(slug)) {
+        this.registry.remove('platform', slug);
+        this.nameToSlug.delete(name);
+        this.lastSpecKey.delete(name);
+      }
+    }
+
+    this.logger.info(`[plugins] platform source listed ${seenSlugs.size} ProviderPortalPlugin(s)`);
+  }
+
+  /** Streams watch events from the current resourceVersion until the stream ends. */
+  private async watch(): Promise<void> {
+    const query = new URLSearchParams({ watch: 'true', allowWatchBookmarks: 'true' });
+    if (this.resourceVersion) query.set('resourceVersion', this.resourceVersion);
+
+    const response = await this.client.request(`${RESOURCE_PATH}?${query.toString()}`, {
+      headers: { Accept: 'application/json' },
+      signal: this.abort.signal,
+    });
+    if (!response.ok) {
+      // 410 Gone: our resourceVersion is too old — drop it and re-list.
+      if (response.status === 410) this.resourceVersion = undefined;
+      throw new Error(`watch ProviderPortalPlugins failed: HTTP ${response.status}`);
+    }
+    if (!response.body) throw new Error('watch ProviderPortalPlugins returned no body');
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (!this.stopped) {
+      const { done, value } = await reader.read();
+      if (done) return; // stream closed; caller re-lists + re-watches
+      buffer += decoder.decode(value, { stream: true });
+
+      let newlineIndex: number;
+      while ((newlineIndex = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, newlineIndex).trim();
+        buffer = buffer.slice(newlineIndex + 1);
+        if (line === '') continue;
+
+        let event: WatchEvent;
+        try {
+          event = JSON.parse(line) as WatchEvent;
+        } catch {
+          this.logger.warn('[plugins] skipping unparseable watch line');
+          continue;
+        }
+        await this.applyWatchEvent(event);
+      }
+    }
+  }
+
+  /**
+   * Reduces a single watch event into the registry. Exposed for unit testing
+   * the watch-event → registry-map mapping.
+   */
+  async applyWatchEvent(event: WatchEvent): Promise<void> {
+    const rv = event.object?.metadata?.resourceVersion;
+    if (rv) this.resourceVersion = rv;
+
+    switch (event.type) {
+      case 'ADDED':
+      case 'MODIFIED':
+        await this.reconcile(event.object);
+        return;
+      case 'DELETED': {
+        const name = event.object?.metadata?.name;
+        const slug = event.object?.spec?.slug ?? (name ? this.nameToSlug.get(name) : undefined);
+        if (slug) this.registry.remove('platform', slug);
+        if (name) {
+          this.nameToSlug.delete(name);
+          this.lastSpecKey.delete(name);
+        }
+        return;
+      }
+      case 'BOOKMARK':
+        return; // resourceVersion already advanced above
+      case 'ERROR':
+        // A 410 Gone status arrives as an ERROR event; force a re-list.
+        if (event.object?.code === 410) this.resourceVersion = undefined;
+        throw new Error(`watch ERROR event: ${event.object?.message ?? 'unknown'}`);
+    }
+  }
+
+  /**
+   * Upserts one resource and writes its resolved status back. Returns the slug.
+   *
+   * Reconciles only when the normalized spec has actually changed since we last
+   * processed it — status-only MODIFIED events (including the ones our own status
+   * patch produces, which leave the spec untouched) are no-ops, which is what
+   * breaks the feedback loop. `force` bypasses the gate for a full re-list resync.
+   */
+  private async reconcile(
+    resource: ProviderPortalPluginResource,
+    force = false
+  ): Promise<string | undefined> {
+    const spec = specFromProviderPortalPlugin(resource, this.logger);
+    const name = resource.metadata?.name;
+    if (!spec) {
+      this.logger.warn(
+        `[plugins] skipping ProviderPortalPlugin "${name ?? '<unnamed>'}": missing slug or assets.baseURL`
+      );
+      return undefined;
+    }
+
+    if (name) this.nameToSlug.set(name, spec.slug);
+
+    // Skip when the spec is byte-identical to the last one we applied.
+    const specKey = JSON.stringify(spec);
+    if (!force && name !== undefined && this.lastSpecKey.get(name) === specKey) {
+      return spec.slug;
+    }
+
+    const entry = await this.registry.upsert('platform', spec, false);
+    if (name !== undefined) this.lastSpecKey.set(name, specKey);
+
+    if (this.patchStatusEnabled && name) {
+      await this.patchStatus(
+        name,
+        resource.metadata?.generation,
+        entry.status,
+        resource.status?.conditions
+      );
+    }
+    return spec.slug;
+  }
+
+  /**
+   * Best-effort status patch. Registry health never depends on this succeeding.
+   *
+   * Idempotent: skips the write entirely when the desired conditions already
+   * match what's on the resource (comparing everything except timestamps), and
+   * preserves each condition's `lastTransitionTime` when its status didn't
+   * change. Without this, a fresh `lastTransitionTime` on every write would make
+   * each patch a real mutation and re-trigger the watch.
+   */
+  private async patchStatus(
+    name: string,
+    generation: number | undefined,
+    status: PluginEntryStatus,
+    current: ProviderPortalPluginConditionResource[] | undefined
+  ): Promise<void> {
+    if (conditionsMatch(status.conditions, current)) {
+      return; // nothing changed — don't churn the resourceVersion
+    }
+
+    const now = new Date().toISOString();
+    const body = {
+      status: {
+        observedGeneration: generation,
+        conditions: status.conditions.map((c) => {
+          const existing = current?.find((e) => e.type === c.type);
+          // lastTransitionTime only advances when the condition's status flips.
+          const lastTransitionTime =
+            existing && existing.status === c.status ? (existing.lastTransitionTime ?? now) : now;
+          return {
+            type: c.type,
+            status: c.status,
+            reason: c.reason,
+            message: c.message ?? '',
+            lastTransitionTime,
+            ...(generation !== undefined ? { observedGeneration: generation } : {}),
+          };
+        }),
+        ...(status.manifest ? { manifest: status.manifest } : {}),
+      },
+    };
+
+    try {
+      const response = await this.client.request(`${RESOURCE_PATH}/${name}/status`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/merge-patch+json' },
+        body: JSON.stringify(body),
+        signal: this.abort.signal,
+      });
+      if (!response.ok) {
+        this.logger.warn(`[plugins] status patch for "${name}" rejected: HTTP ${response.status}`);
+      }
+    } catch (err) {
+      if (this.stopped) return;
+      this.logger.warn(`[plugins] status patch for "${name}" failed: ${String(err)}`);
+    }
+  }
+}

--- a/app/modules/plugins/server/registry.ts
+++ b/app/modules/plugins/server/registry.ts
@@ -1,14 +1,13 @@
 /**
- * In-memory plugin registry. Ported from cloud-portal, trimmed to a single
- * source: `static` (see `types.ts` — no `kubeconfig`/`platform` source exists
- * in staff-portal v1). The per-source partitioning and precedence machinery
- * is kept anyway so adding a second source later is additive, not a rewrite.
+ * In-memory plugin registry. Ported from cloud-portal. Precedence: `static`
+ * (dev-override) beats `platform` (the real, CRD-watched source) on slug
+ * collision — matches cloud-portal's precedent.
  */
 import type { PluginRegistryEntry, PluginRegistrySource, PortalPluginSpec } from '../types';
 import { isReady, resolveManifest, type ResolveManifestOptions } from './manifest-pipeline';
 
 /** Highest precedence first. */
-const SOURCE_PRECEDENCE: PluginRegistrySource[] = ['static'];
+const SOURCE_PRECEDENCE: PluginRegistrySource[] = ['static', 'platform'];
 
 export interface PluginRegistryOptions {
   /** Injectable for tests; forwarded to the manifest pipeline. */

--- a/app/modules/plugins/types.ts
+++ b/app/modules/plugins/types.ts
@@ -14,10 +14,16 @@
  *   platform-wide mount. Add a `.../project`-equivalent pair later if a
  *   staff-portal plugin ever needs one.
  * - No `portal.card/*` extension type yet — no home-page-card use case here.
- * - No `PortalPlugin` CRD / `portal.miloapis.com` constants, and
- *   `PluginRegistrySource` only has `'static'` — staff-portal has no
- *   production (CRD-watched) discovery path in v1. See `server/index.ts`.
  */
+
+// ═══════════════════════════════════════════════════════════
+// CRD identity (portal.miloapis.com/v1alpha1, cluster-scoped)
+// ═══════════════════════════════════════════════════════════
+
+export const PROVIDER_PORTAL_PLUGIN_GROUP = 'portal.miloapis.com';
+export const PROVIDER_PORTAL_PLUGIN_VERSION = 'v1alpha1';
+/** Plural resource name used in the Kubernetes REST path. */
+export const PROVIDER_PORTAL_PLUGIN_PLURAL = 'providerportalplugins';
 
 /** Default manifest path appended to `assets.baseURL` when none is declared. */
 export const DEFAULT_MANIFEST_PATH = '/plugin-manifest.json';
@@ -34,12 +40,13 @@ export const HOST_SDK_VERSION = '1.0.0';
 // ═══════════════════════════════════════════════════════════
 
 /**
- * Where a registry entry originated. Only `static` exists today (synthesized
- * from `PORTAL_PLUGINS`, dev only). A CRD-watched or otherwise dynamically
- * discovered production source would add a variant here, following
- * cloud-portal's `'kubeconfig' | 'platform'` precedent.
+ * Where a registry entry originated.
+ * - `static`   — synthesized from `PORTAL_PLUGINS` (dev only).
+ * - `platform` — watched from `ProviderPortalPlugin` on the platform control
+ *   plane (production). No `kubeconfig` (dev-only kwok) source exists here —
+ *   staff-portal never had one to begin with, unlike cloud-portal.
  */
-export type PluginRegistrySource = 'static';
+export type PluginRegistrySource = 'static' | 'platform';
 
 // ═══════════════════════════════════════════════════════════
 // PortalPlugin spec

--- a/app/server/routes/api.ts
+++ b/app/server/routes/api.ts
@@ -1,8 +1,8 @@
 import { apiRequest } from '@/modules/axios/axios.server';
 import { LokiActivityLogsService, QueryParams } from '@/modules/loki/server';
-import { PrometheusService } from '@/modules/prometheus';
 import { initPluginRegistry } from '@/modules/plugins/server';
 import { pluginsRoutes } from '@/modules/plugins/server/routes';
+import { PrometheusService } from '@/modules/prometheus';
 import { EnvVariables } from '@/server/iface';
 import { logApiError, logApiSuccess } from '@/server/logger';
 import { authMiddleware, getToken } from '@/server/middleware';

--- a/app/utils/config/env.server.ts
+++ b/app/utils/config/env.server.ts
@@ -62,6 +62,12 @@ const envSchema = z.object({
   // NODE_ENV=development.
   PORTAL_PLUGINS: z.string().optional(),
   PORTAL_PLUGINS_JSON: z.string().optional(),
+
+  // Portal plugin system — platform registry source. Path to a kubeconfig
+  // (mounted from a cert-manager CSI volume) used to watch ProviderPortalPlugin
+  // on milo's control plane at boot. Meant for real deployments — no
+  // NODE_ENV gating, unlike the dev-only vars above.
+  PLATFORM_REGISTRY_KUBECONFIG: z.string().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - providerportalplugin.yaml

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - providerportalplugin.yaml
+  - plugin-reader-rbac.yaml

--- a/config/crd/plugin-reader-rbac.yaml
+++ b/config/crd/plugin-reader-rbac.yaml
@@ -1,0 +1,40 @@
+# Grants the provider-portal-plugin-reader credential (see
+# infra/apps/staff-portal/staging/patch-deployment.yaml's CSI volume) read-only
+# access to ProviderPortalPlugin on milo's control plane. Bound to a
+# dedicated group rather than system:masters — this credential is mounted
+# into the live, internet-facing staff-portal app pod, not just wielded by
+# Flux, so it carries only what platform-source.ts actually needs. Mirrors
+# cloud-portal's config/crd/plugin-reader-rbac.yaml.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: provider-portal-plugin-reader
+rules:
+  - apiGroups:
+      - portal.miloapis.com
+    resources:
+      - providerportalplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - portal.miloapis.com
+    resources:
+      - providerportalplugins/status
+    verbs:
+      - get
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: provider-portal-plugin-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: provider-portal-plugin-reader
+subjects:
+  - kind: Group
+    name: datum:provider-portal-plugin-reader
+    apiGroup: rbac.authorization.k8s.io

--- a/config/crd/providerportalplugin.yaml
+++ b/config/crd/providerportalplugin.yaml
@@ -1,0 +1,189 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: providerportalplugins.portal.miloapis.com
+  labels:
+    app.kubernetes.io/part-of: staff-portal
+    app.kubernetes.io/component: plugin-registry
+spec:
+  group: portal.miloapis.com
+  names:
+    kind: ProviderPortalPlugin
+    listKind: ProviderPortalPluginList
+    plural: providerportalplugins
+    singular: providerportalplugin
+    shortNames:
+      - pportalplugin
+    categories:
+      - portal
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Slug
+          type: string
+          description: URL and asset-proxy segment for the plugin
+          jsonPath: .spec.slug
+        - name: Ready
+          type: string
+          description: Aggregate readiness (discovered + compatible + not suspended)
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+        - name: Version
+          type: string
+          description: Version of the live manifest resolved by the portal
+          jsonPath: .status.manifest.version
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: |-
+            ProviderPortalPlugin declares a service-owned UI plugin that
+            staff-portal (the internal operator portal) discovers and loads
+            at runtime. Written only by service-catalog's ServiceConfiguration
+            fan-out (spec.userInterface.provider); consumed by staff-portal,
+            which also writes status. Owned by staff-portal, not milo — see
+            ConsumerPortalPlugin (cloud-portal repo) for the customer-facing
+            counterpart. Same group, distinct Kind, so each portal watches
+            only its own without filtering. No visibility/entitlement gate —
+            staff-portal has no per-project entitlement concept; every staff
+            user with portal access sees every non-suspended plugin.
+          required:
+            - spec
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              description: Desired state, materialized by the services-operator fan-out.
+              required:
+                - slug
+                - assets
+              properties:
+                slug:
+                  type: string
+                  description: |-
+                    Unique DNS label. Forms the asset-proxy prefix
+                    (/api/plugins/<slug>/…) in the portal. Uniqueness enforced
+                    at fan-out.
+                  maxLength: 63
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                  x-kubernetes-validations:
+                    - rule: "self == oldSelf"
+                      message: slug is immutable
+                displayName:
+                  type: string
+                  description: Human-facing name, copied from Service.spec.displayName.
+                deprecated:
+                  type: boolean
+                  default: false
+                  description: True when the winning ServiceConfiguration is Deprecated.
+                suspend:
+                  type: boolean
+                  default: false
+                  description: Platform-operator kill switch; unloads the plugin portal-wide.
+                assets:
+                  type: object
+                  description: Where the portal fetches the plugin's manifest and bundle (server-side).
+                  required:
+                    - baseURL
+                  properties:
+                    baseURL:
+                      type: string
+                      description: |-
+                        Origin serving the built plugin (plugin-manifest.json,
+                        remote entry, chunks, static assets). HTTPS in production;
+                        http://localhost is accepted only by dev registry sources.
+                      minLength: 1
+                    manifestPath:
+                      type: string
+                      default: /plugin-manifest.json
+                      description: Manifest path under baseURL. Defaults to /plugin-manifest.json.
+                      pattern: ^/.*
+                    caBundle:
+                      type: string
+                      description: |-
+                        PEM-encoded CA certificate bundle for an internal CA
+                        fronting baseURL. Omit when the origin's certificate is
+                        trusted by the system CA store, or the origin is plain
+                        HTTP (e.g. local dev sources).
+            status:
+              type: object
+              description: Observed state, written by the portal server.
+              properties:
+                observedGeneration:
+                  type: integer
+                  format: int64
+                  description: The metadata.generation the status was last reconciled against.
+                conditions:
+                  type: array
+                  description: |-
+                    Standard conditions. Discovered (manifest fetched + schema-valid),
+                    Compatible (SDK range satisfied), Ready (aggregate).
+                  items:
+                    type: object
+                    required:
+                      - type
+                      - status
+                      - reason
+                    properties:
+                      type:
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      status:
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      reason:
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      message:
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                  x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys:
+                    - type
+                manifest:
+                  type: object
+                  description: Portal-resolved snapshot of the live manifest.
+                  properties:
+                    version:
+                      type: string
+                      description: Manifest version string.
+                    sdkRange:
+                      type: string
+                      description: SDK semver range the manifest requires.
+                    digest:
+                      type: string
+                      description: Content digest of the fetched manifest (e.g. sha256:…).
+                    fetchedAt:
+                      type: string
+                      format: date-time
+                      description: When the portal last fetched the manifest.
+                    extensions:
+                      type: object
+                      description: Count of extensions by type in the resolved manifest.
+                      additionalProperties:
+                        type: integer
+                        format: int64


### PR DESCRIPTION
## Summary
Defines the production, cluster-scoped `ProviderPortalPlugin` CRD (`portal.miloapis.com/v1alpha1`). service-catalog's `ServiceConfiguration` fan-out writes to it; staff-portal watches it to discover a service's portal plugin.

Owns the schema on the staff-portal side. `ConsumerPortalPlugin`, cloud-portal's counterpart, lives in the cloud-portal repo. Same group, distinct Kind. Each portal watches only its own. No visibility/entitlement block. Staff-portal has no per-project entitlement concept.

This was meant to land with #611 (the plugin-host system port), but the commit was never pushed before that PR merged. Recovering it here as its own PR.

Deployment wiring and staff-portal's own watch/discovery of these objects are a separate, deferred slice. This just lands the schema.

## Test plan
- [x] Cherry-picked cleanly onto current `main`, no conflicts
- [ ] `kubectl apply` the CRD against a real/kind cluster as a sanity check