### PR TITLE
Show real project names in assistant tools

### DIFF
--- a/app/modules/assistant/tools/billing-tools.ts
+++ b/app/modules/assistant/tools/billing-tools.ts
@@ -1,4 +1,5 @@
 import { datumGet } from './api-helpers';
+import { projectDisplayName } from './display-name';
 import {
   buildOrganizationNamespace,
   getActiveBindingsForAccount,
@@ -319,7 +320,7 @@ export function createBillingTools({ accessToken }: BillingToolDeps) {
         return {
           status: 'ok' as const,
           projectName: name,
-          projectDisplayName: project.metadata?.annotations?.['kubernetes.io/display-name'] ?? name,
+          projectDisplayName: projectDisplayName(project.metadata) || name,
           orgName,
           billingAccountName,
           billingAccountDisplayName: getBillingAccountDisplayName(account),

--- a/app/modules/assistant/tools/customer-tools.ts
+++ b/app/modules/assistant/tools/customer-tools.ts
@@ -1,4 +1,5 @@
 import { datumGet } from './api-helpers';
+import { projectDisplayName } from './display-name';
 import { tool } from 'ai';
 import { z } from 'zod';
 
@@ -86,7 +87,7 @@ export function createCustomerTools({ accessToken }: CustomerToolDeps) {
           results: Array.isArray(items)
             ? items.slice(0, 20).map((p: any) => ({
                 name: p.metadata?.name,
-                displayName: p.metadata?.annotations?.['kubernetes.io/display-name'],
+                displayName: projectDisplayName(p.metadata),
                 url: `/customers/projects/${encodeURIComponent(p.metadata?.name)}`,
               }))
             : [],

--- a/app/modules/assistant/tools/display-name.test.ts
+++ b/app/modules/assistant/tools/display-name.test.ts
@@ -1,0 +1,45 @@
+import { projectDisplayName } from './display-name';
+import { describe, expect, it } from 'bun:test';
+
+describe('projectDisplayName', () => {
+  it('prefers the display-name annotation', () => {
+    expect(
+      projectDisplayName({
+        name: 'proj-abc',
+        annotations: {
+          'kubernetes.io/display-name': 'Renamed Project',
+          'kubernetes.io/description': 'Original Name',
+        },
+      })
+    ).toBe('Renamed Project');
+  });
+
+  it('falls back to description, which is where cloud-portal historically wrote the name', () => {
+    expect(
+      projectDisplayName({
+        name: 'proj-abc',
+        annotations: { 'kubernetes.io/description': 'Customer Project' },
+      })
+    ).toBe('Customer Project');
+  });
+
+  it('falls back to the resource name when neither annotation is set', () => {
+    expect(projectDisplayName({ name: 'proj-abc', annotations: {} })).toBe('proj-abc');
+  });
+
+  it('falls through an empty display-name annotation', () => {
+    expect(
+      projectDisplayName({
+        name: 'proj-abc',
+        annotations: {
+          'kubernetes.io/display-name': '',
+          'kubernetes.io/description': 'Customer Project',
+        },
+      })
+    ).toBe('Customer Project');
+  });
+
+  it('returns an empty string when there is no metadata at all', () => {
+    expect(projectDisplayName(undefined)).toBe('');
+  });
+});

--- a/app/modules/assistant/tools/display-name.ts
+++ b/app/modules/assistant/tools/display-name.ts
@@ -1,0 +1,23 @@
+/**
+ * Resolve a Project's human-readable name from its metadata.
+ *
+ * Projects carry their name in two annotations. cloud-portal historically
+ * wrote only `kubernetes.io/description`, and now writes `display-name` too,
+ * so operator-facing surfaces must check both or they render raw resource IDs
+ * for every project created before that change.
+ *
+ * The chain matches cloud-portal's `toProject` and graphql-gateway's
+ * `Project.displayName`. `||` (not `??`) so a blank annotation falls through
+ * instead of surfacing as an empty name.
+ */
+export function projectDisplayName(
+  metadata: { name?: string; annotations?: Record<string, string> } | undefined
+): string {
+  const annotations = metadata?.annotations;
+  return (
+    annotations?.['kubernetes.io/display-name'] ||
+    annotations?.['kubernetes.io/description'] ||
+    metadata?.name ||
+    ''
+  );
+}


### PR DESCRIPTION
**Problem**
Projects carry their human-readable name in the `kubernetes.io/description` annotation as well as `kubernetes.io/display-name`, but two assistant tools read only the latter. The billing tool fell back to the raw resource ID, and `searchProjects` returned no display name at all — so operators saw `proj-a1b2c3` where the customer sees "Acme Production".

**Solution**
Add a small shared `projectDisplayName()` helper whose fallback chain matches cloud-portal's `toProject` and graphql-gateway's `Project.displayName`, and use it at both call sites. Organization reads are deliberately left alone, since orgs genuinely only carry `display-name`.

Ref: https://github.com/datum-cloud/cloud-portal/pull/1444