### PR TITLE
feat: mount service-scoped provider plugin pages, add Overview override

### DIFF
--- a/app/modules/i18n/locales/en.po
+++ b/app/modules/i18n/locales/en.po
@@ -355,7 +355,7 @@ msgid "Approval"
 msgstr "Approval"
 
 #: app/routes/admin/service-catalog/detail/approvals.tsx:21
-#: app/routes/admin/service-catalog/detail/layout.tsx:50
+#: app/routes/admin/service-catalog/detail/layout.tsx:74
 msgid "Approvals"
 msgstr "Approvals"
 
@@ -759,7 +759,7 @@ msgid "Consumer Project"
 msgstr "Consumer Project"
 
 #: app/routes/admin/service-catalog/detail/consumers.tsx:28
-#: app/routes/admin/service-catalog/detail/layout.tsx:43
+#: app/routes/admin/service-catalog/detail/layout.tsx:67
 msgid "Consumers"
 msgstr "Consumers"
 
@@ -1230,7 +1230,7 @@ msgstr "Deny Request"
 msgid "Deny this consumer's access request. Optionally add a note."
 msgstr "Deny this consumer's access request. Optionally add a note."
 
-#: app/routes/admin/service-catalog/detail/index.tsx:134
+#: app/routes/admin/service-catalog/detail/index.tsx:169
 msgid "Dependencies:"
 msgstr "Dependencies:"
 
@@ -1679,7 +1679,7 @@ msgstr "Failed to load DNS record status"
 msgid "Failed to load service catalog."
 msgstr "Failed to load service catalog."
 
-#: app/routes/admin/service-catalog/detail/index.tsx:72
+#: app/routes/admin/service-catalog/detail/index.tsx:107
 msgid "Failed to load service configurations."
 msgstr "Failed to load service configurations."
 
@@ -1857,7 +1857,7 @@ msgid "Fully onboarded"
 msgstr "Fully onboarded"
 
 #: app/features/service-catalog/components/details-card.tsx:54
-#: app/routes/admin/service-catalog/detail/index.tsx:108
+#: app/routes/admin/service-catalog/detail/index.tsx:143
 #: app/routes/admin/service-catalog/index.tsx:177
 msgid "Gated by Provider"
 msgstr "Gated by Provider"
@@ -2915,7 +2915,7 @@ msgstr "Origin"
 #: app/routes/admin/group/detail/index.tsx:17
 #: app/routes/admin/group/detail/layout.tsx:35
 #: app/routes/admin/offer/detail.tsx:372
-#: app/routes/admin/service-catalog/detail/layout.tsx:37
+#: app/routes/admin/service-catalog/detail/layout.tsx:61
 #: app/routes/customer/organization/detail/layout.tsx:68
 #: app/routes/customer/project/detail/layout.tsx:138
 #: app/routes/customer/user/detail/layout.tsx:36
@@ -2928,7 +2928,7 @@ msgstr "Overview"
 msgid "Owner"
 msgstr "Owner"
 
-#: app/routes/admin/service-catalog/detail/index.tsx:126
+#: app/routes/admin/service-catalog/detail/index.tsx:161
 msgid "Owner:"
 msgstr "Owner:"
 
@@ -3437,7 +3437,7 @@ msgstr "Retired"
 #: app/features/dashboard/components/pending-approvals-widget.tsx:80
 #: app/features/dashboard/components/quota-utilization-widget.tsx:113
 #: app/routes/admin/service-catalog/detail/approvals.tsx:134
-#: app/routes/admin/service-catalog/detail/index.tsx:79
+#: app/routes/admin/service-catalog/detail/index.tsx:114
 #: app/routes/admin/service-catalog/index.tsx:143
 msgid "Retry"
 msgstr "Retry"
@@ -4437,7 +4437,7 @@ msgstr "Yes"
 msgid "Yes — new accounts use this Offer"
 msgstr "Yes — new accounts use this Offer"
 
-#: app/routes/admin/service-catalog/detail/index.tsx:70
+#: app/routes/admin/service-catalog/detail/index.tsx:105
 msgid "You do not have permission to view service configurations."
 msgstr "You do not have permission to view service configurations."
 

--- a/app/modules/i18n/locales/fr.po
+++ b/app/modules/i18n/locales/fr.po
@@ -355,7 +355,7 @@ msgid "Approval"
 msgstr ""
 
 #: app/routes/admin/service-catalog/detail/approvals.tsx:21
-#: app/routes/admin/service-catalog/detail/layout.tsx:50
+#: app/routes/admin/service-catalog/detail/layout.tsx:74
 msgid "Approvals"
 msgstr ""
 
@@ -759,7 +759,7 @@ msgid "Consumer Project"
 msgstr ""
 
 #: app/routes/admin/service-catalog/detail/consumers.tsx:28
