### PR TITLE
feat: mount platform-wide plugins and surface their nav under Operations

### DIFF
--- a/app/features/milo/components/navbar/milo-main-nav.tsx
+++ b/app/features/milo/components/navbar/milo-main-nav.tsx
@@ -1,5 +1,4 @@
-import { NAV_SECTIONS } from '../../lib/nav-config';
-import { useActiveNav } from '../../lib/use-active-section';
+import { useActiveNav, useNavSections } from '../../lib/use-active-section';
 import { MiloNavItem } from './milo-nav-item';
 import { cn } from '@datum-cloud/datum-ui/utils';
 import { useLingui } from '@lingui/react/macro';
@@ -14,6 +13,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
  */
 export function MiloMainNav() {
   const { t } = useLingui();
+  const sections = useNavSections();
   const { section: activeSection } = useActiveNav();
   const activeHref = activeSection?.href;
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -75,7 +75,7 @@ export function MiloMainNav() {
       <div
         ref={scrollRef}
         className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-        {NAV_SECTIONS.map((section) => (
+        {sections.map((section) => (
           <MiloNavItem
             key={section.id}
             section={section}

--- a/app/features/milo/components/navbar/milo-mobile-menu.tsx
+++ b/app/features/milo/components/navbar/milo-mobile-menu.tsx
@@ -1,5 +1,4 @@
-import { NAV_SECTIONS } from '../../lib/nav-config';
-import { useActiveNav } from '../../lib/use-active-section';
+import { useActiveNav, useNavSections } from '../../lib/use-active-section';
 import { miloIconButtonClass } from './milo-icon-button';
 import { LogoIcon } from '@/components/logo/logo-icon';
 import { Button } from '@datum-cloud/datum-ui/button';
@@ -23,6 +22,7 @@ import { NavLink } from 'react-router';
  */
 export function MiloMobileMenu({ className }: { className?: string }) {
   const { t } = useLingui();
+  const sections = useNavSections();
   const { section: active } = useActiveNav();
   const [open, setOpen] = useState(false);
 
@@ -47,7 +47,7 @@ export function MiloMobileMenu({ className }: { className?: string }) {
           </SheetTitle>
         </SheetHeader>
         <nav className="flex flex-col gap-4 overflow-y-auto p-3">
-          {NAV_SECTIONS.map((section) => {
+          {sections.map((section) => {
             const items = section.subNav?.groups.flatMap((g) => g.items) ?? [];
             return (
               <div key={section.id} className="flex flex-col gap-0.5">

--- a/app/features/milo/lib/nav-config.ts
+++ b/app/features/milo/lib/nav-config.ts
@@ -2,7 +2,6 @@ import { ENTITY_ICONS, SECTION_ICONS } from '@/utils/config/icons.config';
 import {
   activityRoutes,
   billingAccountRoutes,
-  chainsawTestRoutes,
   contactGroupRoutes,
   contactRoutes,
   fraudRoutes,
@@ -140,11 +139,6 @@ export const NAV_SECTIONS: NavSection[] = [
               label: 'Email Activity',
               href: routes.emailActivity(),
               icon: ENTITY_ICONS.emailActivity,
-            },
-            {
-              label: 'Chainsaw Tests',
-              href: chainsawTestRoutes.list(),
-              icon: ENTITY_ICONS.chainsawTest,
             },
           ],
         },

--- a/app/features/milo/lib/use-active-section.ts
+++ b/app/features/milo/lib/use-active-section.ts
@@ -1,4 +1,5 @@
 import { NAV_SECTIONS, type NavSection, type NavSubItem } from './nav-config';
+import { usePluginNavItems } from './use-plugin-nav-items';
 import { useMemo } from 'react';
 import { useLocation } from 'react-router';
 
@@ -35,6 +36,36 @@ export interface ActiveNav {
 }
 
 /**
+ * The full navbar section list: the static `NAV_SECTIONS` with any
+ * plugin-contributed nav items (discovered at runtime via `usePlugins()`)
+ * appended to the Operations section's sub-nav. Every platform-wide plugin
+ * lands under Operations rather than minting its own top-level section, so
+ * the navbar stays bounded regardless of plugin count. The one place both
+ * regions (`MiloMainNav`, `MiloMobileMenu`) and `useActiveNav` read the
+ * section list from, so plugin nav entries stay in sync everywhere.
+ */
+export function useNavSections(): NavSection[] {
+  const pluginItems = usePluginNavItems();
+
+  return useMemo(() => {
+    if (pluginItems.length === 0) return NAV_SECTIONS;
+
+    return NAV_SECTIONS.map((section) => {
+      if (section.id !== 'operations' || !section.subNav) return section;
+
+      const [firstGroup, ...restGroups] = section.subNav.groups;
+      return {
+        ...section,
+        subNav: {
+          ...section.subNav,
+          groups: [{ ...firstGroup, items: [...firstGroup.items, ...pluginItems] }, ...restGroups],
+        },
+      };
+    });
+  }, [pluginItems]);
+}
+
+/**
  * Resolve which top section and sub-item are active from the current URL.
  * The single brain the shell regions read from — navbar highlights `section`,
  * the sub-nav rail highlights `subItem`, the context bar builds its segments
@@ -42,6 +73,7 @@ export interface ActiveNav {
  */
 export function useActiveNav(): ActiveNav {
   const { pathname } = useLocation();
+  const sections = useNavSections();
 
   return useMemo(() => {
     // A section is active when the URL matches the section's own prefix OR any of
@@ -50,7 +82,7 @@ export function useActiveNav(): ActiveNav {
     // both, and pick the strongest.
     let activeSection: NavSection | undefined;
     let bestLen = 0;
-    for (const section of NAV_SECTIONS) {
+    for (const section of sections) {
       const items = section.subNav?.groups.flatMap((g) => g.items) ?? [];
       const len = Math.max(
         matchLength(pathname, section.match ?? section.href),
@@ -67,5 +99,5 @@ export function useActiveNav(): ActiveNav {
     const items = activeSection.subNav.groups.flatMap((g) => g.items);
     const subItem = bestMatch(pathname, items);
     return { section: activeSection, subItem };
-  }, [pathname]);
+  }, [pathname, sections]);
 }

--- a/app/features/milo/lib/use-plugin-nav-items.ts
+++ b/app/features/milo/lib/use-plugin-nav-items.ts
@@ -1,0 +1,36 @@
+/**
+ * Resolves `portal.nav/platform` plugin extensions into nav sub-items for the
+ * Operations section — `NAV_SECTIONS` (nav-config.ts) is a static,
+ * compile-time array, but plugin nav entries only exist at runtime, discovered
+ * via `usePlugins()`. Every platform-wide plugin lands under Operations
+ * rather than minting its own top-level section — keeps the navbar bounded
+ * regardless of how many plugins get installed.
+ */
+import type { NavSubItem } from './nav-config';
+import { resolvePluginIcon } from '@/modules/plugins/client/icon-map';
+import { getNavExtensions } from '@/modules/plugins/client/match-extension';
+import { usePlugins } from '@/modules/plugins/client/use-plugins';
+import type { PublicPlugin } from '@/modules/plugins/types';
+import { pluginRoutes } from '@/utils/config/routes.config';
+import { useMemo } from 'react';
+
+function toNavItems(plugin: PublicPlugin): NavSubItem[] {
+  return getNavExtensions(plugin.manifest).map((ext) => {
+    const path = ext.properties.path.replace(/^\/+/, '').replace(/\/+$/, '');
+    const href =
+      path === '' ? pluginRoutes.mount(plugin.slug) : pluginRoutes.page(plugin.slug, path);
+
+    return {
+      label: ext.properties.title,
+      href,
+      icon: resolvePluginIcon(ext.properties.icon),
+    };
+  });
+}
+
+/** Plugin-contributed Operations nav items, discovery best-effort (empty on failure). */
+export function usePluginNavItems(): NavSubItem[] {
+  const { data: plugins = [] } = usePlugins();
+
+  return useMemo(() => plugins.flatMap(toNavItems), [plugins]);
+}

--- a/app/modules/plugins/client/federation-host.ts
+++ b/app/modules/plugins/client/federation-host.ts
@@ -26,6 +26,7 @@ import reactQueryPkg from '@tanstack/react-query/package.json';
 import type { ComponentType } from 'react';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
+import * as ReactDOMClient from 'react-dom/client';
 import * as ReactRouter from 'react-router';
 import reactRouterPkg from 'react-router/package.json';
 
@@ -68,6 +69,17 @@ function hostShared() {
     'react-dom': {
       version: ReactDOM.version,
       lib: () => ReactDOM,
+      shareConfig: { singleton: true, requiredVersion: false as const, eager: true },
+    },
+    // React 19 splits `createRoot`/`hydrateRoot` into this subpath. A plugin
+    // whose remote entry references `react-dom/client` (even only from its own
+    // standalone preview harness — MF's build-time scan doesn't distinguish)
+    // needs the host to bridge it explicitly; without an entry here, MF has
+    // nothing to bridge the plugin's `react-dom/client` import against and
+    // fails at container load, before any exposed component renders.
+    'react-dom/client': {
+      version: ReactDOM.version,
+      lib: () => ReactDOMClient,
       shareConfig: { singleton: true, requiredVersion: false as const, eager: true },
     },
     'react-router': {

--- a/app/modules/plugins/client/plugin-page-outlet.tsx
+++ b/app/modules/plugins/client/plugin-page-outlet.tsx
@@ -96,14 +96,16 @@ export function PluginPageOutlet({
   );
 
   return (
-    <div className="relative flex flex-1 flex-col">
+    <div className={`relative flex flex-1 flex-col ${plugin.devMode ? 'pt-9' : ''}`}>
       {plugin.devMode && (
-        // Absolutely positioned rather than its own row: a dedicated row adds
-        // a whole extra block of vertical space above the plugin's own
-        // top padding. Floating it in the corner keeps it visually level
-        // with whatever the plugin renders first (its breadcrumb/header),
-        // without the plugin needing to know this badge exists.
-        <div className="absolute top-4 right-4 z-10">
+        // A small reserved strip (`pt-9`) rather than overlaying directly on
+        // top of the plugin's own first element: plugins commonly render a
+        // bordered Card flush with their own top padding, which the badge
+        // would otherwise sit on top of/inside. Reserving just enough height
+        // for the badge itself keeps it floating clear of whatever the
+        // plugin renders, without the plugin needing to know this badge
+        // exists.
+        <div className="absolute top-2 right-4 z-10">
           <DevPluginBadge />
         </div>
       )}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -242,6 +242,11 @@ export default [
     ]),
 
     route('test-sentry', 'routes/test-sentry.tsx'),
+
+    // Platform-wide plugin mount (`portal.page/platform` extensions) — see
+    // app/routes/plugins.tsx. Sibling to the project-scoped mount at
+    // customers/projects/:projectName/plugins/:slug/*.
+    route('plugins/:slug/*', 'routes/plugins.tsx'),
   ]),
 
   // Public routes without auth

--- a/app/routes/plugins.tsx
+++ b/app/routes/plugins.tsx
@@ -1,0 +1,45 @@
+/**
+ * Platform-wide plugin mount — the portal's permanent catch-all for
+ * platform-scoped service plugins (`/plugins/:slug/*`). One static route;
+ * plugin content resolves inside it at runtime. Sibling to
+ * `app/routes/customer/project/detail/plugins.tsx`'s project-scoped mount,
+ * minus the project scoping.
+ *
+ * The server `loader` resolves `slug` against the registry before any plugin
+ * byte reaches the browser and returns only the sanitized `PublicPlugin`.
+ */
+import type { Route } from './+types/plugins';
+import { PluginOutlet } from '@/modules/plugins/client/plugin-outlet';
+import { getPlugin, toPublicPlugin } from '@/modules/plugins/server';
+import type { PublicPlugin } from '@/modules/plugins/types';
+import { NotFoundError } from '@/utils/errors/http';
+import { metaObject } from '@/utils/helpers/meta.helper';
+import { useLoaderData } from 'react-router';
+
+export const loader = async ({ params }: Route.LoaderArgs) => {
+  const { slug } = params;
+  if (!slug) {
+    throw new NotFoundError('Plugin not found');
+  }
+
+  const entry = getPlugin(slug);
+  const plugin = entry ? toPublicPlugin(entry) : null;
+  if (!plugin) {
+    throw new NotFoundError('Plugin not found');
+  }
+
+  return { plugin };
+};
+
+export const meta: Route.MetaFunction = ({ data }) => {
+  return metaObject(data?.plugin.displayName ?? 'Plugin');
+};
+
+export const handle = {
+  breadcrumb: (data?: { plugin: PublicPlugin }) => data?.plugin.displayName ?? 'Plugin',
+};
+
+export default function PluginMount() {
+  const { plugin } = useLoaderData<typeof loader>();
+  return <PluginOutlet plugin={plugin} />;
+}

--- a/app/utils/config/routes.config.ts
+++ b/app/utils/config/routes.config.ts
@@ -202,6 +202,16 @@ export const profileRoutes = {
   sessions: () => '/profile/sessions',
 } as const;
 
+// ───────────────────────────────── Plugins (/plugins) ─────────────────────────────────
+
+// Platform-wide plugin mount (`portal.page/platform` extensions) — see
+// app/routes/plugins.tsx. `splat` is whatever path the plugin's own page
+// extension declared.
+export const pluginRoutes = {
+  mount: (slug: string) => `/plugins/${slug}`,
+  page: (slug: string, splat: string) => `/plugins/${slug}/${splat}`,
+} as const;
+
 // ───────────────────────────────── Aggregate + root/auth ─────────────────────────────────
 
 // Single entry point; the nested keys mirror the sections above. Prefer the
@@ -242,4 +252,7 @@ export const routes = {
 
   // Account
   profile: profileRoutes,
+
+  // Plugins
+  plugins: pluginRoutes,
 } as const;


### PR DESCRIPTION
## Summary

Closes #630. Platform-wide plugins (`portal.nav/platform` + `portal.page/platform`) had a client-side renderer (`PluginOutlet`) and extractor (`getNavExtensions`) already built, but nowhere to actually render: no top-level route, and nothing calling `getNavExtensions()` from the nav config.

- New top-level route `plugins/:slug/*` (`app/routes/plugins.tsx`), mirroring the existing project-scoped plugin mount (`app/routes/customer/project/detail/plugins.tsx`) minus the project scoping. Adds a `pluginRoutes` path helper in `routes.config.ts`, and a breadcrumb `handle` so the context bar shows the plugin's display name instead of an empty strip.
- Wires `getNavExtensions()` into the nav config (`use-active-section.ts`): every platform-wide plugin's nav item(s) render under **Operations** rather than minting a new top-level navbar section per plugin — keeps the navbar bounded regardless of how many plugins get installed.
- Removes the hardcoded "Chainsaw Tests" nav item from `nav-config.ts` now that the [chainsaw-tests-plugin](https://github.com/datum-cloud/chainsaw-tests-plugin) contributes the same entry dynamically via its manifest (companion PR: datum-cloud/chainsaw-tests-plugin#3).
- Fixes two bugs found while dogfooding the chainsaw-tests-plugin end-to-end against this:
  - The host never shared `react-dom/client` (React 19's split `createRoot`/`hydrateRoot` entry) — Module Federation had nothing to bridge a plugin's `react-dom/client` import against, so container load failed before any exposed component rendered.
  - The dev-mode plugin badge was absolutely positioned at the same inset a plugin's own content starts at, so a plugin whose first element is a flush bordered Card had the badge land on top of/inside it instead of floating above it.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bunx eslint` passes on touched files
- [x] Verified end-to-end locally against the chainsaw-tests-plugin (built + previewed, registered via `PORTAL_PLUGINS`): `/plugins/chainsaw-tests` renders the plugin with no console errors, its "Chainsaw Tests" nav item appears once under Operations (pointing at the plugin route, not the old native page), and the breadcrumb/dev-badge render correctly
- [ ] Confirm no regression to the existing project-scoped Workloads plugin nav/route