-#: app/routes/admin/service-catalog/detail/layout.tsx:43
+#: app/routes/admin/service-catalog/detail/layout.tsx:67
 msgid "Consumers"
 msgstr ""
 
@@ -1230,7 +1230,7 @@ msgstr ""
 msgid "Deny this consumer's access request. Optionally add a note."
 msgstr ""
 
-#: app/routes/admin/service-catalog/detail/index.tsx:134
+#: app/routes/admin/service-catalog/detail/index.tsx:169
 msgid "Dependencies:"
 msgstr ""
 
@@ -1679,7 +1679,7 @@ msgstr ""
 msgid "Failed to load service catalog."
 msgstr ""
 
-#: app/routes/admin/service-catalog/detail/index.tsx:72
+#: app/routes/admin/service-catalog/detail/index.tsx:107
 msgid "Failed to load service configurations."
 msgstr ""
 
@@ -1857,7 +1857,7 @@ msgid "Fully onboarded"
 msgstr ""
 
 #: app/features/service-catalog/components/details-card.tsx:54
-#: app/routes/admin/service-catalog/detail/index.tsx:108
+#: app/routes/admin/service-catalog/detail/index.tsx:143
 #: app/routes/admin/service-catalog/index.tsx:177
 msgid "Gated by Provider"
 msgstr ""
@@ -2915,7 +2915,7 @@ msgstr ""
 #: app/routes/admin/group/detail/index.tsx:17
 #: app/routes/admin/group/detail/layout.tsx:35
 #: app/routes/admin/offer/detail.tsx:372
-#: app/routes/admin/service-catalog/detail/layout.tsx:37
+#: app/routes/admin/service-catalog/detail/layout.tsx:61
 #: app/routes/customer/organization/detail/layout.tsx:68
 #: app/routes/customer/project/detail/layout.tsx:138
 #: app/routes/customer/user/detail/layout.tsx:36
@@ -2928,7 +2928,7 @@ msgstr ""
 msgid "Owner"
 msgstr ""
 
-#: app/routes/admin/service-catalog/detail/index.tsx:126
+#: app/routes/admin/service-catalog/detail/index.tsx:161
 msgid "Owner:"
 msgstr ""
 
@@ -3437,7 +3437,7 @@ msgstr ""
 #: app/features/dashboard/components/pending-approvals-widget.tsx:80
 #: app/features/dashboard/components/quota-utilization-widget.tsx:113
 #: app/routes/admin/service-catalog/detail/approvals.tsx:134
-#: app/routes/admin/service-catalog/detail/index.tsx:79
+#: app/routes/admin/service-catalog/detail/index.tsx:114
 #: app/routes/admin/service-catalog/index.tsx:143
 msgid "Retry"
 msgstr ""
@@ -4437,7 +4437,7 @@ msgstr ""
 msgid "Yes — new accounts use this Offer"
 msgstr ""
 
-#: app/routes/admin/service-catalog/detail/index.tsx:70
+#: app/routes/admin/service-catalog/detail/index.tsx:105
 msgid "You do not have permission to view service configurations."
 msgstr ""
 

--- a/app/modules/plugins/client/match-extension.ts
+++ b/app/modules/plugins/client/match-extension.ts
@@ -21,10 +21,12 @@ import {
   EXTENSION_NAV_PLATFORM,
   EXTENSION_PAGE_PLATFORM,
   EXTENSION_PAGE_PROJECT,
+  EXTENSION_PAGE_SERVICE,
   EXTENSION_RESOURCE_PLATFORM,
   type NavPlatformExtension,
   type PagePlatformExtension,
   type PageProjectExtension,
+  type PageServiceExtension,
   type PluginExtension,
   type PublicPlugin,
   type ResourcePlatformExtension,
@@ -51,6 +53,12 @@ export interface ProjectPageMatch {
   params: Record<string, string | undefined>;
 }
 
+/** Result of matching a splat path against the plugin's service-page extensions. */
+export interface ServicePageMatch {
+  page: PageServiceExtension;
+  params: Record<string, string | undefined>;
+}
+
 // The manifest is schema-validated server-side before it reaches the browser
 // (see app/modules/plugins/manifest.schema.ts), so these guards only narrow the
 // discriminated union — they are not defending against malformed data.
@@ -66,6 +74,9 @@ function isResourceExtension(ext: PluginExtension): ext is ResourcePlatformExten
 function isProjectPageExtension(ext: PluginExtension): ext is PageProjectExtension {
   return ext.type === EXTENSION_PAGE_PROJECT;
 }
+function isServicePageExtension(ext: PluginExtension): ext is PageServiceExtension {
+  return ext.type === EXTENSION_PAGE_SERVICE;
+}
 
 /** Extract the `portal.page/platform` extensions from a manifest. */
 export function getPageExtensions(manifest: ClientPluginManifest): PagePlatformExtension[] {
@@ -75,6 +86,11 @@ export function getPageExtensions(manifest: ClientPluginManifest): PagePlatformE
 /** Extract the `portal.page/project` extensions from a manifest. */
 export function getProjectPageExtensions(manifest: ClientPluginManifest): PageProjectExtension[] {
   return manifest.extensions.filter(isProjectPageExtension);
+}
+
+/** Extract the `portal.page/service` extensions from a manifest. */
+export function getServicePageExtensions(manifest: ClientPluginManifest): PageServiceExtension[] {
+  return manifest.extensions.filter(isServicePageExtension);
 }
 
 /** Extract the `portal.nav/platform` extensions, sorted by `order` then title. */
@@ -108,6 +124,20 @@ export function normalizePagePath(path: string): string {
   return path.replace(/^\/+/, '').replace(/\/+$/, '');
 }
 
+/**
+ * Whether a `portal.page/service` extension is the reserved Overview
+ * override (see the `path: ""` convention on `PageServiceExtension` in
+ * `../types.ts`). Normalizes first so a plugin declaring `path: "/"` is
+ * treated identically to `path: ""` — the same as `normalizePagePath` +
+ * `matchRoutes` already treat them for actual route matching. Every call
+ * site that special-cases the override (the tab strip, the mount outlet,
+ * the Overview route's own lookup) should go through this rather than a raw
+ * `path === ''` check, so they can't silently disagree on edge cases.
+ */
+export function isOverviewOverrideExtension(ext: PageServiceExtension): boolean {
+  return normalizePagePath(ext.properties.path) === '';
+}
+
 /** Normalize the incoming splat into an absolute pathname for matching. */
 function normalizeSplat(splat: string): string {
   const trimmed = splat.replace(/^\/+/, '').replace(/\/+$/, '');
@@ -133,6 +163,14 @@ export function matchPluginProjectPage(
   pages: PageProjectExtension[],
   splat: string
 ): ProjectPageMatch | null {
+  return matchPages(pages, splat);
+}
+
+/** Same matching semantics as {@link matchPluginPage}, for `portal.page/service` extensions. */
+export function matchPluginServicePage(
+  pages: PageServiceExtension[],
+  splat: string
+): ServicePageMatch | null {
   return matchPages(pages, splat);
 }
 

--- a/app/modules/plugins/client/service-overview-override.tsx
+++ b/app/modules/plugins/client/service-overview-override.tsx
@@ -1,0 +1,62 @@
+/**
+ * Renders a `portal.page/service` extension whose `path === ""` in place of
+ * the host's own built-in Overview content — see the `path: ""` convention
+ * documented on `PageServiceExtension` in `../types.ts`. Used by the
+ * Overview route (`app/routes/admin/service-catalog/detail/index.tsx`)
+ * instead of `PluginPageOutlet`: there's exactly one page to render, at the
+ * host's own `/admin/service-catalog/:name` URL, not a `<Routes>` subtree
+ * under a plugin mount — so this wires the same primitives
+ * (`LazyPluginComponent`, `PluginErrorBoundary`, `DevPluginBadge`) directly
+ * rather than going through the mount machinery.
+ */
+import { DevPluginBadge } from './dev-plugin-badge';
+import type { PluginRemoteRef } from './federation-host';
+import { LazyPluginComponent } from './lazy-plugin-component';
+import { PluginErrorBoundary } from './plugin-error-boundary';
+import type { PageServiceExtension, PublicPlugin } from '@/modules/plugins/types';
+import { Skeleton } from '@datum-cloud/datum-ui/skeleton';
+import { useMemo } from 'react';
+
+function OverviewSkeleton() {
+  return (
+    <div className="flex flex-col gap-4 p-4 sm:p-6">
+      <Skeleton className="h-8 w-48" />
+      <Skeleton className="h-4 w-72" />
+      <Skeleton className="h-40 w-full rounded-lg border" />
+    </div>
+  );
+}
+
+export function ServiceOverviewOverride({
+  plugin,
+  extension,
+}: {
+  plugin: PublicPlugin;
+  extension: PageServiceExtension;
+}) {
+  const pluginRef = useMemo<PluginRemoteRef>(
+    () => ({
+      remoteName: plugin.manifest.name,
+      slug: plugin.slug,
+      remoteEntry: plugin.manifest.remoteEntry,
+    }),
+    [plugin.manifest.name, plugin.slug, plugin.manifest.remoteEntry]
+  );
+
+  return (
+    <div className="relative flex flex-1 flex-col">
+      {plugin.devMode && (
+        <div className="absolute top-2 right-4 z-10">
+          <DevPluginBadge />
+        </div>
+      )}
+      <PluginErrorBoundary slug={plugin.slug} displayName={plugin.displayName}>
+        <LazyPluginComponent
+          pluginRef={pluginRef}
+          codeRef={extension.properties.component.$codeRef}
+          fallback={<OverviewSkeleton />}
+        />
+      </PluginErrorBoundary>
+    </div>
+  );
+}

--- a/app/modules/plugins/client/service-plugin-outlet.tsx
+++ b/app/modules/plugins/client/service-plugin-outlet.tsx
@@ -1,0 +1,29 @@
+/**
+ * `<ServicePluginOutlet>` — service-scoped counterpart to `PluginOutlet`.
+ * Renders a plugin's `portal.page/service` extensions instead of its
+ * `portal.page/platform` ones, via the same {@link PluginPageOutlet} render
+ * surface. Mounted under
+ * `/admin/service-catalog/:name/plugins/:slug/*`, so `name` (the Service's
+ * resource name) is already resolved by the ancestor route match.
+ *
+ * Excludes `path: ""` extensions — those are the reserved "replace the
+ * built-in Overview" convention (see `PageServiceExtension` in `../types.ts`)
+ * and are already rendered once, at `/admin/service-catalog/:name` itself,
+ * by `ServiceOverviewOverride`. Passing one through to `PluginPageOutlet`
+ * here would map it to an index route and render it a second time at this
+ * mount's own bare URL (`/admin/service-catalog/:name/plugins/:slug`) —
+ * the same filter `layout.tsx` applies when building the tab strip.
+ */
+import { getServicePageExtensions, isOverviewOverrideExtension } from './match-extension';
+import { PluginPageOutlet } from './plugin-page-outlet';
+import type { PublicPlugin } from '@/modules/plugins/types';
+import { useMemo } from 'react';
+
+export function ServicePluginOutlet({ plugin }: { plugin: PublicPlugin }) {
+  const pages = useMemo(
+    () =>
+      getServicePageExtensions(plugin.manifest).filter((ext) => !isOverviewOverrideExtension(ext)),
+    [plugin.manifest]
+  );
+  return <PluginPageOutlet plugin={plugin} pages={pages} />;
+}

--- a/app/modules/plugins/manifest.schema.ts
+++ b/app/modules/plugins/manifest.schema.ts
@@ -16,6 +16,7 @@ import {
   EXTENSION_NAV_PLATFORM,
   EXTENSION_PAGE_PLATFORM,
   EXTENSION_PAGE_PROJECT,
+  EXTENSION_PAGE_SERVICE,
   EXTENSION_RESOURCE_PLATFORM,
   KNOWN_EXTENSION_TYPES,
   type PluginManifest,
@@ -68,6 +69,16 @@ const pageProjectExtensionSchema = z.object({
   requirements: requirementsSchema,
 });
 
+const pageServiceExtensionSchema = z.object({
+  type: z.literal(EXTENSION_PAGE_SERVICE),
+  properties: z.object({
+    label: z.string().min(1),
+    path: z.string(),
+    component: codeRefSchema,
+  }),
+  requirements: requirementsSchema,
+});
+
 const resourcePlatformExtensionSchema = z.object({
   type: z.literal(EXTENSION_RESOURCE_PLATFORM),
   properties: z.object({
@@ -105,6 +116,7 @@ const extensionSchema = z.union([
   navPlatformExtensionSchema,
   pagePlatformExtensionSchema,
   pageProjectExtensionSchema,
+  pageServiceExtensionSchema,
   resourcePlatformExtensionSchema,
   unknownExtensionSchema,
 ]);

--- a/app/modules/plugins/server/index.ts
+++ b/app/modules/plugins/server/index.ts
@@ -32,6 +32,11 @@ export function getPlugin(slug: string): PluginRegistryEntry | undefined {
   return pluginRegistry.getPlugin(slug);
 }
 
+/** Servable plugins whose `spec.serviceRef.name` matches `serviceName`. */
+export function getPluginsForService(serviceName: string): PluginRegistryEntry[] {
+  return pluginRegistry.getPluginsForService(serviceName);
+}
+
 let initialized = false;
 
 /**

--- a/app/modules/plugins/server/platform-source.ts
+++ b/app/modules/plugins/server/platform-source.ts
@@ -92,6 +92,10 @@ export function specFromProviderPortalPlugin(
     contentSecurityPolicy: Array.isArray(s.contentSecurityPolicy)
       ? s.contentSecurityPolicy
       : undefined,
+    serviceRef:
+      typeof s.serviceRef?.name === 'string' && s.serviceRef.name
+        ? { name: s.serviceRef.name }
+        : undefined,
   };
 }
 

--- a/app/modules/plugins/server/registry.ts
+++ b/app/modules/plugins/server/registry.ts
@@ -91,6 +91,15 @@ export class PluginRegistry {
     return entry && isReady(entry.status) ? entry : undefined;
   }
 
+  /**
+   * Servable plugins whose `spec.serviceRef.name` matches `serviceName` —
+   * the plugins eligible to contribute `portal.page/service` tabs to that
+   * service's `/admin/service-catalog/:name` detail page.
+   */
+  getPluginsForService(serviceName: string): PluginRegistryEntry[] {
+    return this.getPlugins().filter((entry) => entry.spec.serviceRef?.name === serviceName);
+  }
+
   private resolveMerged(slug: string): PluginRegistryEntry | undefined {
     for (const source of SOURCE_PRECEDENCE) {
       const entry = this.sourceMap(source).get(slug);

--- a/app/modules/plugins/server/static-source.ts
+++ b/app/modules/plugins/server/static-source.ts
@@ -6,7 +6,10 @@
  *   iteration.
  * - `PORTAL_PLUGINS_JSON=[…]` — a spec-shaped array, for when a dev plugin
  *   needs richer options the simple syntax doesn't expose (a custom
- *   `manifestPath`, `caBundle`, or `visibility` overrides). JSON entries take
+ *   `manifestPath`, `caBundle`, `visibility` overrides, or — notably —
+ *   `serviceRef`, needed to see a `portal.page/service` tab locally: the
+ *   simple `PORTAL_PLUGINS` syntax has no way to set it, so a plugin loaded
+ *   that way will never match `getPluginsForService()`). JSON entries take
  *   precedence over the simple syntax on slug collision.
  *
  * Synthesized entries run the identical manifest pipeline as any future
@@ -115,6 +118,14 @@ const portalPluginJsonEntrySchema = z.object({
       featureFlag: z.string().optional(),
     })
     .optional(),
+  // Matches ProviderPortalPlugin.spec.serviceRef (see types.ts) — set this to
+  // exercise a `portal.page/service` tab against
+  // /admin/service-catalog/:name locally.
+  serviceRef: z
+    .object({
+      name: z.string().min(1),
+    })
+    .optional(),
 });
 
 const portalPluginsJsonSchema = z.array(portalPluginJsonEntrySchema);
@@ -141,6 +152,7 @@ function jsonEntryToSpec(entry: PortalPluginJsonEntry): PortalPluginSpec {
       entitlement: entry.visibility?.entitlement ?? 'None',
       featureFlag: entry.visibility?.featureFlag,
     },
+    serviceRef: entry.serviceRef,
   };
 }
 

--- a/app/modules/plugins/types.ts
+++ b/app/modules/plugins/types.ts
@@ -88,6 +88,15 @@ export interface PortalPluginSpec {
   visibility: PluginVisibility;
   /** Rarely needed; assets are same-origin proxied. */
   contentSecurityPolicy?: string[];
+  /**
+   * The `Service` (services.miloapis.com) this plugin belongs to, e.g.
+   * `{ name: "compute" }`. Set by service-catalog's `ServiceConfiguration`
+   * fan-out from the same `spec.serviceRef.name` it already resolves the
+   * `Service` from. Anchors `portal.page/service` extensions to the right
+   * `/admin/service-catalog/:name` detail page. Absent for plugins that
+   * predate this field or have no service-scoped pages.
+   */
+  serviceRef?: { name: string };
 }
 
 // ═══════════════════════════════════════════════════════════
@@ -98,6 +107,7 @@ export const EXTENSION_NAV_PLATFORM = 'portal.nav/platform';
 export const EXTENSION_PAGE_PLATFORM = 'portal.page/platform';
 export const EXTENSION_RESOURCE_PLATFORM = 'portal.resource/platform';
 export const EXTENSION_PAGE_PROJECT = 'portal.page/project';
+export const EXTENSION_PAGE_SERVICE = 'portal.page/service';
 
 /** The v1 extension types the host recognizes and renders. */
 export const KNOWN_EXTENSION_TYPES = [
@@ -105,6 +115,7 @@ export const KNOWN_EXTENSION_TYPES = [
   EXTENSION_PAGE_PLATFORM,
   EXTENSION_RESOURCE_PLATFORM,
   EXTENSION_PAGE_PROJECT,
+  EXTENSION_PAGE_SERVICE,
 ] as const;
 
 export type KnownExtensionType = (typeof KNOWN_EXTENSION_TYPES)[number];
@@ -210,6 +221,35 @@ export interface PageProjectExtension {
 }
 
 /**
+ * `portal.page/service` — a tab rendered on the plugin's own `Service`'s
+ * detail page (`/admin/service-catalog/:name/plugins/:slug/*`), alongside the
+ * host's own Overview/Consumers/Approvals tabs. Requires the plugin's
+ * `PortalPluginSpec.serviceRef` to match the `:name` in the URL — a plugin
+ * with no `serviceRef` never renders one of these regardless of what its
+ * manifest declares, since there'd be no service detail page to anchor it to.
+ *
+ * `path: ""` is reserved: instead of adding a tab, that extension *replaces*
+ * the host's own built-in Overview content (still at `/admin/service-catalog/:name`,
+ * not the plugin mount route) — see `ServiceOverviewOverride` on the client
+ * and the Overview route's loader. At most one such extension is honored per
+ * service; if more than one plugin declares `path: ""` for the same service,
+ * the host picks one arbitrarily rather than erroring.
+ */
+export interface PageServiceProperties {
+  /** Tab label shown on the service detail page. */
+  label: string;
+  /** Path relative to the mount point; supports params and nesting. */
+  path: string;
+  component: CodeRef;
+}
+
+export interface PageServiceExtension {
+  type: typeof EXTENSION_PAGE_SERVICE;
+  properties: PageServiceProperties;
+  requirements?: PluginExtensionRequirements;
+}
+
+/**
  * An extension type the host does not recognize. Tolerated, not fatal: the
  * registry records it and excludes it from rendering. The `{type, properties,
  * requirements}` envelope keeps growth additive.
@@ -224,7 +264,8 @@ export type KnownPluginExtension =
   | NavPlatformExtension
   | PagePlatformExtension
   | ResourcePlatformExtension
-  | PageProjectExtension;
+  | PageProjectExtension
+  | PageServiceExtension;
 
 export type PluginExtension = KnownPluginExtension | UnknownExtension;
 

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -229,6 +229,7 @@ export default [
             index('routes/admin/service-catalog/detail/index.tsx'),
             route('consumers', 'routes/admin/service-catalog/detail/consumers.tsx'),
             route('approvals', 'routes/admin/service-catalog/detail/approvals.tsx'),
+            route('plugins/:slug/*', 'routes/admin/service-catalog/detail/plugins.tsx'),
           ]
         ),
       ]),

--- a/app/routes/admin/service-catalog/detail/index.tsx
+++ b/app/routes/admin/service-catalog/detail/index.tsx
@@ -1,4 +1,4 @@
-import { getServiceDetailMetadata, useServiceDetailData } from '../shared';
+import { getServiceDetailMetadata, useServiceDetailData, usePlugins } from '../shared';
 import type { Route } from './+types/index';
 import { BadgeState } from '@/components/badge';
 import { MessageCard } from '@/components/message-card';
@@ -12,6 +12,11 @@ import {
   MonitoredResourcesCard,
   QuotaLimitsCard,
 } from '@/features/service-catalog';
+import {
+  getServicePageExtensions,
+  isOverviewOverrideExtension,
+} from '@/modules/plugins/client/match-extension';
+import { ServiceOverviewOverride } from '@/modules/plugins/client/service-overview-override';
 import {
   useServiceConfigurationsByServiceQuery,
   type ServiceConfiguration,
@@ -42,7 +47,37 @@ function pickActiveConfiguration(
   })[0];
 }
 
+/**
+ * A plugin can replace this whole built-in Overview with its own page (see
+ * the reserved `path: ""` convention on `PageServiceExtension`,
+ * `../../../../modules/plugins/types.ts`) — checked here, before
+ * `BuiltInOverview`'s own data hooks run, so an overridden service doesn't
+ * pay for the `ServiceConfiguration` fetch this built-in view needs and the
+ * override doesn't.
+ */
 export default function Page() {
+  const plugins = usePlugins();
+
+  const override = useMemo(
+    () =>
+      plugins
+        .flatMap((plugin) =>
+          getServicePageExtensions(plugin.manifest)
+            .filter(isOverviewOverrideExtension)
+            .map((extension) => ({ plugin, extension }))
+        )
+        .at(0),
+    [plugins]
+  );
+
+  if (override) {
+    return <ServiceOverviewOverride plugin={override.plugin} extension={override.extension} />;
+  }
+
+  return <BuiltInOverview />;
+}
+
+function BuiltInOverview() {
   const service = useServiceDetailData();
   const serviceName = service.metadata?.name ?? '';
 

--- a/app/routes/admin/service-catalog/detail/layout.tsx
+++ b/app/routes/admin/service-catalog/detail/layout.tsx
@@ -2,12 +2,17 @@ import type { Route } from './+types/layout';
 import { DetailShell, type EntityTab } from '@/features/milo';
 import { PendingApprovalsBadge } from '@/features/service-catalog';
 import { authenticator } from '@/modules/auth';
+import {
+  getServicePageExtensions,
+  isOverviewOverrideExtension,
+} from '@/modules/plugins/client/match-extension';
+import { getPluginsForService, toPublicPlugin } from '@/modules/plugins/server';
 import { serviceDetailQuery } from '@/resources/request/server';
 import { ENTITY_ICONS, TAB_ICONS } from '@/utils/config/icons.config';
 import { serviceCatalogRoutes } from '@/utils/config/routes.config';
 import { useLingui } from '@lingui/react/macro';
 import { ComMiloapisServicesV1Alpha1Service } from '@openapi/services.miloapis.com/v1alpha1';
-import { CheckSquare, Users } from 'lucide-react';
+import { Blocks, CheckSquare, Users } from 'lucide-react';
 import { useLoaderData } from 'react-router';
 
 export const handle = {
@@ -19,18 +24,37 @@ export const handle = {
 
 export const loader = async ({ params, request }: Route.LoaderArgs) => {
   const session = await authenticator.getSession(request);
-  const data = await serviceDetailQuery(session?.accessToken ?? '', params?.name ?? '');
-  return data;
+  const service = await serviceDetailQuery(session?.accessToken ?? '', params?.name ?? '');
+
+  // Every Ready plugin whose `spec.serviceRef.name` matches this Service —
+  // see app/modules/plugins/server/registry.ts's `getPluginsForService`.
+  // Resolved here (not in `plugins.tsx`) so both the tab strip and the
+  // Overview route's override check can use it without a second round trip
+  // (the Overview route reads it back via `usePlugins()`, see `../shared.ts`).
+  const serviceName = service.metadata?.name ?? '';
+  const plugins = getPluginsForService(serviceName)
+    .map(toPublicPlugin)
+    .filter((plugin) => plugin !== null);
+
+  return { service, plugins };
 };
 
 export default function ServiceDetailLayout() {
   const { t } = useLingui();
-  const service = useLoaderData<typeof loader>();
+  const { service, plugins } = useLoaderData<typeof loader>();
 
   const serviceName = service.metadata?.name ?? '';
   const canonicalName = service.spec?.serviceName ?? serviceName;
   const ownerProject = service.spec?.owner?.producerProjectRef?.name;
   const isGated = service.spec?.enablementPolicy?.mode === 'GatedByProvider';
+
+  // `path: ""` extensions replace the built-in Overview instead of adding a
+  // tab (see types.ts) — everything else becomes a tab as before.
+  const servicePlugins = plugins.flatMap((plugin) =>
+    getServicePageExtensions(plugin.manifest)
+      .filter((ext) => !isOverviewOverrideExtension(ext))
+      .map((ext) => ({ slug: plugin.slug, label: ext.properties.label, path: ext.properties.path }))
+  );
 
   const tabs: EntityTab[] = [
     {
@@ -60,6 +84,11 @@ export default function ServiceDetailLayout() {
           },
         ]
       : []),
+    ...servicePlugins.map((sp) => ({
+      label: sp.label,
+      href: serviceCatalogRoutes.plugin.page(serviceName, sp.slug, sp.path),
+      icon: Blocks,
+    })),
   ];
 
   return (

--- a/app/routes/admin/service-catalog/detail/plugins.tsx
+++ b/app/routes/admin/service-catalog/detail/plugins.tsx
@@ -1,0 +1,42 @@
+/**
+ * Service-scoped plugin mount — the portal's permanent catch-all for
+ * service-context plugin tabs (`portal.page/service` extensions), at
+ * `/admin/service-catalog/:name/plugins/:slug/*`. One static route; plugin
+ * content resolves inside it at runtime, mirroring
+ * `app/routes/customer/project/detail/plugins.tsx`'s project-scoped mount.
+ *
+ * The server `loader` resolves `slug` against the plugins registered for
+ * *this* service (`getPluginsForService(name)`) — not `getPlugin(slug)`
+ * alone — so a plugin can't be reached under a service's URL it doesn't
+ * declare `serviceRef` for, even if the slug happens to be valid elsewhere.
+ */
+import type { Route } from './+types/plugins';
+import { ServicePluginOutlet } from '@/modules/plugins/client/service-plugin-outlet';
+import { getPluginsForService, toPublicPlugin } from '@/modules/plugins/server';
+import { NotFoundError } from '@/utils/errors/http';
+import { metaObject } from '@/utils/helpers/meta.helper';
+import { useLoaderData } from 'react-router';
+
+export const loader = async ({ params }: Route.LoaderArgs) => {
+  const { name, slug } = params;
+  if (!name || !slug) {
+    throw new NotFoundError('Plugin not found');
+  }
+
+  const entry = getPluginsForService(name).find((e) => e.spec.slug === slug);
+  const plugin = entry ? toPublicPlugin(entry) : null;
+  if (!plugin) {
+    throw new NotFoundError('Plugin not found');
+  }
+
+  return { plugin };
+};
+
+export const meta: Route.MetaFunction = ({ data }) => {
+  return metaObject(data?.plugin.displayName ?? 'Plugin');
+};
+
+export default function ServicePluginMount() {
+  const { plugin } = useLoaderData<typeof loader>();
+  return <ServicePluginOutlet plugin={plugin} />;
+}

--- a/app/routes/admin/service-catalog/shared.ts
+++ b/app/routes/admin/service-catalog/shared.ts
@@ -3,17 +3,36 @@ import { loader } from './detail/layout';
 import { extractDataFromMatches } from '@/utils/helpers';
 import { useRouteLoaderData } from 'react-router';
 
-// Export the loader type for other files to use
-export type ServiceDetailLoaderData = Awaited<ReturnType<typeof loader>>;
+// Full loader return type, for other files that need more than `.service`.
+type ServiceDetailRouteData = Awaited<ReturnType<typeof loader>>;
 
-// Export a typed hook for other files to use
+// Export the loader type for other files to use
+export type ServiceDetailLoaderData = ServiceDetailRouteData['service'];
+
+// Export a typed hook for other files to use. The layout loader also returns
+// `plugins` (for the tab strip and the Overview override — see `usePlugins`
+// below), but every other consumer of this route's data only ever wanted the
+// `Service` resource itself, so this unwraps `.service` to keep those call
+// sites unchanged.
 export function useServiceDetailData() {
-  return useRouteLoaderData('service-catalog-detail') as ServiceDetailLoaderData;
+  const data = useRouteLoaderData('service-catalog-detail') as ServiceDetailRouteData;
+  return data.service;
+}
+
+// Every Ready plugin whose `serviceRef` matches this Service — see
+// `app/routes/admin/service-catalog/detail/index.tsx`'s Overview-override
+// check and `layout.tsx`'s tab strip.
+export function usePlugins() {
+  const data = useRouteLoaderData('service-catalog-detail') as ServiceDetailRouteData;
+  return data.plugins;
 }
 
 // Helper function to extract service metadata for meta functions
 export function getServiceDetailMetadata(matches: any[]) {
-  const data = extractDataFromMatches<ServiceDetailLoaderData>(matches, 'service-catalog-detail');
+  const data = extractDataFromMatches<{ service: ServiceDetailLoaderData }>(
+    matches,
+    'service-catalog-detail'
+  )?.service;
   return {
     service: data,
     displayName: data?.spec?.displayName ?? data?.metadata?.name ?? '',

--- a/app/utils/config/routes.config.ts
+++ b/app/utils/config/routes.config.ts
@@ -193,6 +193,14 @@ export const serviceCatalogRoutes = {
   detail: (name: string) => `/admin/service-catalog/${name}`,
   consumers: (name: string) => `/admin/service-catalog/${name}/consumers`,
   approvals: (name: string) => `/admin/service-catalog/${name}/approvals`,
+  // Service-scoped plugin mount (`portal.page/service` extensions) — see
+  // app/routes/admin/service-catalog/detail/plugins.tsx. `splat` is whatever
+  // path the plugin's own page extension declared.
+  plugin: {
+    mount: (name: string, slug: string) => `/admin/service-catalog/${name}/plugins/${slug}`,
+    page: (name: string, slug: string, splat: string) =>
+      `/admin/service-catalog/${name}/plugins/${slug}/${splat}`,
+  },
 } as const;
 
 // Admin → Offers (sibling of Service Catalog)

--- a/config/crd/providerportalplugin.yaml
+++ b/config/crd/providerportalplugin.yaml
@@ -116,6 +116,20 @@ spec:
                         fronting baseURL. Omit when the origin's certificate is
                         trusted by the system CA store, or the origin is plain
                         HTTP (e.g. local dev sources).
+                serviceRef:
+                  type: object
+                  description: |-
+                    The Service (services.miloapis.com) this plugin belongs
+                    to. Set from the same ServiceConfiguration.spec.serviceRef
+                    the fan-out already resolves the Service from. Anchors
+                    this plugin's portal.page/service extensions to the
+                    matching /admin/service-catalog/:name detail page.
+                  properties:
+                    name:
+                      type: string
+                      minLength: 1
+                  required:
+                    - name
             status:
               type: object
               description: Observed state, written by the portal server.


### PR DESCRIPTION
## Summary

Adds a `portal.page/service` extension type. A plugin can contribute a tab to a service's admin detail page (`/admin/service-catalog/:name`), mounted at `/admin/service-catalog/:name/plugins/:slug/*`.

A reserved `path: ""` extension replaces the built-in Overview content instead of adding a tab.

Plugins match to a service through a new `spec.serviceRef.name` field on `ProviderPortalPlugin`. CRD schema updated here. Written by service-catalog's fan-out in a companion PR.

Needed by datum-cloud/compute#256, which contributes a Workloads tab and an Overview-replacing page for the compute service.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `bun test app/modules/plugins` passes
- [x] Manifest validated against a real plugin manifest from datum-cloud/compute#256
- [ ] Verified locally against a running compute provider plugin